### PR TITLE
Fix up Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,8 @@ clear_on_drop = "=0.2.3"
 subtle = { version = "0.5", features = ["generic-impls"], default-features = false }
 stdsimd = { version = "0.0.4", optional = true }
 serde = { version = "1.0", optional = true }
-rand = { version = "0.4", optional = true }
+# Allowing rand to be optional during builds causes a build failure when compiling for no_std targets
+rand = { version = "0.4", optional = false }
 
 [features]
 nightly = ["radix_51", "subtle/nightly", "clear_on_drop/nightly"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,54 +24,33 @@ rustdoc-args = ["--html-in-header", ".cargo/registry/src/github.com-1ecc6299db9e
 [badges]
 travis-ci = { repository = "dalek-cryptography/curve25519-dalek", branch = "master"}
 
-[dependencies.stdsimd]
-version = "0.0.4"
-optional = true
+[dev-dependencies]
+sha2 = "0.7"
+serde_cbor = "0.6"
 
-[dependencies.serde]
-version = "1.0"
-optional = true
+# Note: we generate precomputed tables by building the crate twice: once as
+# part of build.rs, and then once "for real".
+#
+# This means that the [dependencies] and [build-dependencies] sections must
+# match exactly, since the build.rs uses the crate itself as a library.
 
-[dependencies.rand]
-optional = true
-version = "0.4"
-
-[dependencies.digest]
-version = "0.7"
-
-[dependencies.subtle]
-version = "0.5"
-default-features = false
-features = ["generic-impls"]
-
-[dependencies.clear_on_drop]
-version = "=0.2.3"
-
-[dependencies.generic-array]
-# same version that digest depends on
-version = "0.9"
-
-[dev-dependencies.sha2]
-version = "0.7"
-
-[dev-dependencies.serde_cbor]
-version = "0.6"
+[dependencies]
+digest = "0.7"
+generic-array = "0.9"
+clear_on_drop = "=0.2.3"
+subtle = { version = "0.5", features = ["generic-impls"], default-features = false }
+stdsimd = { version = "0.0.4", optional = true }
+serde = { version = "1.0", optional = true }
+rand = { version = "0.4", optional = true }
 
 [build-dependencies]
-subtle = "^0.3"
-rand = "0.4"
-generic-array = "0.9"
 digest = "0.7"
-arrayref = "0.3.4"
+generic-array = "0.9"
 clear_on_drop = "=0.2.3"
-
-[build-dependencies.stdsimd]
-version = "0.0.4"
-optional = true
-
-[build-dependencies.serde]
-version = "1.0"
-optional = true
+subtle = { version = "0.5", features = ["generic-impls"], default-features = false }
+stdsimd = { version = "0.0.4", optional = true }
+serde = { version = "1.0", optional = true }
+rand = { version = "0.4", optional = true }
 
 [features]
 nightly = ["radix_51", "subtle/nightly", "clear_on_drop/nightly"]


### PR DESCRIPTION
Document the weird build hack required for the precomputed tables, and keep all the dependencies together with a note that they can't fall out of sync.