### PR TITLE
Default & Identity trait for MontgomeryPoint

### DIFF
--- a/src/montgomery.rs
+++ b/src/montgomery.rs
@@ -76,6 +76,18 @@ impl ConstantTimeEq for MontgomeryPoint {
     }
 }
 
+impl Default for MontgomeryPoint {
+    fn default() -> MontgomeryPoint {
+        MontgomeryPoint::identity()
+    }
+}
+
+impl Identity for MontgomeryPoint {
+    fn identity() -> MontgomeryPoint {
+       EdwardsPoint::identity().to_montgomery()
+    }
+}
+
 impl PartialEq for MontgomeryPoint {
     fn eq(&self, other: &MontgomeryPoint) -> bool {
         self.ct_eq(other).unwrap_u8() == 1u8

--- a/src/montgomery.rs
+++ b/src/montgomery.rs
@@ -78,13 +78,7 @@ impl ConstantTimeEq for MontgomeryPoint {
 
 impl Default for MontgomeryPoint {
     fn default() -> MontgomeryPoint {
-        MontgomeryPoint::identity()
-    }
-}
-
-impl Identity for MontgomeryPoint {
-    fn identity() -> MontgomeryPoint {
-       EdwardsPoint::identity().to_montgomery()
+        MontgomeryPoint([0u8; 32])
     }
 }
 


### PR DESCRIPTION
Based on the code snippet referenced in issue #207 I implemented the `Default` & `Identity` trait for `MontgomeryPoint`.

The `Default` trait allows us to zero `MontgomeryPoint` values with `clear` on `drop`. I decided to implement this using the `identity` function.

It appeared to me, based on the code, that `MontgomeryPoint`s do have an identity value.
```rust
    /// Convert this `EdwardsPoint` on the Edwards model to the
    /// corresponding `MontgomeryPoint` on the Montgomery model.
    ///
    /// Note that this is a one-way conversion, since the Montgomery
    /// model does not retain sign information.
    pub fn to_montgomery(&self) -> MontgomeryPoint {
        // We have u = (1+y)/(1-y) = (Z+Y)/(Z-Y).
        //
        // The denominator is zero only when y=1, the identity point of
        // the Edwards curve.  Since 0.invert() = 0, in this case we
        // compute u = 0, the identity point of the Montgomery line.
        let U = &self.Z + &self.Y;
        let W = &self.Z - &self.Y;
        let u = &U * &W.invert();
        MontgomeryPoint(u.to_bytes())
    }
```

For that reason, implementing `Identity` via 
```rust
    fn identity() -> MontgomeryPoint {
       EdwardsPoint::identity().to_montgomery()
    }
```
seemed to be semantically correct.

If there isn't an identity point on a Montgomery line, would making a comment change in `to_montgomery` to indicate that & using `EdwardsPoint::identity().to_montgomery()` as the implementation for `Default` directly instead make sense?

Edit: Based on the comment in the issue for this PR, `MontgomeryPoint` should have a default of `[0u8; 32]` & there shouldn't be an implementation for `Identity` because `MontgomeryPoint` doesn't have an identity.