### PR TITLE
Add batch scalar inversion

### DIFF
--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -464,6 +464,9 @@ impl Scalar {
             tree[i] = UnpackedScalar::montgomery_mul(&tree[2*i], &tree[2*i+1]);
         }
 
+        // tree[1] is zero iff any of the inputs are zero.
+        debug_assert!(tree[1].from_montgomery().pack() != Scalar::zero());
+
         let allinv = tree[1].montgomery_invert();
 
         for i in 0..inputs.len() {
@@ -976,6 +979,15 @@ mod test {
         let output = serde_cbor::to_vec(&X).unwrap();
         let parsed: Scalar = serde_cbor::from_slice(&output).unwrap();
         assert_eq!(parsed, X);
+    }
+
+    #[test]
+    #[should_panic]
+    fn batch_invert_with_a_zero_input_panics() {
+        let mut xs = vec![Scalar::one(); 16];
+        xs[3] = Scalar::zero();
+        // This should panic in debug mode.
+        Scalar::batch_invert(&mut xs);
     }
 }
 


### PR DESCRIPTION
This PR adds a function for batch `Scalar` inversion. The temporary scalars are erased from the heap in case they're secret.

The `Scalar` code got pretty messy and should be refactored later, but this just minimally adds one function.