### PR TITLE
Fix unbumped version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ make doc-internal
 To import `curve25519-dalek`, add the following to the dependencies section of
 your project's `Cargo.toml`:
 ```toml
-curve25519-dalek = "^0.18"
+curve25519-dalek = "0.19"
 ```
 Then import the crate as:
 ```rust,no_run


### PR DESCRIPTION
This is too late for the 0.19.0 release (I missed it because I grepped for
"0.18.", and the version in the README doesn't specify a minor version), but it
will now be in line with the other version strings.

When we put out the 1.0.0-pre.0 release we can change both together (our docs
already say we've released it, because we inserted an extra version, oops).