### PR TITLE
Add batch inversion and batch Ristretto encoding

### DIFF
--- a/src/field.rs
+++ b/src/field.rs
@@ -178,6 +178,63 @@ impl FieldElement {
         (t19, t3)
     }
 
+    /// Given a slice of public `FieldElements`, replace each with its inverse.
+    ///
+    /// All input `FieldElements` **MUST** be nonzero.
+    ///
+    /// This function is most efficient when the batch size (slice
+    /// length) is a power of 2.
+    pub fn batch_invert(inputs: &mut [FieldElement]) {
+        // First, compute the product of all inputs using a product
+        // tree:
+        //
+        // Inputs: [x_0, x_1, x_2]
+        //
+        // Tree:
+        //
+        //                 x_0*x_1*x_2*1         tree[1]
+        //                   /       \
+        //               x_0*x_1     x_2*1       tree[2,3]
+        //                / \        / \
+        //              x_0  x_1   x_2  1        tree[4,5,6,7]
+        //
+        //  The leaves of the tree are the inputs.  We store the tree in
+        //  an array of length 2*n, similar to a binary heap.
+        //
+        //  To initialize the tree, set every node to 1, then fill in
+        //  the leaf nodes with the input variables.  Finally, set every
+        //  non-leaf node to be the product of its children.
+
+        let n = inputs.len().next_power_of_two();
+        let mut tree = vec![FieldElement::one(); 2*n];
+        tree[n..n+inputs.len()].copy_from_slice(inputs);
+        for i in (1..n).rev() {
+            tree[i] = &tree[2*i] * &tree[2*i+1];
+        }
+
+        // The root of the tree is the product of all inputs, and is
+        // stored at index 1.  Compute its inverse.
+        let allinv = tree[1].invert();
+
+        // To compute y_i = 1/x_i, start at the i-th leaf node of the
+        // tree, and walk up to the root of the tree, multiplying
+        // `allinv` by each sibling.  This computes
+        //
+        // y_i = y * (all x_j except x_i)
+        //
+        // using lg(n) multiplications for each y_i, taking n*lg(n) in
+        // total.
+        for i in 0..inputs.len() {
+            let mut inv = allinv;
+            let mut node = n + i;
+            while node > 1 {
+                inv *= &tree[node ^ 1];
+                node = node >> 1;
+            }
+            inputs[i] = inv;
+        }
+    }
+
     /// Given a nonzero field element, compute its inverse.
     ///
     /// The inverse is computed as self^(p-2), since
@@ -376,6 +433,21 @@ mod test {
     }
 
     #[test]
+    fn batch_invert_a_matches_nonbatched() {
+        let a    = FieldElement::from_bytes(&A_BYTES);
+        let ap58 = FieldElement::from_bytes(&AP58_BYTES);
+        let asq  = FieldElement::from_bytes(&ASQ_BYTES);
+        let ainv = FieldElement::from_bytes(&AINV_BYTES);
+        let a2   = &a + &a;
+        let a_list = vec![a, ap58, asq, ainv, a2];
+        let mut ainv_list = a_list.clone();
+        FieldElement::batch_invert(&mut ainv_list[..]);
+        for i in 0..5 {
+            assert_eq!(a_list[i].invert(), ainv_list[i]);
+        }
+    }
+
+    #[test]
     fn a_p58_vs_ap58_constant() {
         let a    = FieldElement::from_bytes(&A_BYTES);
         let ap58 = FieldElement::from_bytes(&AP58_BYTES);
@@ -469,5 +541,26 @@ mod bench {
     fn fieldelement_a_inv(b: &mut Bencher) {
         let a = FieldElement::from_bytes(&A_BYTES);
         b.iter(|| a.invert());
+    }
+
+    #[bench]
+    fn batch_16_inv(b: &mut Bencher) {
+        let a = FieldElement::from_bytes(&A_BYTES);
+        let mut a_vec = vec![a; 16];
+        b.iter(|| FieldElement::batch_invert(&mut a_vec));
+    }
+
+    #[bench]
+    fn batch_128_inv(b: &mut Bencher) {
+        let a = FieldElement::from_bytes(&A_BYTES);
+        let mut a_vec = vec![a; 128];
+        b.iter(|| FieldElement::batch_invert(&mut a_vec));
+    }
+
+    #[bench]
+    fn batch_1024_inv(b: &mut Bencher) {
+        let a = FieldElement::from_bytes(&A_BYTES);
+        let mut a_vec = vec![a; 1024];
+        b.iter(|| FieldElement::batch_invert(&mut a_vec));
     }
 }

--- a/src/field.rs
+++ b/src/field.rs
@@ -184,6 +184,7 @@ impl FieldElement {
     ///
     /// This function is most efficient when the batch size (slice
     /// length) is a power of 2.
+    #[cfg(any(feature = "alloc", feature = "std"))]
     pub fn batch_invert(inputs: &mut [FieldElement]) {
         // First, compute the product of all inputs using a product
         // tree:

--- a/src/ristretto.rs
+++ b/src/ristretto.rs
@@ -667,6 +667,7 @@ impl RistrettoPoint {
     }
 
     /// Double-and-compress a batch of points.
+    #[cfg(any(feature = "alloc", feature = "std"))]
     pub fn double_and_compress_batch<'a, I>(points: I) -> Vec<CompressedRistretto> 
         where I: IntoIterator<Item = &'a RistrettoPoint>
     {

--- a/src/ristretto.rs
+++ b/src/ristretto.rs
@@ -666,6 +666,86 @@ impl RistrettoPoint {
         CompressedRistretto(s.to_bytes())
     }
 
+    /// Double-and-compress a batch of points.
+    pub fn double_and_compress_batch<'a, I>(points: I) -> Vec<CompressedRistretto> 
+        where I: IntoIterator<Item = &'a RistrettoPoint>
+    {
+        #[derive(Copy, Clone, Debug)]
+        struct BatchCompressState {
+            e: FieldElement,
+            f: FieldElement,
+            g: FieldElement,
+            h: FieldElement,
+            eg: FieldElement,
+            fh: FieldElement,
+        }
+
+        impl BatchCompressState {
+            fn efgh(&self) -> FieldElement {
+                &self.eg * &self.fh
+            }
+        }
+
+        impl<'a> From<&'a RistrettoPoint> for BatchCompressState {
+            fn from(P: &'a RistrettoPoint) -> BatchCompressState {
+                let XX = P.0.X.square();
+                let YY = P.0.Y.square();
+                let ZZ = P.0.Z.square();
+                let dTT = &P.0.T.square() * &constants::EDWARDS_D;
+
+                let e = &P.0.X * &(&P.0.Y + &P.0.Y); // = 2*X*Y
+                let f = &ZZ + &dTT;                  // = Z^2 + d*T^2
+                let g = &YY + &XX;                   // = Y^2 - a*X^2
+                let h = &ZZ - &dTT;                  // = Z^2 - d*T^2
+
+                let eg = &e * &g;
+                let fh = &f * &h;
+
+                BatchCompressState{ e: e, f: f, g: g, h: h, eg: eg, fh: fh }
+            }
+        }
+
+        let states: Vec<BatchCompressState> = points.into_iter().map(|P| BatchCompressState::from(P)).collect();
+
+        let mut invs: Vec<FieldElement> = states.iter().map(|state| state.efgh()).collect();
+
+        FieldElement::batch_invert(&mut invs[..]);
+
+        states.iter().zip(invs.iter()).map(|(state, inv): (&BatchCompressState, &FieldElement)| {
+            let Zinv = &state.eg * &inv;
+            let Tinv = &state.fh * &inv;
+
+            let mut magic = constants::INVSQRT_A_MINUS_D;
+
+            let negcheck1 = (&state.eg * &Zinv).is_negative();
+
+            let mut e = state.e;
+            let mut g = state.g;
+            let mut h = state.h;
+
+            let minus_e = -&e;
+            let f_times_sqrta = &state.f * &constants::SQRT_M1;
+
+            e.conditional_assign(&state.g,       negcheck1);
+            g.conditional_assign(&minus_e,       negcheck1);
+            h.conditional_assign(&f_times_sqrta, negcheck1);
+
+            magic.conditional_assign(&constants::SQRT_M1, negcheck1);
+
+            let negcheck2 = (&(&h * &e) * &Zinv).is_negative();
+
+            g.conditional_negate(negcheck2);
+            
+            let mut s = &(&h - &g) * &(&magic * &(&g * &Tinv));
+
+            let s_is_negative = s.is_negative();
+            s.conditional_negate(s_is_negative);
+
+            CompressedRistretto(s.to_bytes())
+        }).collect()
+    }
+
+
     /// Return the coset self + E[4], for debugging.
     fn coset4(&self) -> [ExtendedPoint; 4] {
         [  self.0
@@ -1217,6 +1297,20 @@ mod test {
     }
 
     #[test]
+    fn double_and_compress_1024_random_points() {
+        let mut rng = OsRng::new().unwrap();
+
+        let points: Vec<RistrettoPoint> = 
+            (0..1024).map(|_| RistrettoPoint::random(&mut rng)).collect();
+
+        let compressed = RistrettoPoint::double_and_compress_batch(&points);
+        
+        for (P, P2_compressed) in points.iter().zip(compressed.iter()) {
+            assert_eq!(*P2_compressed, (P + P).compress());
+        }
+    }
+
+    #[test]
     fn random_is_valid() {
         let mut rng = OsRng::new().unwrap();
         for _ in 0..100 {
@@ -1253,5 +1347,29 @@ mod bench {
         let B = &constants::RISTRETTO_BASEPOINT_TABLE;
         let P = B * &Scalar::random(&mut rng);
         b.iter(|| P.compress());
+    }
+
+    fn double_and_compress_n_random_points(n: usize, b: &mut Bencher) {
+        let mut rng = OsRng::new().unwrap();
+
+        let points: Vec<RistrettoPoint> = 
+            (0..n).map(|_| RistrettoPoint::random(&mut rng)).collect();
+
+        b.iter(|| RistrettoPoint::double_and_compress_batch(&points) );
+    }
+
+    #[bench]
+    fn double_and_compress_16_random_points(b: &mut Bencher) {
+        double_and_compress_n_random_points(16, b);
+    }
+
+    #[bench]
+    fn double_and_compress_128_random_points(b: &mut Bencher) {
+        double_and_compress_n_random_points(128, b);
+    }
+
+    #[bench]
+    fn double_and_compress_1024_random_points(b: &mut Bencher) {
+        double_and_compress_n_random_points(1024, b);
     }
 }


### PR DESCRIPTION
This PR adds a new API to `FieldElement`s for doing batch inversion, and an implementation of the batchable double-and-encode operation for Ristretto. It does not include a write-up of the batchable Ristretto encoding, which will come in a later PR.

Both of these APIs are feature-gated on allocation.