### PR TITLE
impl Default for CompressedEdwardsY

### DIFF
--- a/src/edwards.rs
+++ b/src/edwards.rs
@@ -152,6 +152,12 @@ impl Identity for CompressedEdwardsY {
     }
 }
 
+impl Default for CompressedEdwardsY {
+    fn default() -> CompressedEdwardsY {
+        CompressedEdwardsY::identity()
+    }
+}
+
 impl CompressedEdwardsY {
     /// View this `CompressedEdwardsY` as an array of bytes.
     pub fn as_bytes(&self) -> &[u8; 32] {

--- a/src/edwards.rs
+++ b/src/edwards.rs
@@ -143,6 +143,15 @@ impl Debug for CompressedEdwardsY {
     }
 }
 
+impl Identity for CompressedEdwardsY {
+    fn identity() -> CompressedEdwardsY {
+        CompressedEdwardsY([
+            1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ])
+    }
+}
+
 impl CompressedEdwardsY {
     /// View this `CompressedEdwardsY` as an array of bytes.
     pub fn as_bytes(&self) -> &[u8; 32] {


### PR DESCRIPTION
So this is a little weird, but it's nice syntactically because it lets me do:

```rust
use clear_on_drop::clear::Clear;

#[derive(Default)]
pub struct Keypair {
    secret: Scalar,
    public: CompressedEdwardsY,
}
```

I'm not sure about the `Identity` part though, since a compressed point doesn't really have an identity, it only has a byte sequence that when decompressed would equal the identity point for the Edwards model.