### PR TITLE
Fix missing avx2 import

### DIFF
--- a/src/backend/avx2/edwards.rs
+++ b/src/backend/avx2/edwards.rs
@@ -13,8 +13,9 @@
 // just going to own it
 #![allow(bad_style)]
 
-use std::convert::From;
-use std::ops::{Index, Add, Sub, Mul, Neg};
+use core::convert::From;
+use core::ops::{Index, Add, Sub, Mul, Neg};
+use core::borrow::Borrow;
 
 use stdsimd::simd::{u32x8, i32x8};
 

--- a/src/backend/avx2/field.rs
+++ b/src/backend/avx2/field.rs
@@ -25,7 +25,7 @@ pub const D_LANES64: u8 = 0b11_00_00_00;
 
 pub const ALL_LANES: u8 = A_LANES | B_LANES | C_LANES | D_LANES;
 
-use std::ops::Mul;
+use core::ops::Mul;
 
 use stdsimd::simd::{u32x8, i32x8, u64x4};
 


### PR DESCRIPTION
A missing import of the Borrow trait caused the build to break with the
"yolocrypto" feature enabled; this was't caught by CI because the CI machine
that Travis used didn't have AVX2, so the code was never built.

This commit adds the missing import and changes `std` to `core` so that the
AVX2 backend builds with no_std, but this isn't tested and is, actually,
"yolocrypto".