### PR TITLE
Implement ZeroSafe for Scalar to allow zeroing arrays of packed scalars

### DIFF
--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -251,8 +251,8 @@ impl Scalar {
 }
 
 use clear_on_drop::clear::ZeroSafe;
-// Scalars already implement Default, allowing clearing of individual scalars.
-// But to allow clearing `Vec<Scalar>` or `&[Scalar]` we need to mark Scalars as zeroable
+// `Scalar` already implements `Default`, allowing clearing of individual scalars.
+// But to allow clearing `Vec<Scalar>` or `&[Scalar]` we need to mark `Scalar` as zeroable
 // because ClearOnDrop zeroes the entire array in one call.
 unsafe impl ZeroSafe for Scalar {}
 

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -250,6 +250,12 @@ impl Scalar {
     }
 }
 
+use clear_on_drop::clear::ZeroSafe;
+// Scalars already implement Default, allowing clearing of individual scalars.
+// But to allow clearing `Vec<Scalar>` or `&[Scalar]` we need to mark Scalars as zeroable
+// because ClearOnDrop zeroes the entire array in one call.
+unsafe impl ZeroSafe for Scalar {}
+
 impl Debug for Scalar {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         write!(f, "Scalar{{\n\tbytes: {:?},\n}}", &self.bytes)


### PR DESCRIPTION
`Scalar` already implements `Default`, allowing clearing of individual values. But to allow clearing `Vec<Scalar>` or `&[Scalar]` we need to mark `Scalar` as zeroable because ClearOnDrop zeroes the entire array in one call.
