### PR TITLE
Replace call by reference by call by value

### DIFF
--- a/src/curve.rs
+++ b/src/curve.rs
@@ -867,6 +867,9 @@ impl<'b> MulAssign<&'b Scalar> for ExtendedPoint {
     }
 }
 
+mul_impl!(Scalar, ExtendedPoint, ExtendedPoint);
+mul_impl!(ExtendedPoint, Scalar, ExtendedPoint);
+
 impl<'a, 'b> Mul<&'b Scalar> for &'a ExtendedPoint {
     type Output = ExtendedPoint;
     /// Scalar multiplication: compute `scalar * self`.
@@ -907,6 +910,8 @@ impl<'a, 'b> Mul<&'b ExtendedPoint> for &'a Scalar {
 /// Precomputation
 #[derive(Clone)]
 pub struct EdwardsBasepointTable(pub [[AffineNielsPoint; 8]; 32]);
+
+mul_impl!(Scalar, EdwardsBasepointTable, ExtendedPoint);
 
 impl<'a, 'b> Mul<&'b Scalar> for &'a EdwardsBasepointTable {
     type Output = ExtendedPoint;
@@ -956,6 +961,8 @@ impl<'a, 'b> Mul<&'b Scalar> for &'a EdwardsBasepointTable {
         h
     }
 }
+
+mul_impl!(EdwardsBasepointTable, Scalar, ExtendedPoint);
 
 impl<'a, 'b> Mul<&'a EdwardsBasepointTable> for &'b Scalar {
     type Output = ExtendedPoint;

--- a/src/curve.rs
+++ b/src/curve.rs
@@ -1682,6 +1682,12 @@ mod bench {
     }
 
     #[bench]
+    fn scalar_mult_by_value(b: &mut Bencher) {
+        let B = &constants::ED25519_BASEPOINT;
+        b.iter(|| *B * A_SCALAR);
+    }
+
+    #[bench]
     fn bench_select_precomputed_point(b: &mut Bencher) {
         b.iter(|| select_precomputed_point(0, &constants::ED25519_BASEPOINT_TABLE.0[0]));
     }
@@ -1695,11 +1701,27 @@ mod bench {
     }
 
     #[bench]
+    fn add_extended_and_projective_niels_output_completed_by_value(b: &mut Bencher) {
+        let p1 = constants::ED25519_BASEPOINT;
+        let p2 = constants::ED25519_BASEPOINT.to_projective_niels();
+
+        b.iter(|| p1 + p2);
+    }
+
+    #[bench]
     fn add_extended_and_projective_niels_output_extended(b: &mut Bencher) {
         let p1 = constants::ED25519_BASEPOINT;
         let p2 = constants::ED25519_BASEPOINT.to_projective_niels();
 
         b.iter(|| (&p1 + &p2).to_extended());
+    }
+
+    #[bench]
+    fn add_extended_and_projective_niels_output_extended_by_value(b: &mut Bencher) {
+        let p1 = constants::ED25519_BASEPOINT;
+        let p2 = constants::ED25519_BASEPOINT.to_projective_niels();
+
+        b.iter(|| (p1 + p2).to_extended());
     }
 
     #[bench]

--- a/src/curve.rs
+++ b/src/curve.rs
@@ -134,8 +134,8 @@ impl CompressedEdwardsY {
         let Y = FieldElement::from_bytes(self.as_bytes());
         let Z = FieldElement::one();
         let YY = Y.square();
-        let u = &YY - &Z;                    // u =  y²-1
-        let v = &(&YY * &constants::d) + &Z; // v = dy²+1
+        let u = YY - Z;                    // u =  y²-1
+        let v = (YY * constants::d) + Z;   // v = dy²+1
         let (is_nonzero_square, mut X) = FieldElement::sqrt_ratio(&u, &v);
 
         if is_nonzero_square != 1u8 { return None; }
@@ -145,7 +145,7 @@ impl CompressedEdwardsY {
         let    current_sign_bit = X.is_negative_ed25519();
         X.conditional_negate(current_sign_bit ^ compressed_sign_bit);
 
-        Some(ExtendedPoint{ X: X, Y: Y, Z: Z, T: &X * &Y })
+        Some(ExtendedPoint{ X: X, Y: Y, Z: Z, T: X * Y })
     }
 }
 
@@ -218,7 +218,7 @@ impl CompressedMontgomeryU {
     /// A `FieldElement` corresponding to this coordinate, but in Edwards form.
     pub fn to_edwards_y(u: &FieldElement) -> FieldElement {
         // Since `u = (1+y)/(1-y)` and `v = √(u(u²+Au+1))`, so `y = (u-1)/(u+1)`.
-        &(u - &FieldElement::one()) * &(u + &FieldElement::one()).invert()
+        (u - &FieldElement::one()) * (u + &FieldElement::one()).invert()
     }
 
     /// Given a Montgomery `u` coordinate, compute the corresponding
@@ -232,10 +232,10 @@ impl CompressedMontgomeryU {
     /// Montgomery `v` corresponding to this `u`.
     pub fn to_montgomery_v(u: &FieldElement) -> (u8, FieldElement) {
         let one:       FieldElement = FieldElement::one();
-        let v_squared: FieldElement = u * &(&u.square() + &(&(&constants::A * u) + &one));
+        let v_squared: FieldElement = u * &(u.square() + ((&constants::A * u) + one));
 
         let (okay, v_inv) = v_squared.invsqrt();
-        let v = &v_inv * &v_squared;
+        let v = v_inv * v_squared;
 
         (okay, v)
     }
@@ -266,8 +266,8 @@ impl CompressedMontgomeryU {
     /// convert from Montgomery to Edwards form via the right-hand side of the
     /// equation: `x=(u/v)*sqrt(-A-2)`.
     pub fn to_edwards_x(u: &FieldElement, v: &FieldElement, sign: &u8) -> FieldElement {
-        let mut x: FieldElement = &(u * &v.invert()) * &constants::SQRT_MINUS_APLUS2;
-        let neg_x: FieldElement = -(&x);
+        let mut x: FieldElement = (u * &v.invert()) * constants::SQRT_MINUS_APLUS2;
+        let neg_x: FieldElement = -x;
         let current_sign:    u8 = x.is_negative_ed25519();
 
         // Negate x to match the sign:
@@ -466,8 +466,8 @@ impl ValidityCheck for ProjectivePoint {
         let YY = self.Y.square();
         let ZZ = self.Z.square();
         let ZZZZ = ZZ.square();
-        let lhs = &(&YY - &XX) * &ZZ;
-        let rhs = &ZZZZ + &(&constants::d * &(&XX * &YY));
+        let lhs = (YY - XX) * ZZ;
+        let rhs = ZZZZ + (constants::d * (XX * YY));
 
         lhs == rhs
     }
@@ -553,18 +553,18 @@ impl ProjectivePoint {
     #[allow(dead_code)]  // rustc complains this is unused even when it's used
     fn to_extended(&self) -> ExtendedPoint {
         ExtendedPoint{
-            X: &self.X * &self.Z,
-            Y: &self.Y * &self.Z,
+            X: self.X * self.Z,
+            Y: self.Y * self.Z,
             Z: self.Z.square(),
-            T: &self.X * &self.Y,
+            T: self.X * self.Y,
         }
     }
 
     /// Convert this point to a `CompressedEdwardsY`
     pub fn compress_edwards(&self) -> CompressedEdwardsY {
         let recip = self.Z.invert();
-        let x = &self.X * &recip;
-        let y = &self.Y * &recip;
+        let x = self.X * recip;
+        let y = self.Y * recip;
         let mut s: [u8; 32];
 
         s      =  y.to_bytes();
@@ -590,9 +590,9 @@ impl ProjectivePoint {
         //
         // exceptional points:
         // y = 1 <=> Y/Z = 1 <=> Z - Y = 0
-        let Z_plus_Y   = &self.Z + &self.Y;
-        let Z_minus_Y  = &self.Z - &self.Y;
-        let u = &Z_plus_Y * &Z_minus_Y.invert();
+        let Z_plus_Y   = self.Z + self.Y;
+        let Z_minus_Y  = self.Z - self.Y;
+        let u = Z_plus_Y * Z_minus_Y.invert();
 
         if Z_minus_Y.is_zero() == 0u8 {
             Some(CompressedMontgomeryU(u.to_bytes()))
@@ -606,10 +606,10 @@ impl ExtendedPoint {
     /// Convert to a ProjectiveNielsPoint
     pub fn to_projective_niels(&self) -> ProjectiveNielsPoint {
         ProjectiveNielsPoint{
-            Y_plus_X:  &self.Y + &self.X,
-            Y_minus_X: &self.Y - &self.X,
-            Z:          self.Z,
-            T2d:       &self.T * &constants::d2,
+            Y_plus_X:  self.Y + self.X,
+            Y_minus_X: self.Y - self.X,
+            Z:         self.Z,
+            T2d:       self.T * constants::d2,
         }
     }
 
@@ -630,12 +630,12 @@ impl ExtendedPoint {
     /// Mainly for testing.
     pub fn to_affine_niels(&self) -> AffineNielsPoint {
         let recip = self.Z.invert();
-        let x = &self.X * &recip;
-        let y = &self.Y * &recip;
-        let xy2d = &(&x * &y) * &constants::d2;
+        let x = self.X * recip;
+        let y = self.Y * recip;
+        let xy2d = (x * y) * constants::d2;
         AffineNielsPoint{
-            y_plus_x:  &y + &x,
-            y_minus_x: &y - &x,
+            y_plus_x:  y + x,
+            y_minus_x: y - x,
             xy2d:      xy2d
         }
     }
@@ -661,19 +661,19 @@ impl CompletedPoint {
     /// Convert to a ProjectivePoint
     pub fn to_projective(&self) -> ProjectivePoint {
         ProjectivePoint{
-            X: &self.X * &self.T,
-            Y: &self.Y * &self.Z,
-            Z: &self.Z * &self.T,
+            X: self.X * self.T,
+            Y: self.Y * self.Z,
+            Z: self.Z * self.T,
         }
     }
 
     /// Convert to an ExtendedPoint
     pub fn to_extended(&self) -> ExtendedPoint {
         ExtendedPoint{
-            X: &self.X * &self.T,
-            Y: &self.Y * &self.Z,
-            Z: &self.Z * &self.T,
-            T: &self.X * &self.Y,
+            X: self.X * self.T,
+            Y: self.Y * self.Z,
+            Z: self.Z * self.T,
+            T: self.X * self.Y,
         }
     }
 }
@@ -688,16 +688,16 @@ impl ProjectivePoint {
         let XX          = self.X.square();
         let YY          = self.Y.square();
         let ZZ2         = self.Z.square2();
-        let X_plus_Y    = &self.X + &self.Y;
+        let X_plus_Y    = self.X + self.Y;
         let X_plus_Y_sq = X_plus_Y.square();
-        let YY_plus_XX  = &YY + &XX;
-        let YY_minus_XX = &YY - &XX;
+        let YY_plus_XX  = YY + XX;
+        let YY_minus_XX = YY - XX;
 
         CompletedPoint{
-            X: &X_plus_Y_sq - &YY_plus_XX,
+            X: X_plus_Y_sq - YY_plus_XX,
             Y: YY_plus_XX,
             Z: YY_minus_XX,
-            T: &ZZ2 - &YY_minus_XX
+            T: ZZ2 - YY_minus_XX
         }
     }
 }
@@ -717,19 +717,19 @@ impl<'a,'b> Add<&'b ProjectiveNielsPoint> for &'a ExtendedPoint {
     type Output = CompletedPoint;
 
     fn add(self, other: &'b ProjectiveNielsPoint) -> CompletedPoint {
-        let Y_plus_X  = &self.Y + &self.X;
-        let Y_minus_X = &self.Y - &self.X;
-        let PP = &Y_plus_X  * &other.Y_plus_X;
-        let MM = &Y_minus_X * &other.Y_minus_X;
-        let TT2d = &self.T * &other.T2d;
-        let ZZ   = &self.Z * &other.Z;
-        let ZZ2  = &ZZ + &ZZ;
+        let Y_plus_X  = self.Y + self.X;
+        let Y_minus_X = self.Y - self.X;
+        let PP = Y_plus_X  * other.Y_plus_X;
+        let MM = Y_minus_X * other.Y_minus_X;
+        let TT2d = self.T * other.T2d;
+        let ZZ   = self.Z * other.Z;
+        let ZZ2  = ZZ + ZZ;
 
         CompletedPoint{
-            X: &PP - &MM,
-            Y: &PP + &MM,
-            Z: &ZZ2 + &TT2d,
-            T: &ZZ2 - &TT2d
+            X: PP - MM,
+            Y: PP + MM,
+            Z: ZZ2 + TT2d,
+            T: ZZ2 - TT2d
         }
     }
 }
@@ -746,19 +746,19 @@ impl<'a,'b> Sub<&'b ProjectiveNielsPoint> for &'a ExtendedPoint {
     type Output = CompletedPoint;
 
     fn sub(self, other: &'b ProjectiveNielsPoint) -> CompletedPoint {
-        let Y_plus_X  = &self.Y + &self.X;
-        let Y_minus_X = &self.Y - &self.X;
-        let PM = &Y_plus_X * &other.Y_minus_X;
-        let MP = &Y_minus_X  * &other.Y_plus_X;
-        let TT2d = &self.T * &other.T2d;
-        let ZZ   = &self.Z * &other.Z;
-        let ZZ2  = &ZZ + &ZZ;
+        let Y_plus_X  = self.Y + self.X;
+        let Y_minus_X = self.Y - self.X;
+        let PM = Y_plus_X * other.Y_minus_X;
+        let MP = Y_minus_X  * other.Y_plus_X;
+        let TT2d = self.T * other.T2d;
+        let ZZ   = self.Z * other.Z;
+        let ZZ2  = ZZ + ZZ;
 
         CompletedPoint{
-            X: &PM - &MP,
-            Y: &PM + &MP,
-            Z: &ZZ2 - &TT2d,
-            T: &ZZ2 + &TT2d
+            X: PM - MP,
+            Y: PM + MP,
+            Z: ZZ2 - TT2d,
+            T: ZZ2 + TT2d
         }
     }
 }
@@ -767,18 +767,18 @@ impl<'a,'b> Add<&'b AffineNielsPoint> for &'a ExtendedPoint {
     type Output = CompletedPoint;
 
     fn add(self, other: &'b AffineNielsPoint) -> CompletedPoint {
-        let Y_plus_X  = &self.Y + &self.X;
-        let Y_minus_X = &self.Y - &self.X;
-        let PP        = &Y_plus_X  * &other.y_plus_x;
-        let MM        = &Y_minus_X * &other.y_minus_x;
-        let Txy2d     = &self.T * &other.xy2d;
-        let Z2        = &self.Z + &self.Z;
+        let Y_plus_X  = self.Y + self.X;
+        let Y_minus_X = self.Y - self.X;
+        let PP        = Y_plus_X  * other.y_plus_x;
+        let MM        = Y_minus_X * other.y_minus_x;
+        let Txy2d     = self.T * other.xy2d;
+        let Z2        = self.Z + self.Z;
 
         CompletedPoint{
-            X: &PP - &MM,
-            Y: &PP + &MM,
-            Z: &Z2 + &Txy2d,
-            T: &Z2 - &Txy2d
+            X: PP - MM,
+            Y: PP + MM,
+            Z: Z2 + Txy2d,
+            T: Z2 - Txy2d
         }
     }
 }
@@ -787,18 +787,18 @@ impl<'a,'b> Sub<&'b AffineNielsPoint> for &'a ExtendedPoint {
     type Output = CompletedPoint;
 
     fn sub(self, other: &'b AffineNielsPoint) -> CompletedPoint {
-        let Y_plus_X  = &self.Y + &self.X;
-        let Y_minus_X = &self.Y - &self.X;
-        let PM        = &Y_plus_X  * &other.y_minus_x;
-        let MP        = &Y_minus_X * &other.y_plus_x;
-        let Txy2d     = &self.T * &other.xy2d;
-        let Z2        = &self.Z + &self.Z;
+        let Y_plus_X  = self.Y + self.X;
+        let Y_minus_X = self.Y - self.X;
+        let PM        = Y_plus_X  * other.y_minus_x;
+        let MP        = Y_minus_X * other.y_plus_x;
+        let Txy2d     = self.T * other.xy2d;
+        let Z2        = self.Z + self.Z;
 
         CompletedPoint{
-            X: &PM - &MP,
-            Y: &PM + &MP,
-            Z: &Z2 - &Txy2d,
-            T: &Z2 + &Txy2d
+            X: PM - MP,
+            Y: PM + MP,
+            Z: Z2 - Txy2d,
+            T: Z2 + Txy2d
         }
     }
 }
@@ -822,10 +822,10 @@ impl<'a> Neg for &'a ExtendedPoint {
 
     fn neg(self) -> ExtendedPoint {
         ExtendedPoint{
-            X: -(&self.X),
+            X: -self.X,
             Y:  self.Y,
             Z:  self.Z,
-            T: -(&self.T),
+            T: -self.T,
         }
     }
 }
@@ -838,7 +838,7 @@ impl<'a> Neg for &'a ProjectiveNielsPoint {
             Y_plus_X:   self.Y_minus_X,
             Y_minus_X:  self.Y_plus_X,
             Z:          self.Z,
-            T2d:        -(&self.T2d),
+            T2d:        -self.T2d,
         }
     }
 }
@@ -851,7 +851,7 @@ impl<'a> Neg for &'a AffineNielsPoint {
         AffineNielsPoint{
             y_plus_x:   self.y_minus_x,
             y_minus_x:  self.y_plus_x,
-            xy2d:       -(&self.xy2d)
+            xy2d:       -self.xy2d
         }
     }
 }
@@ -887,7 +887,7 @@ impl<'a, 'b> Mul<&'b Scalar> for &'a ExtendedPoint {
         let mut t: CompletedPoint;
         for i in (0..64).rev() {
             h = h.mult_by_pow_2(4);
-            t = &h + &select_precomputed_point(e[i], &As);
+            t = h + select_precomputed_point(e[i], &As);
             h = t.to_extended();
         }
         h

--- a/src/curve.rs
+++ b/src/curve.rs
@@ -738,7 +738,7 @@ impl<'a,'b> Add<&'b ProjectiveNielsPoint> for &'a ExtendedPoint {
 
 impl Add<ProjectiveNielsPoint> for ExtendedPoint {
     type Output = CompletedPoint;
-    #[inline(always)]
+    #[inline]
     fn add(self, other: ProjectiveNielsPoint) -> CompletedPoint {
         &self + &other
     }
@@ -817,6 +817,7 @@ impl<'a,'b> Add<&'b ExtendedPoint> for &'a ExtendedPoint {
 }
 
 impl<'b> AddAssign<&'b ExtendedPoint> for ExtendedPoint {
+    #[inline]
     fn add_assign(&mut self, _rhs: &'b ExtendedPoint) {
         *self = (self as &ExtendedPoint) + _rhs;
     }
@@ -831,6 +832,7 @@ impl<'a,'b> Sub<&'b ExtendedPoint> for &'a ExtendedPoint {
 }
 
 impl<'b> SubAssign<&'b ExtendedPoint> for ExtendedPoint {
+    #[inline]
     fn sub_assign(&mut self, _rhs: &'b ExtendedPoint) {
         *self = (self as &ExtendedPoint) - _rhs;
     }
@@ -903,6 +905,7 @@ impl<'a, 'b> Mul<&'b Scalar> for &'a ExtendedPoint {
     ///
     /// Uses a window of size 4.  Note: for scalar multiplication of
     /// the basepoint, `basepoint_mult` is approximately 4x faster.
+    #[inline]
     fn mul(self, scalar: &'b Scalar) -> ExtendedPoint {
         let A = self.to_projective_niels();
         let mut As: [ProjectiveNielsPoint; 8] = [A; 8];
@@ -969,6 +972,7 @@ impl<'a, 'b> Mul<&'b Scalar> for &'a EdwardsBasepointTable {
     /// We then use the `select_precomputed_point` function, which
     /// takes `-8 ≤ x < 8` and `[16^2i * B, ..., 8 * 16^2i * B]`,
     /// and returns `x * 16^2i * B` in constant time.
+    #[inline]
     fn mul(self, scalar: &'b Scalar) -> ExtendedPoint {
         let e = scalar.to_radix_16();
         let mut h = ExtendedPoint::identity();
@@ -1020,6 +1024,7 @@ impl<'a, 'b> Mul<&'a EdwardsBasepointTable> for &'b Scalar {
     /// We then use the `select_precomputed_point` function, which
     /// takes `-8 ≤ x < 8` and `[16^2i * B, ..., 8 * 16^2i * B]`,
     /// and returns `x * 16^2i * B` in constant time.
+    #[inline]
     fn mul(self, basepoint_table: &'a EdwardsBasepointTable) -> ExtendedPoint {
         basepoint_table * &self
     }

--- a/src/curve.rs
+++ b/src/curve.rs
@@ -717,7 +717,7 @@ impl ExtendedPoint {
 impl<'a,'b> Add<&'b ProjectiveNielsPoint> for &'a ExtendedPoint {
     type Output = CompletedPoint;
 
-    #[inline]
+    #[inline(always)]
     fn add(self, other: &'b ProjectiveNielsPoint) -> CompletedPoint {
         let Y_plus_X  = self.Y + self.X;
         let Y_minus_X = self.Y - self.X;
@@ -738,7 +738,7 @@ impl<'a,'b> Add<&'b ProjectiveNielsPoint> for &'a ExtendedPoint {
 
 impl Add<ProjectiveNielsPoint> for ExtendedPoint {
     type Output = CompletedPoint;
-    #[inline]
+    #[inline(always)]
     fn add(self, other: ProjectiveNielsPoint) -> CompletedPoint {
         &self + &other
     }
@@ -747,7 +747,7 @@ impl Add<ProjectiveNielsPoint> for ExtendedPoint {
 impl<'a,'b> Sub<&'b ProjectiveNielsPoint> for &'a ExtendedPoint {
     type Output = CompletedPoint;
 
-    #[inline]
+    #[inline(always)]
     fn sub(self, other: &'b ProjectiveNielsPoint) -> CompletedPoint {
         let Y_plus_X  = self.Y + self.X;
         let Y_minus_X = self.Y - self.X;
@@ -769,7 +769,7 @@ impl<'a,'b> Sub<&'b ProjectiveNielsPoint> for &'a ExtendedPoint {
 impl<'a,'b> Add<&'b AffineNielsPoint> for &'a ExtendedPoint {
     type Output = CompletedPoint;
 
-    #[inline]
+    #[inline(always)]
     fn add(self, other: &'b AffineNielsPoint) -> CompletedPoint {
         let Y_plus_X  = self.Y + self.X;
         let Y_minus_X = self.Y - self.X;
@@ -790,7 +790,7 @@ impl<'a,'b> Add<&'b AffineNielsPoint> for &'a ExtendedPoint {
 impl<'a,'b> Sub<&'b AffineNielsPoint> for &'a ExtendedPoint {
     type Output = CompletedPoint;
 
-    #[inline]
+    #[inline(always)]
     fn sub(self, other: &'b AffineNielsPoint) -> CompletedPoint {
         let Y_plus_X  = self.Y + self.X;
         let Y_minus_X = self.Y - self.X;
@@ -810,14 +810,14 @@ impl<'a,'b> Sub<&'b AffineNielsPoint> for &'a ExtendedPoint {
 
 impl<'a,'b> Add<&'b ExtendedPoint> for &'a ExtendedPoint {
     type Output = ExtendedPoint;
-    #[inline]
+    #[inline(always)]
     fn add(self, other: &'b ExtendedPoint) -> ExtendedPoint {
         (self + &other.to_projective_niels()).to_extended()
     }
 }
 
 impl<'b> AddAssign<&'b ExtendedPoint> for ExtendedPoint {
-    #[inline]
+    #[inline(always)]
     fn add_assign(&mut self, _rhs: &'b ExtendedPoint) {
         *self = (self as &ExtendedPoint) + _rhs;
     }
@@ -825,14 +825,14 @@ impl<'b> AddAssign<&'b ExtendedPoint> for ExtendedPoint {
 
 impl<'a,'b> Sub<&'b ExtendedPoint> for &'a ExtendedPoint {
     type Output = ExtendedPoint;
-    #[inline]
+    #[inline(always)]
     fn sub(self, other: &'b ExtendedPoint) -> ExtendedPoint {
         (self - &other.to_projective_niels()).to_extended()
     }
 }
 
 impl<'b> SubAssign<&'b ExtendedPoint> for ExtendedPoint {
-    #[inline]
+    #[inline(always)]
     fn sub_assign(&mut self, _rhs: &'b ExtendedPoint) {
         *self = (self as &ExtendedPoint) - _rhs;
     }
@@ -845,7 +845,7 @@ impl<'b> SubAssign<&'b ExtendedPoint> for ExtendedPoint {
 impl<'a> Neg for &'a ExtendedPoint {
     type Output = ExtendedPoint;
 
-    #[inline]
+    #[inline(always)]
     fn neg(self) -> ExtendedPoint {
         ExtendedPoint{
             X: -self.X,
@@ -859,7 +859,7 @@ impl<'a> Neg for &'a ExtendedPoint {
 impl<'a> Neg for &'a ProjectiveNielsPoint {
     type Output = ProjectiveNielsPoint;
 
-    #[inline]
+    #[inline(always)]
     fn neg(self) -> ProjectiveNielsPoint {
         ProjectiveNielsPoint{
             Y_plus_X:   self.Y_minus_X,
@@ -874,7 +874,7 @@ impl<'a> Neg for &'a ProjectiveNielsPoint {
 impl<'a> Neg for &'a AffineNielsPoint {
     type Output = AffineNielsPoint;
 
-    #[inline]
+    #[inline(always)]
     fn neg(self) -> AffineNielsPoint {
         AffineNielsPoint{
             y_plus_x:   self.y_minus_x,
@@ -889,7 +889,7 @@ impl<'a> Neg for &'a AffineNielsPoint {
 // ------------------------------------------------------------------------
 
 impl<'b> MulAssign<&'b Scalar> for ExtendedPoint {
-    #[inline]
+    #[inline(always)]
     fn mul_assign(&mut self, scalar: &'b Scalar) {
         let result = (self as &ExtendedPoint) * scalar;
         *self = result;
@@ -905,7 +905,7 @@ impl<'a, 'b> Mul<&'b Scalar> for &'a ExtendedPoint {
     ///
     /// Uses a window of size 4.  Note: for scalar multiplication of
     /// the basepoint, `basepoint_mult` is approximately 4x faster.
-    #[inline]
+    #[inline(always)]
     fn mul(self, scalar: &'b Scalar) -> ExtendedPoint {
         let A = self.to_projective_niels();
         let mut As: [ProjectiveNielsPoint; 8] = [A; 8];
@@ -931,7 +931,7 @@ impl<'a, 'b> Mul<&'b ExtendedPoint> for &'a Scalar {
     ///
     /// Uses a window of size 4.  Note: for scalar multiplication of
     /// the basepoint, `basepoint_mult` is approximately 4x faster.
-    #[inline]
+    #[inline(always)]
     fn mul(self, point: &'b ExtendedPoint) -> ExtendedPoint {
         point * &self
     }
@@ -972,7 +972,7 @@ impl<'a, 'b> Mul<&'b Scalar> for &'a EdwardsBasepointTable {
     /// We then use the `select_precomputed_point` function, which
     /// takes `-8 ≤ x < 8` and `[16^2i * B, ..., 8 * 16^2i * B]`,
     /// and returns `x * 16^2i * B` in constant time.
-    #[inline]
+    #[inline(always)]
     fn mul(self, scalar: &'b Scalar) -> ExtendedPoint {
         let e = scalar.to_radix_16();
         let mut h = ExtendedPoint::identity();
@@ -1024,7 +1024,7 @@ impl<'a, 'b> Mul<&'a EdwardsBasepointTable> for &'b Scalar {
     /// We then use the `select_precomputed_point` function, which
     /// takes `-8 ≤ x < 8` and `[16^2i * B, ..., 8 * 16^2i * B]`,
     /// and returns `x * 16^2i * B` in constant time.
-    #[inline]
+    #[inline(always)]
     fn mul(self, basepoint_table: &'a EdwardsBasepointTable) -> ExtendedPoint {
         basepoint_table * &self
     }
@@ -1063,14 +1063,14 @@ impl ExtendedPoint {
     /// Multiply by the cofactor: compute `8 * self`.
     ///
     /// Convenience wrapper around `mult_by_pow_2`.
-    #[inline]
+    #[inline(always)]
     pub fn mult_by_cofactor(&self) -> ExtendedPoint {
         self.mult_by_pow_2(3)
     }
 
     /// Compute `2^k * self` by successive doublings.
     /// Requires `k > 0`.
-    #[inline]
+    #[inline(always)]
     pub fn mult_by_pow_2(&self, k: u32) -> ExtendedPoint {
         let mut r: CompletedPoint;
         let mut s = self.to_projective();

--- a/src/curve.rs
+++ b/src/curve.rs
@@ -134,8 +134,8 @@ impl CompressedEdwardsY {
         let Y = FieldElement::from_bytes(self.as_bytes());
         let Z = FieldElement::one();
         let YY = Y.square();
-        let u = &YY - &Z;                    // u =  y²-1
-        let v = &(&YY * &constants::d) + &Z; // v = dy²+1
+        let u = YY - Z;                    // u =  y²-1
+        let v = (YY * constants::d) + Z;   // v = dy²+1
         let (is_nonzero_square, mut X) = FieldElement::sqrt_ratio(&u, &v);
 
         if is_nonzero_square != 1u8 { return None; }
@@ -145,7 +145,7 @@ impl CompressedEdwardsY {
         let    current_sign_bit = X.is_negative_ed25519();
         X.conditional_negate(current_sign_bit ^ compressed_sign_bit);
 
-        Some(ExtendedPoint{ X: X, Y: Y, Z: Z, T: &X * &Y })
+        Some(ExtendedPoint{ X: X, Y: Y, Z: Z, T: X * Y })
     }
 }
 
@@ -218,7 +218,7 @@ impl CompressedMontgomeryU {
     /// A `FieldElement` corresponding to this coordinate, but in Edwards form.
     pub fn to_edwards_y(u: &FieldElement) -> FieldElement {
         // Since `u = (1+y)/(1-y)` and `v = √(u(u²+Au+1))`, so `y = (u-1)/(u+1)`.
-        &(u - &FieldElement::one()) * &(u + &FieldElement::one()).invert()
+        (u - FieldElement::one()) * (u + FieldElement::one()).invert()
     }
 
     /// Given a Montgomery `u` coordinate, compute the corresponding

--- a/src/curve.rs
+++ b/src/curve.rs
@@ -134,8 +134,8 @@ impl CompressedEdwardsY {
         let Y = FieldElement::from_bytes(self.as_bytes());
         let Z = FieldElement::one();
         let YY = Y.square();
-        let u = YY - Z;                    // u =  y²-1
-        let v = (YY * constants::d) + Z;   // v = dy²+1
+        let u = &YY - &Z;                    // u =  y²-1
+        let v = &(&YY * &constants::d) + &Z; // v = dy²+1
         let (is_nonzero_square, mut X) = FieldElement::sqrt_ratio(&u, &v);
 
         if is_nonzero_square != 1u8 { return None; }
@@ -145,7 +145,7 @@ impl CompressedEdwardsY {
         let    current_sign_bit = X.is_negative_ed25519();
         X.conditional_negate(current_sign_bit ^ compressed_sign_bit);
 
-        Some(ExtendedPoint{ X: X, Y: Y, Z: Z, T: X * Y })
+        Some(ExtendedPoint{ X: X, Y: Y, Z: Z, T: &X * &Y })
     }
 }
 
@@ -218,7 +218,7 @@ impl CompressedMontgomeryU {
     /// A `FieldElement` corresponding to this coordinate, but in Edwards form.
     pub fn to_edwards_y(u: &FieldElement) -> FieldElement {
         // Since `u = (1+y)/(1-y)` and `v = √(u(u²+Au+1))`, so `y = (u-1)/(u+1)`.
-        (u - FieldElement::one()) * (u + FieldElement::one()).invert()
+        &(u - &FieldElement::one()) * &(u + &FieldElement::one()).invert()
     }
 
     /// Given a Montgomery `u` coordinate, compute the corresponding

--- a/src/curve.rs
+++ b/src/curve.rs
@@ -716,6 +716,7 @@ impl ExtendedPoint {
 impl<'a,'b> Add<&'b ProjectiveNielsPoint> for &'a ExtendedPoint {
     type Output = CompletedPoint;
 
+    #[inline]
     fn add(self, other: &'b ProjectiveNielsPoint) -> CompletedPoint {
         let Y_plus_X  = self.Y + self.X;
         let Y_minus_X = self.Y - self.X;
@@ -745,6 +746,7 @@ impl Add<ProjectiveNielsPoint> for ExtendedPoint {
 impl<'a,'b> Sub<&'b ProjectiveNielsPoint> for &'a ExtendedPoint {
     type Output = CompletedPoint;
 
+    #[inline]
     fn sub(self, other: &'b ProjectiveNielsPoint) -> CompletedPoint {
         let Y_plus_X  = self.Y + self.X;
         let Y_minus_X = self.Y - self.X;
@@ -766,6 +768,7 @@ impl<'a,'b> Sub<&'b ProjectiveNielsPoint> for &'a ExtendedPoint {
 impl<'a,'b> Add<&'b AffineNielsPoint> for &'a ExtendedPoint {
     type Output = CompletedPoint;
 
+    #[inline]
     fn add(self, other: &'b AffineNielsPoint) -> CompletedPoint {
         let Y_plus_X  = self.Y + self.X;
         let Y_minus_X = self.Y - self.X;
@@ -786,6 +789,7 @@ impl<'a,'b> Add<&'b AffineNielsPoint> for &'a ExtendedPoint {
 impl<'a,'b> Sub<&'b AffineNielsPoint> for &'a ExtendedPoint {
     type Output = CompletedPoint;
 
+    #[inline]
     fn sub(self, other: &'b AffineNielsPoint) -> CompletedPoint {
         let Y_plus_X  = self.Y + self.X;
         let Y_minus_X = self.Y - self.X;
@@ -805,6 +809,7 @@ impl<'a,'b> Sub<&'b AffineNielsPoint> for &'a ExtendedPoint {
 
 impl<'a,'b> Add<&'b ExtendedPoint> for &'a ExtendedPoint {
     type Output = ExtendedPoint;
+    #[inline]
     fn add(self, other: &'b ExtendedPoint) -> ExtendedPoint {
         (self + &other.to_projective_niels()).to_extended()
     }
@@ -812,6 +817,7 @@ impl<'a,'b> Add<&'b ExtendedPoint> for &'a ExtendedPoint {
 
 impl<'a,'b> Sub<&'b ExtendedPoint> for &'a ExtendedPoint {
     type Output = ExtendedPoint;
+    #[inline]
     fn sub(self, other: &'b ExtendedPoint) -> ExtendedPoint {
         (self - &other.to_projective_niels()).to_extended()
     }
@@ -820,6 +826,7 @@ impl<'a,'b> Sub<&'b ExtendedPoint> for &'a ExtendedPoint {
 impl<'a> Neg for &'a ExtendedPoint {
     type Output = ExtendedPoint;
 
+    #[inline]
     fn neg(self) -> ExtendedPoint {
         ExtendedPoint{
             X: -self.X,
@@ -833,6 +840,7 @@ impl<'a> Neg for &'a ExtendedPoint {
 impl<'a> Neg for &'a ProjectiveNielsPoint {
     type Output = ProjectiveNielsPoint;
 
+    #[inline]
     fn neg(self) -> ProjectiveNielsPoint {
         ProjectiveNielsPoint{
             Y_plus_X:   self.Y_minus_X,
@@ -847,6 +855,7 @@ impl<'a> Neg for &'a ProjectiveNielsPoint {
 impl<'a> Neg for &'a AffineNielsPoint {
     type Output = AffineNielsPoint;
 
+    #[inline]
     fn neg(self) -> AffineNielsPoint {
         AffineNielsPoint{
             y_plus_x:   self.y_minus_x,
@@ -861,6 +870,7 @@ impl<'a> Neg for &'a AffineNielsPoint {
 // ------------------------------------------------------------------------
 
 impl<'b> MulAssign<&'b Scalar> for ExtendedPoint {
+    #[inline]
     fn mul_assign(&mut self, scalar: &'b Scalar) {
         let result = (self as &ExtendedPoint) * scalar;
         *self = result;
@@ -901,6 +911,7 @@ impl<'a, 'b> Mul<&'b ExtendedPoint> for &'a Scalar {
     ///
     /// Uses a window of size 4.  Note: for scalar multiplication of
     /// the basepoint, `basepoint_mult` is approximately 4x faster.
+    #[inline]
     fn mul(self, point: &'b ExtendedPoint) -> ExtendedPoint {
         point * &self
     }

--- a/src/curve.rs
+++ b/src/curve.rs
@@ -734,6 +734,14 @@ impl<'a,'b> Add<&'b ProjectiveNielsPoint> for &'a ExtendedPoint {
     }
 }
 
+impl Add<ProjectiveNielsPoint> for ExtendedPoint {
+    type Output = CompletedPoint;
+    #[inline(always)]
+    fn add(self, other: ProjectiveNielsPoint) -> CompletedPoint {
+        &self + &other
+    }
+}
+
 impl<'a,'b> Sub<&'b ProjectiveNielsPoint> for &'a ExtendedPoint {
     type Output = CompletedPoint;
 

--- a/src/decaf.rs
+++ b/src/decaf.rs
@@ -424,6 +424,8 @@ impl Eq for DecafPoint {}
 // Arithmetic
 // ------------------------------------------------------------------------
 
+add_impl!(DecafPoint, DecafPoint, DecafPoint);
+
 impl<'a, 'b> Add<&'b DecafPoint> for &'a DecafPoint {
     type Output = DecafPoint;
 
@@ -432,6 +434,8 @@ impl<'a, 'b> Add<&'b DecafPoint> for &'a DecafPoint {
     }
 }
 
+sub_impl!(DecafPoint, DecafPoint, DecafPoint);
+
 impl<'a, 'b> Sub<&'b DecafPoint> for &'a DecafPoint {
     type Output = DecafPoint;
 
@@ -439,6 +443,8 @@ impl<'a, 'b> Sub<&'b DecafPoint> for &'a DecafPoint {
         DecafPoint(&self.0 - &other.0)
     }
 }
+
+neg_impl!(DecafPoint, DecafPoint);
 
 impl<'a> Neg for &'a DecafPoint {
     type Output = DecafPoint;

--- a/src/decaf.rs
+++ b/src/decaf.rs
@@ -528,14 +528,14 @@ impl<'a, 'b> Add<&'b DecafPoint> for &'a DecafPoint {
 sub_impl!(DecafPoint, DecafPoint, DecafPoint);
 
 impl<'b> AddAssign<&'b DecafPoint> for DecafPoint {
-    #[inline]
+    #[inline(always)]
     fn add_assign(&mut self, _rhs: &DecafPoint) {
         *self = (self as &DecafPoint) + _rhs;
     }
 }
 
 impl<'a, 'b> Sub<&'b DecafPoint> for &'a DecafPoint {
-    #[inline]
+    #[inline(always)]
     type Output = DecafPoint;
 
     fn sub(self, other: &'b DecafPoint) -> DecafPoint {
@@ -546,7 +546,7 @@ impl<'a, 'b> Sub<&'b DecafPoint> for &'a DecafPoint {
 neg_impl!(DecafPoint, DecafPoint);
 
 impl<'b> SubAssign<&'b DecafPoint> for DecafPoint {
-    #[inline]
+    #[inline(always)]
     fn sub_assign(&mut self, _rhs: &DecafPoint) {
         *self = (self as &DecafPoint) - _rhs;
     }
@@ -555,14 +555,14 @@ impl<'b> SubAssign<&'b DecafPoint> for DecafPoint {
 impl<'a> Neg for &'a DecafPoint {
     type Output = DecafPoint;
 
-    #[inline]
+    #[inline(always)]
     fn neg(self) -> DecafPoint {
         DecafPoint(-&self.0)
     }
 }
 
 impl<'b> MulAssign<&'b Scalar> for DecafPoint {
-    #[inline]
+    #[inline(always)]
     fn mul_assign(&mut self, scalar: &'b Scalar) {
         let result = (self as &DecafPoint) * scalar;
         *self = result;
@@ -572,7 +572,7 @@ impl<'b> MulAssign<&'b Scalar> for DecafPoint {
 impl<'a, 'b> Mul<&'b Scalar> for &'a DecafPoint {
     type Output = DecafPoint;
     /// Scalar multiplication: compute `scalar * self`.
-    #[inline]
+    #[inline(always)]
     fn mul(self, scalar: &'b Scalar) -> DecafPoint {
         DecafPoint(&self.0 * scalar)
     }
@@ -582,7 +582,7 @@ impl<'a, 'b> Mul<&'b DecafPoint> for &'a Scalar {
     type Output = DecafPoint;
 
     /// Scalar multiplication: compute `self * scalar`.
-    #[inline]
+    #[inline(always)]
     fn mul(self, point: &'b DecafPoint) -> DecafPoint {
         DecafPoint(self * &point.0)
     }
@@ -596,7 +596,7 @@ pub struct DecafBasepointTable(pub EdwardsBasepointTable);
 impl<'a, 'b> Mul<&'b Scalar> for &'a DecafBasepointTable {
     type Output = DecafPoint;
 
-    #[inline]
+    #[inline(always)]
     fn mul(self, scalar: &'b Scalar) -> DecafPoint {
         DecafPoint(&self.0 * scalar)
     }
@@ -605,7 +605,7 @@ impl<'a, 'b> Mul<&'b Scalar> for &'a DecafBasepointTable {
 impl<'a, 'b> Mul<&'a DecafBasepointTable> for &'b Scalar {
     type Output = DecafPoint;
 
-    #[inline]
+    #[inline(always)]
     fn mul(self, basepoint_table: &'a DecafBasepointTable) -> DecafPoint {
         DecafPoint(self * &basepoint_table.0)
     }

--- a/src/decaf.rs
+++ b/src/decaf.rs
@@ -519,6 +519,7 @@ add_impl!(DecafPoint, DecafPoint, DecafPoint);
 impl<'a, 'b> Add<&'b DecafPoint> for &'a DecafPoint {
     type Output = DecafPoint;
 
+    #[inline(always)]
     fn add(self, other: &'b DecafPoint) -> DecafPoint {
         DecafPoint(&self.0 + &other.0)
     }
@@ -527,12 +528,14 @@ impl<'a, 'b> Add<&'b DecafPoint> for &'a DecafPoint {
 sub_impl!(DecafPoint, DecafPoint, DecafPoint);
 
 impl<'b> AddAssign<&'b DecafPoint> for DecafPoint {
+    #[inline]
     fn add_assign(&mut self, _rhs: &DecafPoint) {
         *self = (self as &DecafPoint) + _rhs;
     }
 }
 
 impl<'a, 'b> Sub<&'b DecafPoint> for &'a DecafPoint {
+    #[inline]
     type Output = DecafPoint;
 
     fn sub(self, other: &'b DecafPoint) -> DecafPoint {
@@ -543,6 +546,7 @@ impl<'a, 'b> Sub<&'b DecafPoint> for &'a DecafPoint {
 neg_impl!(DecafPoint, DecafPoint);
 
 impl<'b> SubAssign<&'b DecafPoint> for DecafPoint {
+    #[inline]
     fn sub_assign(&mut self, _rhs: &DecafPoint) {
         *self = (self as &DecafPoint) - _rhs;
     }
@@ -551,12 +555,14 @@ impl<'b> SubAssign<&'b DecafPoint> for DecafPoint {
 impl<'a> Neg for &'a DecafPoint {
     type Output = DecafPoint;
 
+    #[inline]
     fn neg(self) -> DecafPoint {
         DecafPoint(-&self.0)
     }
 }
 
 impl<'b> MulAssign<&'b Scalar> for DecafPoint {
+    #[inline]
     fn mul_assign(&mut self, scalar: &'b Scalar) {
         let result = (self as &DecafPoint) * scalar;
         *self = result;
@@ -566,6 +572,7 @@ impl<'b> MulAssign<&'b Scalar> for DecafPoint {
 impl<'a, 'b> Mul<&'b Scalar> for &'a DecafPoint {
     type Output = DecafPoint;
     /// Scalar multiplication: compute `scalar * self`.
+    #[inline]
     fn mul(self, scalar: &'b Scalar) -> DecafPoint {
         DecafPoint(&self.0 * scalar)
     }
@@ -575,6 +582,7 @@ impl<'a, 'b> Mul<&'b DecafPoint> for &'a Scalar {
     type Output = DecafPoint;
 
     /// Scalar multiplication: compute `self * scalar`.
+    #[inline]
     fn mul(self, point: &'b DecafPoint) -> DecafPoint {
         DecafPoint(self * &point.0)
     }
@@ -588,6 +596,7 @@ pub struct DecafBasepointTable(pub EdwardsBasepointTable);
 impl<'a, 'b> Mul<&'b Scalar> for &'a DecafBasepointTable {
     type Output = DecafPoint;
 
+    #[inline]
     fn mul(self, scalar: &'b Scalar) -> DecafPoint {
         DecafPoint(&self.0 * scalar)
     }
@@ -596,6 +605,7 @@ impl<'a, 'b> Mul<&'b Scalar> for &'a DecafBasepointTable {
 impl<'a, 'b> Mul<&'a DecafBasepointTable> for &'b Scalar {
     type Output = DecafPoint;
 
+    #[inline]
     fn mul(self, basepoint_table: &'a DecafBasepointTable) -> DecafPoint {
         DecafPoint(self * &basepoint_table.0)
     }

--- a/src/field.rs
+++ b/src/field.rs
@@ -137,6 +137,14 @@ impl<'a, 'b> Add<&'b FieldElement> for &'a FieldElement {
     }
 }
 
+impl Add<FieldElement> for FieldElement {
+    type Output = FieldElement;
+    #[inline(always)]
+    fn add(self, rhs: FieldElement) -> FieldElement {
+        &self + &rhs
+    }
+}
+
 impl<'b> SubAssign<&'b FieldElement> for FieldElement {
     #[cfg(not(feature="radix_51"))]
     fn sub_assign(&mut self, _rhs: &'b FieldElement) { // fdifference()
@@ -180,6 +188,14 @@ impl<'a, 'b> Sub<&'b FieldElement> for &'a FieldElement {
             (self.0[3] + 36028797018963952u64) - _rhs.0[3],
             (self.0[4] + 36028797018963952u64) - _rhs.0[4],
         ])
+    }
+}
+
+impl Sub<FieldElement> for FieldElement {
+    type Output = FieldElement;
+    #[inline(always)]
+    fn sub(self, rhs: FieldElement) -> FieldElement {
+        &self - &rhs
     }
 }
 
@@ -322,12 +338,27 @@ impl<'a, 'b> Mul<&'b FieldElement> for &'a FieldElement {
     }
 }
 
+impl Mul<FieldElement> for FieldElement {
+    type Output = FieldElement;
+    #[inline(always)]
+    fn mul(self, rhs: FieldElement) -> FieldElement {
+        &self * &rhs
+    }
+}
+
 impl<'a> Neg for &'a FieldElement {
     type Output = FieldElement;
     fn neg(self) -> FieldElement {
         let mut output = *self;
         output.negate();
         output
+    }
+}
+
+impl Neg for FieldElement {
+    type Output = FieldElement;
+    fn neg(self) -> FieldElement {
+        -(&self)
     }
 }
 

--- a/src/field.rs
+++ b/src/field.rs
@@ -197,7 +197,7 @@ impl<'a, 'b> Sub<&'b FieldElement> for &'a FieldElement {
 }
 
 impl<'b> MulAssign<&'b FieldElement> for FieldElement {
-    #[inline]
+    #[inline(always)]
     fn mul_assign(&mut self, _rhs: &'b FieldElement) {
         let result = (self as &FieldElement) * _rhs;
         self.0 = result.0;

--- a/src/field.rs
+++ b/src/field.rs
@@ -1390,6 +1390,12 @@ mod bench {
     }
 
     #[bench]
+    fn fieldelement_a_mul_a_by_value(b: &mut Bencher) {
+        let a = FieldElement::from_bytes(&A_BYTES);
+        b.iter(|| a*a);
+    }
+
+    #[bench]
     fn fieldelement_a_sq(b: &mut Bencher) {
         let a = FieldElement::from_bytes(&A_BYTES);
         b.iter(|| a.square());

--- a/src/field.rs
+++ b/src/field.rs
@@ -128,20 +128,17 @@ impl<'b> AddAssign<&'b FieldElement> for FieldElement {
     }
 }
 
+add_impl!(FieldElement, FieldElement, FieldElement);
+sub_impl!(FieldElement, FieldElement, FieldElement);
+mul_impl!(FieldElement, FieldElement, FieldElement);
+neg_impl!(FieldElement, FieldElement);
+
 impl<'a, 'b> Add<&'b FieldElement> for &'a FieldElement {
     type Output = FieldElement;
     fn add(self, _rhs: &'b FieldElement) -> FieldElement {
         let mut output = *self;
         output += _rhs;
         output
-    }
-}
-
-impl Add<FieldElement> for FieldElement {
-    type Output = FieldElement;
-    #[inline(always)]
-    fn add(self, rhs: FieldElement) -> FieldElement {
-        &self + &rhs
     }
 }
 
@@ -188,14 +185,6 @@ impl<'a, 'b> Sub<&'b FieldElement> for &'a FieldElement {
             (self.0[3] + 36028797018963952u64) - _rhs.0[3],
             (self.0[4] + 36028797018963952u64) - _rhs.0[4],
         ])
-    }
-}
-
-impl Sub<FieldElement> for FieldElement {
-    type Output = FieldElement;
-    #[inline(always)]
-    fn sub(self, rhs: FieldElement) -> FieldElement {
-        &self - &rhs
     }
 }
 
@@ -338,27 +327,12 @@ impl<'a, 'b> Mul<&'b FieldElement> for &'a FieldElement {
     }
 }
 
-impl Mul<FieldElement> for FieldElement {
-    type Output = FieldElement;
-    #[inline(always)]
-    fn mul(self, rhs: FieldElement) -> FieldElement {
-        &self * &rhs
-    }
-}
-
 impl<'a> Neg for &'a FieldElement {
     type Output = FieldElement;
     fn neg(self) -> FieldElement {
         let mut output = *self;
         output.negate();
         output
-    }
-}
-
-impl Neg for FieldElement {
-    type Output = FieldElement;
-    fn neg(self) -> FieldElement {
-        -(&self)
     }
 }
 

--- a/src/field.rs
+++ b/src/field.rs
@@ -109,18 +109,21 @@ impl Debug for FieldElement {
 impl Index<usize> for FieldElement {
     type Output = Limb;
 
+    #[inline]
     fn index(&self, _index: usize) -> &Limb {
         &(self.0[_index])
     }
 }
 
 impl IndexMut<usize> for FieldElement {
+    #[inline]
     fn index_mut(&mut self, _index: usize) -> &mut Limb {
         &mut(self.0[_index])
     }
 }
 
 impl<'b> AddAssign<&'b FieldElement> for FieldElement {
+    #[inline]
     fn add_assign(&mut self, _rhs: &'b FieldElement) { // fsum()
         for i in 0..self.0.len() {
             self[i] += _rhs[i];
@@ -135,6 +138,7 @@ neg_impl!(FieldElement, FieldElement);
 
 impl<'a, 'b> Add<&'b FieldElement> for &'a FieldElement {
     type Output = FieldElement;
+    #[inline]
     fn add(self, _rhs: &'b FieldElement) -> FieldElement {
         let mut output = *self;
         output += _rhs;
@@ -144,12 +148,14 @@ impl<'a, 'b> Add<&'b FieldElement> for &'a FieldElement {
 
 impl<'b> SubAssign<&'b FieldElement> for FieldElement {
     #[cfg(not(feature="radix_51"))]
+    #[inline]
     fn sub_assign(&mut self, _rhs: &'b FieldElement) { // fdifference()
         for i in 0..10 {
             self[i] -= _rhs[i];
         }
     }
     #[cfg(feature="radix_51")]
+    #[inline]
     fn sub_assign(&mut self, _rhs: &'b FieldElement) {
         let result = (self as &FieldElement) - _rhs;
         for i in 0..5 {
@@ -161,12 +167,14 @@ impl<'b> SubAssign<&'b FieldElement> for FieldElement {
 impl<'a, 'b> Sub<&'b FieldElement> for &'a FieldElement {
     type Output = FieldElement;
     #[cfg(not(feature="radix_51"))]
+    #[inline]
     fn sub(self, _rhs: &'b FieldElement) -> FieldElement {
         let mut output = *self;
         output -= _rhs;
         output
     }
     #[cfg(feature="radix_51")]
+    #[inline]
     fn sub(self, _rhs: &'b FieldElement) -> FieldElement {
         // To avoid underflow, first add a multiple of p.
         // Choose 16*p = p << 4 to be larger than 54-bit _rhs.
@@ -189,6 +197,7 @@ impl<'a, 'b> Sub<&'b FieldElement> for &'a FieldElement {
 }
 
 impl<'b> MulAssign<&'b FieldElement> for FieldElement {
+    #[inline]
     fn mul_assign(&mut self, _rhs: &'b FieldElement) {
         let result = (self as &FieldElement) * _rhs;
         self.0 = result.0;
@@ -198,6 +207,7 @@ impl<'b> MulAssign<&'b FieldElement> for FieldElement {
 impl<'a, 'b> Mul<&'b FieldElement> for &'a FieldElement {
     type Output = FieldElement;
     #[cfg(feature="radix_51")]
+    #[inline]
     fn mul(self, _rhs: &'b FieldElement) -> FieldElement {
         /// Multiply two 64-bit integers with 128 bits of output.
         #[inline(always)]
@@ -243,6 +253,7 @@ impl<'a, 'b> Mul<&'b FieldElement> for &'a FieldElement {
     }
 
     #[cfg(not(feature="radix_51"))]
+    #[inline]
     fn mul(self, _rhs: &'b FieldElement) -> FieldElement {
         // Notes preserved from ed25519.go (presumably originally from ref10):
         //
@@ -329,6 +340,7 @@ impl<'a, 'b> Mul<&'b FieldElement> for &'a FieldElement {
 
 impl<'a> Neg for &'a FieldElement {
     type Output = FieldElement;
+    #[inline]
     fn neg(self) -> FieldElement {
         let mut output = *self;
         output.negate();
@@ -388,6 +400,7 @@ impl CTAssignable for FieldElement {
 impl FieldElement {
     /// Invert the sign of this field element
     #[cfg(not(feature="radix_51"))]
+    #[inline]
     pub fn negate(&mut self) {
         for i in 0..10 {
             self[i] = -self[i];
@@ -395,6 +408,7 @@ impl FieldElement {
     }
     /// Invert the sign of this field element
     #[cfg(feature="radix_51")]
+    #[inline]
     pub fn negate(&mut self) {
         // See commentary in the Sub impl
         let neg = FieldElement::reduce([

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,10 @@ extern crate rand;
 #[cfg(not(feature = "std"))]
 extern crate collections;
 
+// Macros
+#[macro_use]
+mod macros;
+
 // Modules for low-level operations directly on field elements and curve points.
 
 pub mod field;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -5,6 +5,7 @@ macro_rules! add_impl {
     ($lhs:ty, $rhs:ty, $out:ty) => {
         impl Add<$rhs> for $lhs {
             type Output = $out;
+
             #[inline(always)]
             fn add(self, rhs: $rhs) -> $out {
                 &self + &rhs
@@ -18,6 +19,7 @@ macro_rules! sub_impl {
     ($lhs:ty, $rhs:ty, $out:ty) => {
         impl Sub<$rhs> for $lhs {
             type Output = $out;
+
             #[inline(always)]
             fn sub(self, rhs: $rhs) -> $out {
                 &self - &rhs
@@ -31,6 +33,7 @@ macro_rules! mul_impl {
     ($lhs:ty, $rhs:ty, $out:ty) => {
         impl Mul<$rhs> for $lhs {
             type Output = $out;
+
             #[inline(always)]
             fn mul(self, rhs: $rhs) -> $out {
                 &self * &rhs
@@ -44,6 +47,7 @@ macro_rules! neg_impl {
     ($t:ty, $out:ty) => {
         impl Neg for $t {
             type Output = $out;
+
             #[inline(always)]
             fn neg(self) -> $out {
                 -(&self)

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,53 @@
+// Various macros for implmenting repetative pass-by-value semantics
+
+#[macro_export]
+macro_rules! add_impl {
+    ($lhs:ty, $rhs:ty, $out:ty) => {
+        impl Add<$rhs> for $lhs {
+            type Output = $out;
+            #[inline(always)]
+            fn add(self, rhs: $rhs) -> $out {
+                &self + &rhs
+            }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! sub_impl {
+    ($lhs:ty, $rhs:ty, $out:ty) => {
+        impl Sub<$rhs> for $lhs {
+            type Output = $out;
+            #[inline(always)]
+            fn sub(self, rhs: $rhs) -> $out {
+                &self - &rhs
+            }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! mul_impl {
+    ($lhs:ty, $rhs:ty, $out:ty) => {
+        impl Mul<$rhs> for $lhs {
+            type Output = $out;
+            #[inline(always)]
+            fn mul(self, rhs: $rhs) -> $out {
+                &self * &rhs
+            }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! neg_impl {
+    ($t:ty, $out:ty) => {
+        impl Neg for $t {
+            type Output = $out;
+            #[inline(always)]
+            fn neg(self) -> $out {
+                -(&self)
+            }
+        }
+    };
+}

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -106,6 +106,7 @@ impl IndexMut<usize> for Scalar {
 }
 
 impl<'b> MulAssign<&'b Scalar> for Scalar {
+    #[inline]
     fn mul_assign(&mut self, _rhs: &'b Scalar) {
         let result = (self as &Scalar) * _rhs;
         self.0 = result.0;
@@ -114,12 +115,14 @@ impl<'b> MulAssign<&'b Scalar> for Scalar {
 
 impl<'a, 'b> Mul<&'b Scalar> for &'a Scalar {
     type Output = Scalar;
+    #[inline]
     fn mul(self, _rhs: &'b Scalar) -> Scalar {
         Scalar::multiply_add(self, _rhs, &Scalar::zero())
     }
 }
 
 impl<'b> AddAssign<&'b Scalar> for Scalar {
+    #[inline]
     fn add_assign(&mut self, _rhs: &'b Scalar) {
         *self = Scalar::multiply_add(&Scalar::one(), self, _rhs);
     }
@@ -129,12 +132,14 @@ add_impl!(Scalar, Scalar, Scalar);
 
 impl<'a, 'b> Add<&'b Scalar> for &'a Scalar {
     type Output = Scalar;
+    #[inline]
     fn add(self, _rhs: &'b Scalar) -> Scalar {
         Scalar::multiply_add(&Scalar::one(), self, _rhs)
     }
 }
 
 impl<'b> SubAssign<&'b Scalar> for Scalar {
+    #[inline]
     fn sub_assign(&mut self, _rhs: &'b Scalar) {
         // (l-1)*_rhs + self = self - _rhs
         *self = Scalar::multiply_add(&constants::l_minus_1, _rhs, self);
@@ -145,6 +150,7 @@ sub_impl!(Scalar, Scalar, Scalar);
 
 impl<'a, 'b> Sub<&'b Scalar> for &'a Scalar {
     type Output = Scalar;
+    #[inline]
     fn sub(self, _rhs: &'b Scalar) -> Scalar {
         // (l-1)*_rhs + self = self - _rhs
         Scalar::multiply_add(&constants::l_minus_1, _rhs, self)
@@ -155,6 +161,7 @@ neg_impl!(Scalar, Scalar);
 
 impl<'a> Neg for &'a Scalar {
     type Output = Scalar;
+    #[inline]
     fn neg(self) -> Scalar {
         self * &constants::l_minus_1
    }

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -125,6 +125,8 @@ impl<'b> AddAssign<&'b Scalar> for Scalar {
     }
 }
 
+add_impl!(Scalar, Scalar, Scalar);
+
 impl<'a, 'b> Add<&'b Scalar> for &'a Scalar {
     type Output = Scalar;
     fn add(self, _rhs: &'b Scalar) -> Scalar {
@@ -139,6 +141,8 @@ impl<'b> SubAssign<&'b Scalar> for Scalar {
     }
 }
 
+sub_impl!(Scalar, Scalar, Scalar);
+
 impl<'a, 'b> Sub<&'b Scalar> for &'a Scalar {
     type Output = Scalar;
     fn sub(self, _rhs: &'b Scalar) -> Scalar {
@@ -146,6 +150,8 @@ impl<'a, 'b> Sub<&'b Scalar> for &'a Scalar {
         Scalar::multiply_add(&constants::l_minus_1, _rhs, self)
     }
 }
+
+neg_impl!(Scalar, Scalar);
 
 impl<'a> Neg for &'a Scalar {
     type Output = Scalar;

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -106,7 +106,7 @@ impl IndexMut<usize> for Scalar {
 }
 
 impl<'b> MulAssign<&'b Scalar> for Scalar {
-    #[inline]
+    #[inline(always)]
     fn mul_assign(&mut self, _rhs: &'b Scalar) {
         let result = (self as &Scalar) * _rhs;
         self.0 = result.0;
@@ -115,14 +115,14 @@ impl<'b> MulAssign<&'b Scalar> for Scalar {
 
 impl<'a, 'b> Mul<&'b Scalar> for &'a Scalar {
     type Output = Scalar;
-    #[inline]
+    #[inline(always)]
     fn mul(self, _rhs: &'b Scalar) -> Scalar {
         Scalar::multiply_add(self, _rhs, &Scalar::zero())
     }
 }
 
 impl<'b> AddAssign<&'b Scalar> for Scalar {
-    #[inline]
+    #[inline(always)]
     fn add_assign(&mut self, _rhs: &'b Scalar) {
         *self = Scalar::multiply_add(&Scalar::one(), self, _rhs);
     }
@@ -132,14 +132,14 @@ add_impl!(Scalar, Scalar, Scalar);
 
 impl<'a, 'b> Add<&'b Scalar> for &'a Scalar {
     type Output = Scalar;
-    #[inline]
+    #[inline(always)]
     fn add(self, _rhs: &'b Scalar) -> Scalar {
         Scalar::multiply_add(&Scalar::one(), self, _rhs)
     }
 }
 
 impl<'b> SubAssign<&'b Scalar> for Scalar {
-    #[inline]
+    #[inline(always)]
     fn sub_assign(&mut self, _rhs: &'b Scalar) {
         // (l-1)*_rhs + self = self - _rhs
         *self = Scalar::multiply_add(&constants::l_minus_1, _rhs, self);
@@ -150,7 +150,7 @@ sub_impl!(Scalar, Scalar, Scalar);
 
 impl<'a, 'b> Sub<&'b Scalar> for &'a Scalar {
     type Output = Scalar;
-    #[inline]
+    #[inline(always)]
     fn sub(self, _rhs: &'b Scalar) -> Scalar {
         // (l-1)*_rhs + self = self - _rhs
         Scalar::multiply_add(&constants::l_minus_1, _rhs, self)
@@ -161,7 +161,7 @@ neg_impl!(Scalar, Scalar);
 
 impl<'a> Neg for &'a Scalar {
     type Output = Scalar;
-    #[inline]
+    #[inline(always)]
     fn neg(self) -> Scalar {
         self * &constants::l_minus_1
    }


### PR DESCRIPTION
Tracking issue: #57

Implements `Add`, `Sub` and `Mul` on value variants of `FieldElement`, `ExtendedElement` and `Scalar`.
At the same time gets rid of "Eye of Sauron" (arithmetic that looks like `&(&x + &y) * &z.square()`) expressions. Difference in performance can be compared to master and seems to be in the low _ns_ for operatations on `FieldElement`s however is higher on more complex operations.


This PR isn't ready to be merged until the performance issues are resolved.