### PR TITLE
Fix distribution of curve points for hashing to Ristretto points.

### DIFF
--- a/src/ristretto.rs
+++ b/src/ristretto.rs
@@ -646,7 +646,7 @@ impl RistrettoPoint {
         let R_1 = RistrettoPoint::elligator_ristretto_flavor(&r_1);
 
         let mut r_2_bytes = [0u8; 32];
-        r_2_bytes.copy_from_slice(&output.as_slice()[0..32]);
+        r_2_bytes.copy_from_slice(&output.as_slice()[32..64]);
         let r_2 = FieldElement::from_bytes(&r_2_bytes);
         let R_2 = RistrettoPoint::elligator_ristretto_flavor(&r_2);
 


### PR DESCRIPTION
Pretty sure this was just a typo (based on the signature of the function and the code for `random`), so I skipped opening an issue.

Current code basically just computes the same encoding twice instead of sampling from different domains.