### PR TITLE
Implement Product and Sum traits

### DIFF
--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -566,7 +566,7 @@ impl Scalar {
     /// $$
     /// k = \sum\_{i=0}\^m k\_i 2^i,
     /// $$
-    /// and split the sum as  
+    /// and split the sum as
     /// $$
     /// k = \sum\_{i=0}^{w-1} k\_i 2^i + 2^w \sum\_{i=0} k\_{i+w} 2^i
     /// $$
@@ -607,7 +607,7 @@ impl Scalar {
 
         let width = 1 << w;
         let window_mask = width - 1;
-        
+
         let mut pos = 0;
         let mut carry = 0;
         while pos < 256 {


### PR DESCRIPTION
This PR implements the [Product](https://doc.rust-lang.org/std/iter/trait.Product.html) and [Sum](https://doc.rust-lang.org/std/iter/trait.Sum.html) traits for Scalar.

Partially resolves #131 

I made this PR before implement the Sum trait on the other types so that you can comment on my code before trying to implement the other traits. If you would like me completely close issue #131 before making a PR just tell me.