### PR TITLE
Disable default features in byteorder dependency to be no_std-compatible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ harness = false
 # match exactly, since the build.rs uses the crate itself as a library.
 
 [dependencies]
-byteorder = "1"
+byteorder = {version = "1", default-features = false }
 digest = "0.7"
 generic-array = "0.9"
 clear_on_drop = "=0.2.3"


### PR DESCRIPTION
When building with [Rust SGX SDK](https://github.com/baidu/rust-sgx-sdk) `byteorder` was pulling in `std` crate which conflicted with `sgx_tstd`. Disabling default features in `byteorder` prevents this.