### PR TITLE
Rework backend selection logic.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,34 +2,28 @@ language: rust
 
 rust:
   - stable
-  - beta
   - nightly
 
 env:
-  - TEST_COMMAND=test EXTRA_FLAGS='' FEATURES=''
+  # Tests the u32 backend
+  - TEST_COMMAND=test EXTRA_FLAGS='--no-default-features' FEATURES='std u32_backend'
+  # Tests the u64 backend
+  - TEST_COMMAND=test EXTRA_FLAGS='--no-default-features' FEATURES='std u64_backend'
+  # Tests the avx2 backend
+  - TEST_COMMAND=test EXTRA_FLAGS='--no-default-features' FEATURES='std avx2_backend yolocrypto'
+  # Tests serde support and default feature selection
   - TEST_COMMAND=test EXTRA_FLAGS='' FEATURES='serde'
-  - TEST_COMMAND=test EXTRA_FLAGS='' FEATURES='nightly'
-  - TEST_COMMAND=test EXTRA_FLAGS='' FEATURES='yolocrypto nightly'
+  # Tests building without std
   - TEST_COMMAND=build EXTRA_FLAGS=--no-default-features FEATURES='' 
 
 matrix:
   exclude:
-    # Test nightly features, such as radix_51, only on nightly.
+    # Test the avx2 backend only on nightly
     - rust: stable
-      env: TEST_COMMAND=test EXTRA_FLAGS='' FEATURES='nightly'
-    - rust: beta
-      env: TEST_COMMAND=test EXTRA_FLAGS='' FEATURES='nightly'
-    - rust: stable
-      env: TEST_COMMAND=test EXTRA_FLAGS='' FEATURES='yolocrypto nightly'
-    - rust: beta
-      env: TEST_COMMAND=test EXTRA_FLAGS='' FEATURES='yolocrypto nightly'
+      env: TEST_COMMAND=test EXTRA_FLAGS='--no-default-features' FEATURES='std avx2_backend yolocrypto'
     # Test no_std only on nightly.
     - rust: stable
-      env: TEST_COMMAND=build EXTRA_FLAGS=--no-default-features FEATURES=''
-    - rust: beta
-      env: TEST_COMMAND=build EXTRA_FLAGS=--no-default-features FEATURES=''
-    - rust: nightly
-      env: TEST_COMMAND=build EXTRA_FLAGS=--no-default-features FEATURES='alloc'
+      env: TEST_COMMAND=build EXTRA_FLAGS=--no-default-features FEATURES='' 
 
 script:
   - cargo $TEST_COMMAND --features="$FEATURES" $EXTRA_FLAGS

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,15 +60,20 @@ serde = { version = "1.0", optional = true }
 rand = { version = "0.4", optional = false }
 
 [features]
-nightly = ["radix_51", "subtle/nightly", "clear_on_drop/nightly"]
-default = ["std"]
+nightly = ["subtle/nightly", "clear_on_drop/nightly"]
+default = ["std", "u64_backend"]
 std = ["rand", "subtle/std"]
 alloc = []
-yolocrypto = ["avx2_backend"]
-# Radix-51 arithmetic using u128
-radix_51 = []
-# experimental avx2 support
-avx2_backend = ["nightly"]
+yolocrypto = []
+
+# The u32 backend uses u32s with u64 products.
+u32_backend = []
+# The u64 backend uses u64s with u128 products.
+u64_backend = []
+# The AVX2 backend uses u32x8s with u64x4 products.
+# It uses the u64 code for serial operations.
+avx2_backend = ["nightly", "u64_backend"]
+
 # Signals that we're in the main build stage.  This is off by default,
 # to signal stage 1 of the build, where build.rs loads the library
 # into the build script. Then, the build.rs emits the stage2_build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,10 @@ alloc = []
 yolocrypto = ["avx2_backend"]
 # Radix-51 arithmetic using u128
 radix_51 = []
-# Include precomputed basepoint tables.  This is off by default so that build.rs can generate the tables, and then re-enabled by build.rs in the main-stage compilation.
-precomputed_tables = []
 # experimental avx2 support
 avx2_backend = ["nightly"]
+# Signals that we're in the main build stage.  This is off by default,
+# to signal stage 1 of the build, where build.rs loads the library
+# into the build script. Then, the build.rs emits the stage2_build
+# feature before the main-stage compilation.
+stage2_build = []

--- a/README.md
+++ b/README.md
@@ -59,24 +59,37 @@ extern crate curve25519_dalek;
 
 # Backends and Features
 
+The `yolocrypto` feature enables experimental features.  The name `yolocrypto`
+is meant to indicate that it is not considered production-ready, and we do not
+consider `yolocrypto` features to be covered by semver guarantees.
+
+The `std` feature is enabled by default, but it can be disabled.
+
+The `nightly` feature enables nightly-only features.  **It is recommended for security**.
+
 Curve arithmetic is implemented using one of the following backends:
 
 * a `u32` backend using `u64` products;
-* a `u64` backend using `u128` products, available using the `nightly` feature;
+* a `u64` backend using `u128` products;
 * an experimental AVX2 backend, available using the `yolocrypto` feature when
   compiling for a target with `target_feature=+avx2`.
+
+By default the `u64` backend is selected.  To select a specific backend, use:
+```sh
+cargo build --no-default-features --features "std u32_backend"
+cargo build --no-default-features --features "std u64_backend"
+cargo build --no-default-features --features "std avx2_backend yolocrypto"
+```
 
 Benchmarks are run using [`criterion.rs`][criterion]:
 
 ```sh
-cargo bench                                 # u32 backend
-cargo bench --features="nightly"            # u64 backend
-cargo bench --features="nightly yolocrypto" # u64 or avx2 if available
+# You must set RUSTFLAGS to enable AVX2 support.
+export RUSTFLAGS="-C target_cpu=native"
+cargo bench --no-default-features --features "std u32_backend"
+cargo bench --no-default-features --features "std u64_backend"
+cargo bench --no-default-features --features "std avx2_backend yolocrypto"
 ```
-
-The `yolocrypto` feature enables experimental features.  The name `yolocrypto`
-is meant to indicate that it is not considered production-ready, and we do not
-consider `yolocrypto` features to be covered by semver guarantees.
 
 # Contributing
 

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,3 @@
-#![cfg_attr(feature = "nightly", feature(i128_type))]
 #![cfg_attr(feature = "nightly", feature(cfg_target_feature))]
 #![cfg_attr(all(feature = "nightly", feature = "yolocrypto"), feature(stdsimd))]
 #![allow(unused_variables)]
@@ -75,11 +74,11 @@ fn main() {
     f.write_all(
         format!(
             "\n
-#[cfg(feature=\"radix_51\")]
-use backend::u64::field::FieldElement64;
-
-#[cfg(not(feature=\"radix_51\"))]
+#[cfg(feature = \"u32_backend\")]
 use backend::u32::field::FieldElement32;
+
+#[cfg(feature = \"u64_backend\")]
+use backend::u64::field::FieldElement64;
 
 use edwards::EdwardsBasepointTable;
 

--- a/build.rs
+++ b/build.rs
@@ -62,8 +62,8 @@ use curve_models::AffineNielsPoint;
 use scalar_mul::window::NafLookupTable8;
 
 fn main() {
-    // Enable the "precomputed_tables" feature in the main build stage
-    println!("cargo:rustc-cfg=feature=\"precomputed_tables\"\n");
+    // Enable the "stage2_build" feature in the main build stage
+    println!("cargo:rustc-cfg=feature=\"stage2_build\"\n");
 
     let out_dir = env::var("OUT_DIR").unwrap();
     let dest_path = Path::new(&out_dir).join("basepoint_table.rs");

--- a/src/backend/avx2/mod.rs
+++ b/src/backend/avx2/mod.rs
@@ -9,7 +9,9 @@
 // - Henry de Valence <hdevalence@hdevalence.ca>
 
 // See the comment above the ristretto::notes module.
-#![cfg_attr(all(feature = "nightly", feature="precomputed_tables"), doc(include = "../docs/avx2-notes.md"))]
+#![cfg_attr(
+    all(feature = "nightly", feature = "stage2_build"), doc(include = "../docs/avx2-notes.md")
+)]
 
 pub(crate) mod field;
 

--- a/src/backend/avx2/scalar_mul/mod.rs
+++ b/src/backend/avx2/scalar_mul/mod.rs
@@ -10,7 +10,7 @@
 
 pub mod variable_base;
 
-#[cfg(feature="precomputed_tables")]
+#[cfg(feature = "stage2_build")]
 pub mod vartime_double_base;
 
 #[cfg(any(feature = "alloc", feature = "std"))]

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -21,12 +21,12 @@
 //! `32bit` since identifiers can't start with letters, and the backends
 //! do use `u32`/`u64`, so this seems like a least-bad option.
 
-#[cfg(not(feature="radix_51"))]
+#[cfg(feature = "u32_backend")]
 pub mod u32;
 
-#[cfg(feature="radix_51")]
+#[cfg(feature = "u64_backend")]
 pub mod u64;
 
-#[cfg(all(feature="nightly", all(feature="avx2_backend", target_feature="avx2")))]
+#[cfg(all(feature = "avx2_backend", feature = "yolocrypto", target_feature = "avx2"))]
 pub mod avx2;
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -85,14 +85,14 @@ pub const BASEPOINT_ORDER: Scalar = Scalar{
 
 // Precomputed basepoint table is generated into a file by build.rs
 
-#[cfg(feature="precomputed_tables")]
+#[cfg(feature = "stage2_build")]
 include!(concat!(env!("OUT_DIR"), "/basepoint_table.rs"));
 
-#[cfg(feature="precomputed_tables")]
+#[cfg(feature = "stage2_build")]
 use ristretto::RistrettoBasepointTable;
 
 /// The Ristretto basepoint, as a `RistrettoBasepointTable` for scalar multiplication.
-#[cfg(feature="precomputed_tables")]
+#[cfg(feature = "stage2_build")]
 pub const RISTRETTO_BASEPOINT_TABLE: RistrettoBasepointTable
     = RistrettoBasepointTable(ED25519_BASEPOINT_TABLE);
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -33,9 +33,9 @@ use ristretto::CompressedRistretto;
 use montgomery::MontgomeryPoint;
 use scalar::Scalar;
 
-#[cfg(feature="radix_51")]
+#[cfg(feature = "u64_backend")]
 pub use backend::u64::constants::*;
-#[cfg(not(feature="radix_51"))]
+#[cfg(feature = "u32_backend")]
 pub use backend::u32::constants::*;
 
 /// The Ed25519 basepoint, in `CompressedEdwardsY` format.
@@ -149,8 +149,8 @@ mod test {
     }
 
     /// Test that d = -121665/121666
-    #[cfg(not(feature="radix_51"))]
     #[test]
+    #[cfg(feature = "u32_backend")]
     fn test_d_vs_ratio() {
         use backend::u32::field::FieldElement32;
         let a = -&FieldElement32([121665,0,0,0,0,0,0,0,0,0]);
@@ -162,8 +162,8 @@ mod test {
     }
 
     /// Test that d = -121665/121666
-    #[cfg(feature="radix_51")]
     #[test]
+    #[cfg(feature = "u64_backend")]
     fn test_d_vs_ratio() {
         use backend::u64::field::FieldElement64;
         let a = -&FieldElement64([121665,0,0,0,0]);

--- a/src/edwards.rs
+++ b/src/edwards.rs
@@ -490,13 +490,13 @@ impl<'a, 'b> Mul<&'b Scalar> for &'a EdwardsPoint {
     /// `EdwardsBasepointTable` is approximately 4x faster.
     fn mul(self, scalar: &'b Scalar) -> EdwardsPoint {
         // If we built with AVX2, use the AVX2 backend.
-        #[cfg(all(feature="nightly", all(feature="avx2_backend", target_feature="avx2")))]
+        #[cfg(all(feature="avx2_backend", target_feature="avx2"))]
         {
             use backend::avx2::scalar_mul::variable_base::mul;
             mul(self, scalar)
         }
         // Otherwise, use the serial backend:
-        #[cfg(not(all(feature="nightly", all(feature="avx2_backend", target_feature="avx2"))))]
+        #[cfg(not(all(feature="avx2_backend", target_feature="avx2")))]
         {
             use scalar_mul::variable_base::mul;
             mul(self, scalar)
@@ -571,13 +571,13 @@ pub fn multiscalar_mul<I, J>(scalars: I, points: J) -> EdwardsPoint
     // delegate based on the iter's size hint -- hdevalence
 
     // If we built with AVX2, use the AVX2 backend.
-    #[cfg(all(feature="nightly", all(feature="avx2_backend", target_feature="avx2")))]
+    #[cfg(all(feature="avx2_backend", target_feature="avx2"))]
     {
         use backend::avx2::scalar_mul::straus::multiscalar_mul;
         multiscalar_mul(scalars, points)
     }
     // Otherwise, proceed as normal:
-    #[cfg(not(all(feature="nightly", all(feature="avx2_backend", target_feature="avx2"))))]
+    #[cfg(not(all(feature="avx2_backend", target_feature="avx2")))]
     {
         use scalar_mul::straus::multiscalar_mul;
         multiscalar_mul(scalars, points)
@@ -844,13 +844,13 @@ pub mod vartime {
         // XXX later when we do more fancy multiscalar mults, we can delegate
         // based on the iter's size hint -- hdevalence
         // If we built with AVX2, use the AVX2 backend.
-        #[cfg(all(feature="nightly", all(feature="avx2_backend", target_feature="avx2")))]
+        #[cfg(all(feature="avx2_backend", target_feature="avx2"))]
         {
             use backend::avx2::scalar_mul::vartime_straus::multiscalar_mul;
             multiscalar_mul(scalars, points)
         }
         // Otherwise, proceed as normal:
-        #[cfg(not(all(feature="nightly", all(feature="avx2_backend", target_feature="avx2"))))]
+        #[cfg(not(all(feature="avx2_backend", target_feature="avx2")))]
         {
             use scalar_mul::vartime_straus::multiscalar_mul;
             multiscalar_mul(scalars, points)
@@ -861,13 +861,13 @@ pub mod vartime {
     #[cfg(feature="stage2_build")]
     pub fn double_scalar_mul_basepoint(a: &Scalar, A: &EdwardsPoint, b: &Scalar) -> EdwardsPoint {
         // If we built with AVX2, use the AVX2 backend.
-        #[cfg(all(feature="nightly", all(feature="avx2_backend", target_feature="avx2")))]
+        #[cfg(all(feature="avx2_backend", target_feature="avx2"))]
         {
             use backend::avx2::scalar_mul::vartime_double_base::mul;
             mul(a, A, b)
         }
         // Otherwise, proceed as normal:
-        #[cfg(not(all(feature="nightly", all(feature="avx2_backend", target_feature="avx2"))))]
+        #[cfg(not(all(feature="avx2_backend", target_feature="avx2")))]
         {
             use scalar_mul::vartime_double_base::mul;
             mul(a, A, b)
@@ -1169,7 +1169,7 @@ mod test {
     /// and enable `debug_assert!()`.  This performs many scalar
     /// multiplications to attempt to trigger possible overflows etc.
     ///
-    /// For instance, the `radix_51` `Mul` implementation for
+    /// For instance, the `u64` `Mul` implementation for
     /// `FieldElements` requires the input `Limb`s to be bounded by
     /// 2^54, but we cannot enforce this dynamically at runtime, or
     /// statically at compile time (until Rust gets type-level

--- a/src/edwards.rs
+++ b/src/edwards.rs
@@ -858,7 +858,7 @@ pub mod vartime {
     }
 
     /// Compute \\(aA + bB\\) in variable time, where \\(B\\) is the Ed25519 basepoint.
-    #[cfg(feature="precomputed_tables")]
+    #[cfg(feature="stage2_build")]
     pub fn double_scalar_mul_basepoint(a: &Scalar, A: &EdwardsPoint, b: &Scalar) -> EdwardsPoint {
         // If we built with AVX2, use the AVX2 backend.
         #[cfg(all(feature="nightly", all(feature="avx2_backend", target_feature="avx2")))]
@@ -879,7 +879,7 @@ pub mod vartime {
 // Tests
 // ------------------------------------------------------------------------
 
-#[cfg(test)]
+#[cfg(all(test, feature = "stage2_build"))]
 mod test {
     use field::FieldElement;
     use scalar::Scalar;
@@ -971,7 +971,6 @@ mod test {
 
     /// Test that computing 1*basepoint gives the correct basepoint.
     #[test]
-    #[cfg(feature="precomputed_tables")]
     fn basepoint_mult_one_vs_basepoint() {
         let bp = &constants::ED25519_BASEPOINT_TABLE * &Scalar::one();
         let compressed = bp.compress();
@@ -980,7 +979,6 @@ mod test {
 
     /// Test that `EdwardsBasepointTable::basepoint()` gives the correct basepoint.
     #[test]
-    #[cfg(feature="precomputed_tables")]
     fn basepoint_table_basepoint_function_correct() {
         let bp = constants::ED25519_BASEPOINT_TABLE.basepoint();
         assert_eq!(bp.compress(), constants::ED25519_BASEPOINT_COMPRESSED);
@@ -1031,7 +1029,6 @@ mod test {
 
     /// Sanity check for conversion to precomputed points
     #[test]
-    #[cfg(feature="precomputed_tables")]
     fn to_affine_niels_clears_denominators() {
         // construct a point as aB so it has denominators (ie. Z != 1)
         let aB = &constants::ED25519_BASEPOINT_TABLE * &A_SCALAR;
@@ -1043,7 +1040,6 @@ mod test {
 
     /// Test basepoint_mult versus a known scalar multiple from ed25519.py
     #[test]
-    #[cfg(feature="precomputed_tables")]
     fn basepoint_mult_vs_ed25519py() {
         let aB = &constants::ED25519_BASEPOINT_TABLE * &A_SCALAR;
         assert_eq!(aB.compress(), A_TIMES_BASEPOINT);
@@ -1051,7 +1047,6 @@ mod test {
 
     /// Test that multiplication by the basepoint order kills the basepoint
     #[test]
-    #[cfg(feature="precomputed_tables")]
     fn basepoint_mult_by_basepoint_order() {
         let B = &constants::ED25519_BASEPOINT_TABLE;
         let should_be_id = B * &constants::BASEPOINT_ORDER;
@@ -1060,11 +1055,9 @@ mod test {
 
     /// Test precomputed basepoint mult
     #[test]
-    #[cfg(feature="precomputed_tables")]
     fn test_precomputed_basepoint_mult() {
-        let table = EdwardsBasepointTable::create(&constants::ED25519_BASEPOINT_POINT);
         let aB_1 = &constants::ED25519_BASEPOINT_TABLE * &A_SCALAR;
-        let aB_2 = &table * &A_SCALAR;
+        let aB_2 = &constants::ED25519_BASEPOINT_POINT * &A_SCALAR;
         assert_eq!(aB_1.compress(), aB_2.compress());
     }
 
@@ -1084,7 +1077,6 @@ mod test {
 
     /// Test that computing 2*basepoint is the same as basepoint.double()
     #[test]
-    #[cfg(feature="precomputed_tables")]
     fn basepoint_mult_two_vs_basepoint2() {
         let two = Scalar::from_u64(2);
         let bp2 = &constants::ED25519_BASEPOINT_TABLE * &two;
@@ -1210,7 +1202,6 @@ mod test {
 
         /// Test double_scalar_mul_vartime vs ed25519.py
         #[test]
-        #[cfg(feature="precomputed_tables")]
         fn double_scalar_mul_basepoint_vs_ed25519py() {
             let A = A_TIMES_BASEPOINT.decompress().unwrap();
             let result = vartime::double_scalar_mul_basepoint(&A_SCALAR, &A, &B_SCALAR);

--- a/src/field.rs
+++ b/src/field.rs
@@ -32,24 +32,24 @@ use subtle::ConstantTimeEq;
 use constants;
 use backend;
 
-#[cfg(feature="radix_51")]
+#[cfg(feature = "u64_backend")]
 pub use backend::u64::field::*;
 /// A `FieldElement` represents an element of the field
 /// \\( \mathbb Z / (2\^{255} - 19)\\).
 ///
 /// The `FieldElement` type is an alias for one of the platform-specific
 /// implementations.
-#[cfg(feature="radix_51")]
+#[cfg(feature = "u64_backend")]
 pub type FieldElement = backend::u64::field::FieldElement64;
 
-#[cfg(not(feature="radix_51"))]
+#[cfg(feature = "u32_backend")]
 pub use backend::u32::field::*;
 /// A `FieldElement` represents an element of the field
 /// \\( \mathbb Z / (2\^{255} - 19)\\).
 ///
 /// The `FieldElement` type is an alias for one of the platform-specific
 /// implementations.
-#[cfg(not(feature="radix_51"))]
+#[cfg(feature = "u32_backend")]
 pub type FieldElement = backend::u32::field::FieldElement32;
 
 impl Eq for FieldElement {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,6 @@
 
 #![cfg_attr(feature = "alloc", feature(alloc))]
 
-#![cfg_attr(feature = "nightly", feature(i128_type))]
 #![cfg_attr(feature = "nightly", feature(cfg_target_feature))]
 #![cfg_attr(feature = "nightly", feature(external_doc))]
 #![cfg_attr(all(feature = "nightly", feature = "yolocrypto"), feature(stdsimd))]

--- a/src/montgomery.rs
+++ b/src/montgomery.rs
@@ -279,7 +279,7 @@ impl<'a, 'b> Mul<&'b MontgomeryPoint> for &'a Scalar {
 // Tests
 // ------------------------------------------------------------------------
 
-#[cfg(test)]
+#[cfg(all(test, feature = "stage2_build"))]
 mod test {
     use constants;
     use super::*;
@@ -338,7 +338,6 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature="precomputed_tables")]
     fn montgomery_ladder_matches_edwards_scalarmult() {
         let mut csprng: OsRng = OsRng::new().unwrap();
 

--- a/src/ristretto.rs
+++ b/src/ristretto.rs
@@ -161,7 +161,7 @@
 // missing).
 //
 // This hack is also used in the avx2 notes.
-#[cfg_attr(all(feature = "nightly", feature="precomputed_tables"), doc(include = "../docs/ristretto-notes.md"))]
+#[cfg_attr(all(feature = "nightly", feature = "stage2_build"), doc(include = "../docs/ristretto-notes.md"))]
 mod notes {
 }
 
@@ -1014,7 +1014,7 @@ pub mod vartime {
 // Tests
 // ------------------------------------------------------------------------
 
-#[cfg(test)]
+#[cfg(all(test, feature = "stage2_build"))]
 mod test {
     use rand::OsRng;
 
@@ -1152,7 +1152,6 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature="precomputed_tables")]
     fn four_torsion_random() {
         let mut rng = OsRng::new().unwrap();
         let B = &constants::RISTRETTO_BASEPOINT_TABLE;
@@ -1215,7 +1214,6 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature="precomputed_tables")]
     fn random_roundtrip() {
         let mut rng = OsRng::new().unwrap();
         let B = &constants::RISTRETTO_BASEPOINT_TABLE;

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -39,14 +39,14 @@ use constants;
 ///
 /// This is a type alias for one of the scalar types in the `backend`
 /// module.
-#[cfg(feature="radix_51")]
+#[cfg(feature = "u64_backend")]
 type UnpackedScalar = backend::u64::scalar::Scalar64;
 
 /// An `UnpackedScalar` represents an element of the field GF(l), optimized for speed.
 ///
 /// This is a type alias for one of the scalar types in the `backend`
 /// module.
-#[cfg(not(feature="radix_51"))]
+#[cfg(feature = "u32_backend")]
 type UnpackedScalar = backend::u32::scalar::Scalar32;
 
 

--- a/src/scalar_mul/mod.rs
+++ b/src/scalar_mul/mod.rs
@@ -12,7 +12,7 @@ pub mod window;
 
 pub mod variable_base;
 
-#[cfg(feature="precomputed_tables")]
+#[cfg(feature = "stage2_build")]
 pub mod vartime_double_base;
 
 #[cfg(any(feature = "alloc", feature = "std"))]


### PR DESCRIPTION
Each backend can now be selected by an individual feature:

- `u32_backend` for `backend::u32`;
- `u64_backend` for `backend::u64`;
- `avx2_backend` for `backend::avx2`;

The `u64_backend` is selected by default, since most people use X64 and we have
no way to select based on target (see discussion in #126).  However, these
changes mean that it is possible to select the backend explicitly, and if we
had the ability to select target-default features, we could do so easily.

This addresses #126 as best as is possible with current Rust features.