### PR TITLE
[WIP] upgrade to rand 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,28 +41,27 @@ harness = false
 # match exactly, since the build.rs uses the crate itself as a library.
 
 [dependencies]
-byteorder = {version = "1", default-features = false }
+rand = { version = "0.5.0-pre.2", default-features = false }
+byteorder = { version = "1", default-features = false }
 digest = "0.7"
 generic-array = "0.9"
 clear_on_drop = "=0.2.3"
 subtle = { version = "0.6", features = ["generic-impls"], default-features = false }
 serde = { version = "1.0", optional = true }
-rand = { version = "0.4", optional = true }
 
 [build-dependencies]
-byteorder = "1"
+rand = { version = "0.5.0-pre.2", default-features = false }
+byteorder = { version = "1", default-features = false }
 digest = "0.7"
 generic-array = "0.9"
 clear_on_drop = "=0.2.3"
 subtle = { version = "0.6", features = ["generic-impls"], default-features = false }
 serde = { version = "1.0", optional = true }
-# Allowing rand to be optional during builds causes a build failure when compiling for no_std targets
-rand = { version = "0.4", optional = false }
 
 [features]
 nightly = ["subtle/nightly", "clear_on_drop/nightly"]
 default = ["std", "u64_backend"]
-std = ["rand", "subtle/std"]
+std = ["subtle/std"]
 alloc = []
 yolocrypto = []
 

--- a/benches/dalek_benchmarks.rs
+++ b/benches/dalek_benchmarks.rs
@@ -1,7 +1,7 @@
 #![allow(non_snake_case)]
 
 extern crate rand;
-use rand::OsRng;
+use rand::rngs::OsRng;
 
 #[macro_use]
 extern crate criterion;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,15 +34,11 @@
 
 #[cfg(feature = "std")]
 extern crate core;
-
-#[cfg(feature = "std")]
-extern crate rand;
-
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
+extern crate rand;
 extern crate clear_on_drop;
-
 extern crate byteorder;
 
 // The `Digest` trait is implemented using `generic_array`, so we need it

--- a/src/montgomery.rs
+++ b/src/montgomery.rs
@@ -284,7 +284,7 @@ mod test {
     use constants;
     use super::*;
 
-    use rand::OsRng;
+    use rand::rngs::OsRng;
 
     /// Test Montgomery -> Edwards on the X/Ed25519 basepoint
     #[test]

--- a/src/ristretto.rs
+++ b/src/ristretto.rs
@@ -172,8 +172,7 @@ use core::ops::{Mul, MulAssign};
 use core::iter::Sum;
 use core::borrow::Borrow;
 
-#[cfg(feature = "std")]
-use rand::Rng;
+use rand::{Rng, CryptoRng};
 
 use digest::Digest;
 use generic_array::typenum::U64;
@@ -406,7 +405,7 @@ impl RistrettoPoint {
     /// # extern crate curve25519_dalek;
     /// # use curve25519_dalek::ristretto::RistrettoPoint;
     /// extern crate rand;
-    /// use rand::OsRng;
+    /// use rand::rngs::OsRng;
     ///
     /// # // Need fn main() here in comment so the doctest compiles
     /// # // See https://doc.rust-lang.org/book/documentation.html#documentation-as-tests
@@ -576,15 +575,14 @@ impl RistrettoPoint {
     /// discrete log of the output point with respect to any other
     /// point should be unknown.  The map is applied twice and the
     /// results are added, to ensure a uniform distribution.
-    #[cfg(feature = "std")]
-    pub fn random<T: Rng>(rng: &mut T) -> Self {
+    pub fn random<T: Rng + CryptoRng>(rng: &mut T) -> Self {
         let mut field_bytes = [0u8; 32];
 
-        rng.fill_bytes(&mut field_bytes);
+        rng.fill(&mut field_bytes);
         let r_1 = FieldElement::from_bytes(&field_bytes);
         let R_1 = RistrettoPoint::elligator_ristretto_flavor(&r_1);
 
-        rng.fill_bytes(&mut field_bytes);
+        rng.fill(&mut field_bytes);
         let r_2 = FieldElement::from_bytes(&field_bytes);
         let R_2 = RistrettoPoint::elligator_ristretto_flavor(&r_2);
 
@@ -1016,7 +1014,7 @@ pub mod vartime {
 
 #[cfg(all(test, feature = "stage2_build"))]
 mod test {
-    use rand::OsRng;
+    use rand::rngs::OsRng;
 
     use scalar::Scalar;
     use constants;

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -22,8 +22,7 @@ use core::cmp::{Eq, PartialEq};
 use core::iter::{Product, Sum};
 use core::borrow::Borrow;
 
-#[cfg(feature = "std")]
-use rand::Rng;
+use rand::{Rng, CryptoRng};
 
 use digest::Digest;
 use generic_array::typenum::U64;
@@ -324,15 +323,15 @@ impl Scalar {
     ///
     /// # Inputs
     ///
-    /// * `rng`: any RNG which implements the `rand::Rng` interface.
+    /// * `rng`: any RNG which implements the `rand::CryptoRng` interface.
     ///
     /// # Returns
     ///
     /// A random scalar within ℤ/lℤ.
     #[cfg(feature = "std")]
-    pub fn random<T: Rng>(rng: &mut T) -> Self {
+    pub fn random<T: Rng + CryptoRng>(rng: &mut T) -> Self {
         let mut scalar_bytes = [0u8; 64];
-        rng.fill_bytes(&mut scalar_bytes);
+        rng.fill(&mut scalar_bytes);
         Scalar::from_bytes_mod_order_wide(&scalar_bytes)
     }
 


### PR DESCRIPTION
This specifies the git repository, because `impl CryptoRng for OsRng` was only
added after the last pre-release (in https://github.com/rust-lang-nursery/rand/pull/414)

Once the 0.5 version of `rand` is released, we can edit this commit to remove
the git dependency, and then merge it.

Closes #132 