### PR TITLE
Impl Default for Scalar

### DIFF
--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -426,6 +426,12 @@ where
     }
 }
 
+impl Default for Scalar {
+    fn default() -> Scalar {
+        Scalar::zero()
+    }
+}
+
 impl From<u8> for Scalar {
     fn from(x: u8) -> Scalar {
         let mut s_bytes = [0u8; 32];


### PR DESCRIPTION
This lets us do, e.g.:

```rust
use clear_on_drop::clear::Clear;

#[derive(Default)]
pub struct SecretKey(pub(crate) Scalar);

impl Drop for SecretKey {
    fn drop(&mut self) {
        self.clear();
    }
}
```