### PR TITLE
Support passing both borrowed and owned Rngs

### DIFF
--- a/src/ristretto.rs
+++ b/src/ristretto.rs
@@ -621,7 +621,7 @@ impl RistrettoPoint {
     /// discrete log of the output point with respect to any other
     /// point should be unknown.  The map is applied twice and the
     /// results are added, to ensure a uniform distribution.
-    pub fn random<T: Rng + CryptoRng>(rng: &mut T) -> Self {
+    pub fn random<T: Rng + CryptoRng>(mut rng: T) -> Self {
         let mut uniform_bytes = [0u8; 64];
         rng.fill(&mut uniform_bytes);
 


### PR DESCRIPTION
Rng was designed to support both &mut and owned usage like this.

It's slightly odd to do this on a method since Borrow exists for that, but this helps a lot with data types so one may as well use it. 