### PR TITLE
Allow Options in the VartimeMultiscalarMul trait

### DIFF
--- a/src/edwards.rs
+++ b/src/edwards.rs
@@ -556,12 +556,11 @@ impl MultiscalarMul for EdwardsPoint {
 impl VartimeMultiscalarMul for EdwardsPoint {
     type Point = EdwardsPoint;
     
-    fn vartime_multiscalar_mul<I, J>(scalars: I, points: J) -> EdwardsPoint
+    fn optional_multiscalar_mul<I, J>(scalars: I, points: J) -> Option<EdwardsPoint>
     where
         I: IntoIterator,
         I::Item: Borrow<Scalar>,
-        J: IntoIterator,
-        J::Item: Borrow<EdwardsPoint>,
+        J: IntoIterator<Item = Option<EdwardsPoint>>,
     {
         // XXX later when we do more fancy multiscalar mults, we can
         // delegate based on the iter's size hint -- hdevalence
@@ -570,13 +569,13 @@ impl VartimeMultiscalarMul for EdwardsPoint {
         #[cfg(all(feature="avx2_backend", target_feature="avx2"))]
         {
             use backend::avx2::scalar_mul::straus::Straus;
-            Straus::vartime_multiscalar_mul(scalars, points)
+            Straus::optional_multiscalar_mul(scalars, points)
         }
         // Otherwise, proceed as normal:
         #[cfg(not(all(feature="avx2_backend", target_feature="avx2")))]
         {
             use scalar_mul::straus::Straus;
-            Straus::vartime_multiscalar_mul(scalars, points)
+            Straus::optional_multiscalar_mul(scalars, points)
         }
     }
 }

--- a/src/ristretto.rs
+++ b/src/ristretto.rs
@@ -816,17 +816,16 @@ impl MultiscalarMul for RistrettoPoint {
 impl VartimeMultiscalarMul for RistrettoPoint {
     type Point = RistrettoPoint;
     
-    fn vartime_multiscalar_mul<I, J>(scalars: I, points: J) -> RistrettoPoint
+    fn optional_multiscalar_mul<I, J>(scalars: I, points: J) -> Option<RistrettoPoint>
     where
         I: IntoIterator,
         I::Item: Borrow<Scalar>,
-        J: IntoIterator,
-        J::Item: Borrow<RistrettoPoint>,
+        J: IntoIterator<Item = Option<RistrettoPoint>>,
     {
-        let extended_points = points.into_iter().map(|P| P.borrow().0);
-        RistrettoPoint(
-            EdwardsPoint::vartime_multiscalar_mul(scalars, extended_points)
-        )
+        let extended_points = points.into_iter().map(|opt_P| opt_P.map(|P| P.borrow().0));
+
+        EdwardsPoint::optional_multiscalar_mul(scalars, extended_points)
+            .map(|P| RistrettoPoint(P))
     }
 }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -106,11 +106,12 @@ pub trait VartimeMultiscalarMul {
     /// The type of point being multiplied, e.g., `RistrettoPoint`.
     type Point;
 
-    /// Given an iterator of (possibly secret) scalars and an iterator of
+    /// Given an iterator of public scalars and an iterator of
     /// public points, compute
     /// $$
-    /// Q = c\_1 P\_1 + \cdots + c\_n P\_n.
+    /// Q = c\_1 P\_1 + \cdots + c\_n P\_n,
     /// $$
+    /// using variable-time operations.
     ///
     /// It is an error to call this function with two iterators of different lengths.
     ///
@@ -123,7 +124,7 @@ pub trait VartimeMultiscalarMul {
     ///
     /// ```
     /// use curve25519_dalek::constants;
-    /// use curve25519_dalek::traits::MultiscalarMul;
+    /// use curve25519_dalek::traits::VartimeMultiscalarMul;
     /// use curve25519_dalek::ristretto::RistrettoPoint;
     /// use curve25519_dalek::scalar::Scalar;
     ///
@@ -139,12 +140,12 @@ pub trait VartimeMultiscalarMul {
     ///
     /// // A1 = a*P + b*Q + c*R
     /// let abc = [a,b,c];
-    /// let A1 = RistrettoPoint::multiscalar_mul(&abc, &[P,Q,R]);
+    /// let A1 = RistrettoPoint::vartime_multiscalar_mul(&abc, &[P,Q,R]);
     /// // Note: (&abc).into_iter(): Iterator<Item=&Scalar>
     ///
     /// // A2 = (-a)*P + (-b)*Q + (-c)*R
     /// let minus_abc = abc.iter().map(|x| -x);
-    /// let A2 = RistrettoPoint::multiscalar_mul(minus_abc, &[P,Q,R]);
+    /// let A2 = RistrettoPoint::vartime_multiscalar_mul(minus_abc, &[P,Q,R]);
     /// // Note: minus_abc.into_iter(): Iterator<Item=Scalar>
     ///
     /// assert_eq!(A1.compress(), (-A2).compress());


### PR DESCRIPTION
This changes the primary function for the `VartimeMultiscalarMul` trait
to an `optional_multiscalar_mul` trait that accepts
`Option<Self::Point>` (and returns `None` if any input points are
`None`).

The existing `vartime_multiscalar_mul` is changed to be a wrapper around
this function to avoid code duplication.  This may result in an
extra copy of each input point, but that cost is probably not
significant compared to the cost of the multiscalar multiplication.

The motivation is to allow performing multiscalar multiplications with
inline decompression.  Currently, API consumers have to allocate
temporary buffers for all of their points, decompress into those
buffers, then pass (iterators over) those buffers into the multiscalar
multiplication code, which then creates new buffers for lookup tables.