### PR TITLE
Update to digest 0.8 and sha2 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,6 @@ packed_simd = { version = "0.3.0", features = ["into_bits"], optional = true }
 rand = { version = "0.5", default-features = false }
 byteorder = { version = "^1.2.3", default-features = false, features = ["i128"] }
 digest = { version = "0.8", default-features = false }
-generic-array = "0.9"
 clear_on_drop = "=0.2.3"
 subtle = { version = "1", default-features = false }
 serde = { version = "1.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ features = ["nightly"]
 travis-ci = { repository = "dalek-cryptography/curve25519-dalek", branch = "master"}
 
 [dev-dependencies]
-sha2 = "0.7"
+sha2 = { version = "0.8", default-features = false }
 bincode = "1"
 criterion = "0.2"
 
@@ -43,8 +43,7 @@ harness = false
 [dependencies]
 rand = { version = "0.5", default-features = false }
 byteorder = { version = "^1.2.3", default-features = false, features = ["i128"] }
-digest = "0.7"
-generic-array = "0.9"
+digest = { version = "0.8", default-features = false }
 clear_on_drop = "=0.2.3"
 subtle = { version = "1", default-features = false }
 serde = { version = "1.0", optional = true }
@@ -53,7 +52,7 @@ packed_simd = { version = "0.3.0", features = ["into_bits"], optional = true }
 [build-dependencies]
 rand = { version = "0.5", default-features = false }
 byteorder = { version = "^1.2.3", default-features = false, features = ["i128"] }
-digest = "0.7"
+digest = { version = "0.8", default-features = false }
 generic-array = "0.9"
 clear_on_drop = "=0.2.3"
 subtle = { version = "1", default-features = false }

--- a/build.rs
+++ b/build.rs
@@ -10,7 +10,6 @@ extern crate byteorder;
 extern crate clear_on_drop;
 extern crate core;
 extern crate digest;
-extern crate generic_array;
 extern crate rand;
 extern crate subtle;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,12 +44,7 @@ extern crate packed_simd;
 extern crate rand;
 extern crate clear_on_drop;
 extern crate byteorder;
-
-// The `Digest` trait is implemented using `generic_array`, so we need it
-// too. Hopefully we can eliminate `generic_array` from `Digest` once const
-// generics land.
-extern crate digest;
-extern crate generic_array;
+pub extern crate digest;
 
 // Used for traits related to constant-time code.
 extern crate subtle;

--- a/src/ristretto.rs
+++ b/src/ristretto.rs
@@ -167,7 +167,7 @@ use core::borrow::Borrow;
 use rand::{Rng, CryptoRng};
 
 use digest::Digest;
-use generic_array::typenum::U64;
+use digest::generic_array::typenum::U64;
 
 use constants;
 use field::FieldElement;
@@ -870,7 +870,7 @@ define_mul_variants!(LHS = Scalar, RHS = RistrettoPoint, Output = RistrettoPoint
 #[cfg(feature = "alloc")]
 impl MultiscalarMul for RistrettoPoint {
     type Point = RistrettoPoint;
-    
+
     fn multiscalar_mul<I, J>(scalars: I, points: J) -> RistrettoPoint
     where
         I: IntoIterator,
@@ -888,7 +888,7 @@ impl MultiscalarMul for RistrettoPoint {
 #[cfg(feature = "alloc")]
 impl VartimeMultiscalarMul for RistrettoPoint {
     type Point = RistrettoPoint;
-    
+
     fn optional_multiscalar_mul<I, J>(scalars: I, points: J) -> Option<RistrettoPoint>
     where
         I: IntoIterator,

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -80,10 +80,10 @@
 //! assert!(a == two);
 //! ```
 //!
-//! There is also a constructor that reduces a \\(512\\)-bit integer, 
+//! There is also a constructor that reduces a \\(512\\)-bit integer,
 //! [`Scalar::from_bytes_mod_order_wide`](struct.Scalar.html#method.from_bytes_mod_order_wide).
 //!
-//! To construct a `Scalar` as the hash of some input data, use 
+//! To construct a `Scalar` as the hash of some input data, use
 //! [`Scalar::hash_from_bytes`](struct.Scalar.html#method.hash_from_bytes),
 //! which takes a buffer, or
 //! [`Scalar::from_hash`](struct.Scalar.html#method.from_hash),
@@ -154,7 +154,7 @@ use prelude::*;
 use rand::{Rng, CryptoRng};
 
 use digest::Digest;
-use generic_array::typenum::U64;
+use digest::generic_array::typenum::U64;
 
 use subtle::Choice;
 use subtle::ConditionallyAssignable;
@@ -579,14 +579,13 @@ impl Scalar {
     /// use sha2::Sha512;
     ///
     /// # fn main() {
-    /// let mut h = Sha512::default();
-    ///
-    /// h.input(b"To really appreciate architecture, you may even need to commit a murder.");
-    /// h.input(b"While the programs used for The Manhattan Transcripts are of the most extreme");
-    /// h.input(b"nature, they also parallel the most common formula plot: the archetype of");
-    /// h.input(b"murder. Other phantasms were occasionally used to underline the fact that");
-    /// h.input(b"perhaps all architecture, rather than being about functional standards, is");
-    /// h.input(b"about love and death.");
+    /// let mut h = Sha512::new()
+    ///     .chain("To really appreciate architecture, you may even need to commit a murder.")
+    ///     .chain("While the programs used for The Manhattan Transcripts are of the most extreme")
+    ///     .chain("nature, they also parallel the most common formula plot: the archetype of")
+    ///     .chain("murder. Other phantasms were occasionally used to underline the fact that")
+    ///     .chain("perhaps all architecture, rather than being about functional standards, is")
+    ///     .chain("about love and death.");
     ///
     /// let s = Scalar::from_hash(h);
     ///


### PR DESCRIPTION
Vicariously updates to `generic-array` 0.12, however this change also removes `generic-array` as a direct dependency, as it can be sourced from the `digest` crate.