### PR TITLE
Bump byteorder version to avoid breaking on stable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ harness = false
 
 [dependencies]
 rand = { version = "0.5", default-features = false }
-byteorder = { version = "1", default-features = false, features = ["i128"] }
+byteorder = { version = "^1.2.3", default-features = false, features = ["i128"] }
 digest = "0.7"
 generic-array = "0.9"
 clear_on_drop = "=0.2.3"
@@ -52,7 +52,7 @@ packed_simd = { version = "0.1.0", features = ["into_bits"], optional = true }
 
 [build-dependencies]
 rand = { version = "0.5", default-features = false }
-byteorder = { version = "1", default-features = false, features = ["i128"] }
+byteorder = { version = "^1.2.3", default-features = false, features = ["i128"] }
 digest = "0.7"
 generic-array = "0.9"
 clear_on_drop = "=0.2.3"


### PR DESCRIPTION
As pointed out by @ruuda:

> This is more of a problem with `#[feature]` in Rust; once a feature becomes
> stable, having `#[feature]` becomes an error, so it is not easy to depend on a
> feature on nightly, and then have the same code work on stable once the feature
> is stabilized.

The earliest `byteorder` version without a `#[feature]` is `1.2.3`, so we
require any higher version than that one.

Closes #184.
Closes #186.