### PR TITLE
Implement public-facing ops traits on all combos of &T/T

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -26,6 +26,11 @@ extern crate serde;
 #[cfg(feature = "yolocrypto")]
 extern crate stdsimd;
 
+// Macros come first!
+#[path="src/macros.rs"]
+#[macro_use]
+mod macros;
+
 // Public modules
 
 #[path="src/scalar.rs"]

--- a/src/edwards.rs
+++ b/src/edwards.rs
@@ -378,11 +378,15 @@ impl<'a, 'b> Add<&'b ExtendedPoint> for &'a ExtendedPoint {
     }
 }
 
+define_add_variants!(LHS = ExtendedPoint, RHS = ExtendedPoint, Output = ExtendedPoint);
+
 impl<'b> AddAssign<&'b ExtendedPoint> for ExtendedPoint {
     fn add_assign(&mut self, _rhs: &'b ExtendedPoint) {
         *self = (self as &ExtendedPoint) + _rhs;
     }
 }
+
+define_add_assign_variants!(LHS = ExtendedPoint, RHS = ExtendedPoint);
 
 impl<'a, 'b> Sub<&'b ExtendedPoint> for &'a ExtendedPoint {
     type Output = ExtendedPoint;
@@ -391,11 +395,15 @@ impl<'a, 'b> Sub<&'b ExtendedPoint> for &'a ExtendedPoint {
     }
 }
 
+define_sub_variants!(LHS = ExtendedPoint, RHS = ExtendedPoint, Output = ExtendedPoint);
+
 impl<'b> SubAssign<&'b ExtendedPoint> for ExtendedPoint {
     fn sub_assign(&mut self, _rhs: &'b ExtendedPoint) {
         *self = (self as &ExtendedPoint) - _rhs;
     }
 }
+
+define_sub_assign_variants!(LHS = ExtendedPoint, RHS = ExtendedPoint);
 
 // ------------------------------------------------------------------------
 // Negation
@@ -414,6 +422,14 @@ impl<'a> Neg for &'a ExtendedPoint {
     }
 }
 
+impl Neg for ExtendedPoint {
+    type Output = ExtendedPoint;
+
+    fn neg(self) -> ExtendedPoint {
+        -&self
+    }
+}
+
 // ------------------------------------------------------------------------
 // Scalar multiplication
 // ------------------------------------------------------------------------
@@ -424,6 +440,11 @@ impl<'b> MulAssign<&'b Scalar> for ExtendedPoint {
         *self = result;
     }
 }
+
+define_mul_assign_variants!(LHS = ExtendedPoint, RHS = Scalar);
+
+define_mul_variants!(LHS = ExtendedPoint, RHS = Scalar, Output = ExtendedPoint);
+define_mul_variants!(LHS = Scalar, RHS = ExtendedPoint, Output = ExtendedPoint);
 
 impl<'a, 'b> Mul<&'b Scalar> for &'a ExtendedPoint {
     type Output = ExtendedPoint;
@@ -478,7 +499,7 @@ impl<'a, 'b> Mul<&'b ExtendedPoint> for &'a Scalar {
     /// For scalar multiplication of a basepoint,
     /// `EdwardsBasepointTable` is approximately 4x faster.
     fn mul(self, point: &'b ExtendedPoint) -> ExtendedPoint {
-        point * &self
+        point * self
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,10 @@ extern crate serde;
 #[cfg(all(test, feature = "serde"))]
 extern crate serde_cbor;
 
+// Internal macros. Must come first!
+#[macro_use]
+pub(crate) mod macros;
+
 //------------------------------------------------------------------------
 // curve25519-dalek public modules
 //------------------------------------------------------------------------

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,123 @@
+// -*- mode: rust; -*-
+//
+// This file is part of curve25519-dalek.
+// Copyright (c) 2016-2017 Isis Lovecruft, Henry de Valence
+// See LICENSE for licensing information.
+//
+// Authors:
+// - Isis Agora Lovecruft <isis@patternsinthevoid.net>
+// - Henry de Valence <hdevalence@hdevalence.ca>
+
+//! Internal macros.
+
+/// Define borrow and non-borrow variants of `Add`.
+macro_rules! define_add_variants {
+    (LHS = $lhs:ty, RHS = $rhs:ty, Output = $out:ty) => {
+        impl<'b> Add<&'b $rhs> for $lhs {
+            type Output = $out;
+            fn add(self, rhs: &'b $rhs) -> $out {
+                &self + rhs
+            }
+        }
+
+        impl<'a> Add<$rhs> for &'a $lhs {
+            type Output = $out;
+            fn add(self, rhs: $rhs) -> $out {
+                self + &rhs
+            }
+        }
+
+        impl Add<$rhs> for $lhs {
+            type Output = $out;
+            fn add(self, rhs: $rhs) -> $out {
+                &self + &rhs
+            }
+        }
+    }
+}
+
+/// Define non-borrow variants of `AddAssign`.
+macro_rules! define_add_assign_variants {
+    (LHS = $lhs:ty, RHS = $rhs:ty) => {
+        impl AddAssign<$rhs> for $lhs {
+            fn add_assign(&mut self, rhs: $rhs) {
+                *self += &rhs;
+            }
+        }
+    }
+}
+
+/// Define borrow and non-borrow variants of `Sub`.
+macro_rules! define_sub_variants {
+    (LHS = $lhs:ty, RHS = $rhs:ty, Output = $out:ty) => {
+        impl<'b> Sub<&'b $rhs> for $lhs {
+            type Output = $out;
+            fn sub(self, rhs: &'b $rhs) -> $out {
+                &self - rhs
+            }
+        }
+
+        impl<'a> Sub<$rhs> for &'a $lhs {
+            type Output = $out;
+            fn sub(self, rhs: $rhs) -> $out {
+                self - &rhs
+            }
+        }
+
+        impl Sub<$rhs> for $lhs {
+            type Output = $out;
+            fn sub(self, rhs: $rhs) -> $out {
+                &self - &rhs
+            }
+        }
+    }
+}
+
+/// Define non-borrow variants of `SubAssign`.
+macro_rules! define_sub_assign_variants {
+    (LHS = $lhs:ty, RHS = $rhs:ty) => {
+        impl SubAssign<$rhs> for $lhs {
+            fn sub_assign(&mut self, rhs: $rhs) {
+                *self -= &rhs;
+            }
+        }
+    }
+}
+
+/// Define borrow and non-borrow variants of `Mul`.
+macro_rules! define_mul_variants {
+    (LHS = $lhs:ty, RHS = $rhs:ty, Output = $out:ty) => {
+        impl<'b> Mul<&'b $rhs> for $lhs {
+            type Output = $out;
+            fn mul(self, rhs: &'b $rhs) -> $out {
+                &self * rhs
+            }
+        }
+
+        impl<'a> Mul<$rhs> for &'a $lhs {
+            type Output = $out;
+            fn mul(self, rhs: $rhs) -> $out {
+                self * &rhs
+            }
+        }
+
+        impl Mul<$rhs> for $lhs {
+            type Output = $out;
+            fn mul(self, rhs: $rhs) -> $out {
+                &self * &rhs
+            }
+        }
+    }
+}
+
+/// Define non-borrow variants of `MulAssign`.
+macro_rules! define_mul_assign_variants {
+    (LHS = $lhs:ty, RHS = $rhs:ty) => {
+        impl MulAssign<$rhs> for $lhs {
+            fn mul_assign(&mut self, rhs: $rhs) {
+                *self *= &rhs;
+            }
+        }
+    }
+}
+

--- a/src/ristretto.rs
+++ b/src/ristretto.rs
@@ -925,11 +925,15 @@ impl<'a, 'b> Add<&'b RistrettoPoint> for &'a RistrettoPoint {
     }
 }
 
+define_add_variants!(LHS = RistrettoPoint, RHS = RistrettoPoint, Output = RistrettoPoint);
+
 impl<'b> AddAssign<&'b RistrettoPoint> for RistrettoPoint {
     fn add_assign(&mut self, _rhs: &RistrettoPoint) {
         *self = (self as &RistrettoPoint) + _rhs;
     }
 }
+
+define_add_assign_variants!(LHS = RistrettoPoint, RHS = RistrettoPoint);
 
 impl<'a, 'b> Sub<&'b RistrettoPoint> for &'a RistrettoPoint {
     type Output = RistrettoPoint;
@@ -939,17 +943,29 @@ impl<'a, 'b> Sub<&'b RistrettoPoint> for &'a RistrettoPoint {
     }
 }
 
+define_sub_variants!(LHS = RistrettoPoint, RHS = RistrettoPoint, Output = RistrettoPoint);
+
 impl<'b> SubAssign<&'b RistrettoPoint> for RistrettoPoint {
     fn sub_assign(&mut self, _rhs: &RistrettoPoint) {
         *self = (self as &RistrettoPoint) - _rhs;
     }
 }
 
+define_sub_assign_variants!(LHS = RistrettoPoint, RHS = RistrettoPoint);
+
 impl<'a> Neg for &'a RistrettoPoint {
     type Output = RistrettoPoint;
 
     fn neg(self) -> RistrettoPoint {
         RistrettoPoint(-&self.0)
+    }
+}
+
+impl Neg for RistrettoPoint {
+    type Output = RistrettoPoint;
+
+    fn neg(self) -> RistrettoPoint {
+        -&self
     }
 }
 
@@ -976,6 +992,12 @@ impl<'a, 'b> Mul<&'b RistrettoPoint> for &'a Scalar {
         RistrettoPoint(self * &point.0)
     }
 }
+
+define_mul_assign_variants!(LHS = RistrettoPoint, RHS = Scalar);
+
+define_mul_variants!(LHS = RistrettoPoint, RHS = Scalar, Output = RistrettoPoint);
+define_mul_variants!(LHS = Scalar, RHS = RistrettoPoint, Output = RistrettoPoint);
+
 
 /// Given a vector of (possibly secret) scalars and a vector of
 /// (possibly secret) points, compute `c_1 P_1 + ... + c_n P_n`.

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -186,6 +186,8 @@ impl<'b> MulAssign<&'b Scalar> for Scalar {
     }
 }
 
+define_mul_assign_variants!(LHS = Scalar, RHS = Scalar);
+
 impl<'a, 'b> Mul<&'b Scalar> for &'a Scalar {
     type Output = Scalar;
     fn mul(self, _rhs: &'b Scalar) -> Scalar {
@@ -193,11 +195,15 @@ impl<'a, 'b> Mul<&'b Scalar> for &'a Scalar {
     }
 }
 
+define_mul_variants!(LHS = Scalar, RHS = Scalar, Output = Scalar);
+
 impl<'b> AddAssign<&'b Scalar> for Scalar {
     fn add_assign(&mut self, _rhs: &'b Scalar) {
         *self = UnpackedScalar::add(&self.unpack(), &_rhs.unpack()).pack();
     }
 }
+
+define_add_assign_variants!(LHS = Scalar, RHS = Scalar);
 
 impl<'a, 'b> Add<&'b Scalar> for &'a Scalar {
     type Output = Scalar;
@@ -206,11 +212,15 @@ impl<'a, 'b> Add<&'b Scalar> for &'a Scalar {
     }
 }
 
+define_add_variants!(LHS = Scalar, RHS = Scalar, Output = Scalar);
+
 impl<'b> SubAssign<&'b Scalar> for Scalar {
     fn sub_assign(&mut self, _rhs: &'b Scalar) {
         *self = UnpackedScalar::sub(&self.unpack(), &_rhs.unpack()).pack();
     }
 }
+
+define_sub_assign_variants!(LHS = Scalar, RHS = Scalar);
 
 impl<'a, 'b> Sub<&'b Scalar> for &'a Scalar {
     type Output = Scalar;
@@ -219,10 +229,19 @@ impl<'a, 'b> Sub<&'b Scalar> for &'a Scalar {
     }
 }
 
+define_sub_variants!(LHS = Scalar, RHS = Scalar, Output = Scalar);
+
 impl<'a> Neg for &'a Scalar {
     type Output = Scalar;
     fn neg(self) -> Scalar {
         &Scalar::zero() - self
+    }
+}
+
+impl<'a> Neg for Scalar {
+    type Output = Scalar;
+    fn neg(self) -> Scalar {
+        -&self
     }
 }
 


### PR DESCRIPTION
The public-facing types with arithmetic operations are:

- `Scalar`s
- `ExtendedPoint`s
- `RistrettoPoint`s

For these types we define operators with all combinations of borrowed and
non-borrowed inputs, to avoid forcing API consumers to write extra ampersands.
Since all of the operations involved with these types are expensive relative to
the cost of an unnecessary copy, this isn't a big deal.

The `MontgomeryPoint` struct isn't included in the above because it's only
useful for scalar multiplication.

This commit is based on work by @UnlawfulMonad, and this PR supersedes #57 (which I think doesn't apply anymore).