### PR TITLE
Check the equality of `EdwardsPoint`s in the projective coordinates

### DIFF
--- a/src/edwards.rs
+++ b/src/edwards.rs
@@ -394,7 +394,14 @@ impl ConditionallySelectable for EdwardsPoint {
 
 impl ConstantTimeEq for EdwardsPoint {
     fn ct_eq(&self, other: &EdwardsPoint) -> Choice {
-        self.compress().ct_eq(&other.compress())
+        // We would like to check that the point (X/Z, Y/Z) is equal to
+        // the point (X'/Z', Y'/Z') without converting into affine
+        // coordinates (x, y) and (x', y'), which requires two inversions.
+        // We have that X = xZ and X' = x'Z'. Thus, x = x' is equivalent to
+        // (xZ)Z' = (x'Z')Z, and similarly for the y-coordinate.
+
+        (&self.X * &other.Z).ct_eq(&(&other.X * &self.Z))
+            & (&self.Y * &other.Z).ct_eq(&(&other.Y * &self.Z))
     }
 }
 


### PR DESCRIPTION
I stumbled on this sentence at [ristretto.group](https://ristretto.group/details/equality.html):

> Equality testing of points on the Edwards curve requires comparing to affine coordinates, which requires an expensive inversion. However, testing whether two points lie in the same coset can be done in projective coordinates, making it actually easier than equality testing in the original non-quotient group.

which led me to check the code here and notice this could be optimized. :smiley_cat: 