### PR TITLE
Upgrade rand to (non-pre)release version 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ harness = false
 # match exactly, since the build.rs uses the crate itself as a library.
 
 [dependencies]
-rand = { version = "0.5.0-pre.2", default-features = false }
+rand = { version = "0.5.0", default-features = false }
 byteorder = { version = "1", default-features = false }
 digest = "0.7"
 generic-array = "0.9"
@@ -50,7 +50,7 @@ subtle = { version = "0.6", features = ["generic-impls"], default-features = fal
 serde = { version = "1.0", optional = true }
 
 [build-dependencies]
-rand = { version = "0.5.0-pre.2", default-features = false }
+rand = { version = "0.5.0", default-features = false }
 byteorder = { version = "1", default-features = false }
 digest = "0.7"
 generic-array = "0.9"


### PR DESCRIPTION
It was previously using pre-release version 0.5.0-pre.2