### PR TITLE
Use assets from dalek.rs in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# curve25519-dalek  [![](https://img.shields.io/crates/v/curve25519-dalek.svg)](https://crates.io/crates/curve25519-dalek) [![](https://docs.rs/curve25519-dalek/badge.svg)](https://docs.rs/curve25519-dalek) [![](https://travis-ci.org/dalek-cryptography/curve25519-dalek.svg?branch=master)](https://travis-ci.org/dalek-cryptography/curve25519-dalek)
+# curve25519-dalek  [![](https://img.shields.io/crates/v/curve25519-dalek.svg)](https://crates.io/crates/curve25519-dalek) [![](https://travis-ci.org/dalek-cryptography/curve25519-dalek.svg?branch=master)](https://travis-ci.org/dalek-cryptography/curve25519-dalek)
 
 <img
  width="33%"

--- a/README.md
+++ b/README.md
@@ -118,3 +118,5 @@ contributions.
 [ed25519-dalek]: https://github.com/dalek-cryptography/ed25519-dalek
 [x25519-dalek]: https://github.com/dalek-cryptography/x25519-dalek
 [contributing]: https://github.com/dalek-cryptography/curve25519-dalek/blob/master/CONTRIBUTING.md
+[docs-external]: https://doc.dalek.rs/curve25519_dalek/
+[docs-internal]: https://doc-internal.dalek.rs/curve25519_dalek/

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <img
  width="33%"
  align="right"
- src="https://raw.githubusercontent.com/dalek-cryptography/curve25519-dalek/develop/dalek-logo-clear.png"/>
+ src="https://doc.dalek.rs/assets/dalek-logo-clear.png"/>
 
 **A pure-Rust implementation of group operations on Ristretto and Curve25519.**
 

--- a/rustdoc-include-katex-header.html
+++ b/rustdoc-include-katex-header.html
@@ -1,6 +1,6 @@
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.8.3/katex.min.css" integrity="sha384-B41nY7vEWuDrE9Mr+J2nBL0Liu+nl/rBXTdpQal730oTHdlrlXHzYMOhDU60cwde" crossorigin="anonymous">
-<script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.8.3/katex.min.js" integrity="sha384-L9gv4ooDLrYwW0QCM6zY3EKSSPrsuUncpx26+erN0pJX4wv1B1FzVW1SvpcJPx/8" crossorigin="anonymous"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.8.3/contrib/auto-render.min.js" integrity="sha384-RkgGHBDdR8eyBOoWeZ/vpGg1cOvSAJRflCUDACusAAIVwkwPrOUYykglPeqWakZu" crossorigin="anonymous"></script>
+<link rel="stylesheet" href="https://doc.dalek.rs/assets/katex/katex.min.css">
+<script src="https://doc.dalek.rs/assets/katex/katex.min.js"></script>
+<script src="https://doc.dalek.rs/assets/katex/contrib/auto-render.min.js"></script>
 <script>
 document.addEventListener("DOMContentLoaded", function() { renderMathInElement(document.body); });
 </script>

--- a/src/edwards.rs
+++ b/src/edwards.rs
@@ -68,7 +68,8 @@
 //! The Edwards arithmetic is implemented using the “extended twisted
 //! coordinates” of Hisil, Wong, Carter, and Dawson, and the
 //! corresponding complete formulas.  For more details,
-//! see the `curve_models` submodule of the internal documentation.
+//! see the [`curve_models` submodule][curve_models] 
+//! of the internal documentation.
 //!
 //! ## Validity Checking
 //!
@@ -80,6 +81,8 @@
 //! unrepresentable: `EdwardsPoint` objects can only be created via
 //! successful decompression of a compressed point, or else by
 //! operations on other (valid) `EdwardsPoint`s.
+//!
+//! [curve_models]: https://doc-internal.dalek.rs/curve25519_dalek/curve_models/index.html
 
 // We allow non snake_case names because coordinates in projective space are
 // traditionally denoted by the capitalisation of their respective

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 #![cfg_attr(feature = "nightly", deny(missing_docs))]
 
 #![cfg_attr(feature = "nightly", doc(include = "../README.md"))]
-#![doc(html_logo_url = "https://github.com/dalek-cryptography/curve25519-dalek/blob/develop/dalek-logo-clear.png?raw=true")]
+#![doc(html_logo_url = "https://doc.dalek.rs/assets/dalek-logo-clear.png")]
 
 //------------------------------------------------------------------------
 // External dependencies:

--- a/src/ristretto.rs
+++ b/src/ristretto.rs
@@ -129,7 +129,7 @@
 //! gives the _Ristretto_ encoding.
 //!
 //! Notes on the details of the encoding can be found in the
-//! `ristretto::notes` submodule of the internal `curve25519-dalek`
+//! [`ristretto::notes`][ristretto_notes] submodule of the internal `curve25519-dalek`
 //! documentation.
 //!
 //! [cryptonote]:
@@ -138,6 +138,8 @@
 //! https://moderncrypto.org/mail-archive/curves/2017/000858.html
 //! [ristretto_coffee]:
 //! https://en.wikipedia.org/wiki/Ristretto
+//! [ristretto_notes]:
+//! https://doc-internal.dalek.rs/curve25519_dalek/ristretto/notes/index.html
 
 mod notes {
 


### PR DESCRIPTION
This makes doc.dalek.rs the canonical docs source (vs docs.rs), and replaces the KaTeX files hosted on Cloudflare and the image from githubusercontent with our own hosting.