### PR TITLE
implement Zeroize for Scalar and MontgomeryPoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ clear_on_drop = "=0.2.3"
 subtle = { version = "2.0.0-pre.0", default-features = false }
 serde = { version = "1.0", optional = true }
 packed_simd = { version = "0.3.0", features = ["into_bits"], optional = true }
+zeroize = { version = "0.5.2", default-features = false }
 
 [build-dependencies]
 rand = { version = "0.6.0", default-features = false }
@@ -57,9 +58,10 @@ clear_on_drop = "=0.2.3"
 subtle = { version = "2.0.0-pre.0", default-features = false }
 serde = { version = "1.0", optional = true }
 packed_simd = { version = "0.3.0", features = ["into_bits"], optional = true }
+zeroize = { version = "0.5.2", default-features = false }
 
 [features]
-nightly = ["subtle/nightly", "clear_on_drop/nightly"]
+nightly = ["subtle/nightly", "clear_on_drop/nightly", "zeroize/nightly"]
 default = ["std", "u64_backend"]
 std = ["alloc", "subtle/std", "rand/std"]
 alloc = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ clear_on_drop = "=0.2.3"
 subtle = { version = "2.0.0-pre.0", default-features = false }
 serde = { version = "1.0", optional = true }
 packed_simd = { version = "0.3.0", features = ["into_bits"], optional = true }
-zeroize = { version = "0.5.2", default-features = false }
+zeroize = { version = "0.6.0", default-features = false }
 
 [build-dependencies]
 rand = { version = "0.6.0", default-features = false }
@@ -58,7 +58,7 @@ clear_on_drop = "=0.2.3"
 subtle = { version = "2.0.0-pre.0", default-features = false }
 serde = { version = "1.0", optional = true }
 packed_simd = { version = "0.3.0", features = ["into_bits"], optional = true }
-zeroize = { version = "0.5.2", default-features = false }
+zeroize = { version = "0.6.0", default-features = false, features = ["zeroize_derive"] }
 
 [features]
 nightly = ["subtle/nightly", "clear_on_drop/nightly", "zeroize/nightly"]

--- a/build.rs
+++ b/build.rs
@@ -16,6 +16,8 @@ extern crate subtle;
 #[cfg(all(feature = "nightly", feature = "avx2_backend"))]
 extern crate packed_simd;
 
+extern crate zeroize;
+
 use std::env;
 use std::fs::File;
 use std::io::Write;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,8 @@ extern crate serde;
 #[cfg(all(test, feature = "serde"))]
 extern crate bincode;
 
+extern crate zeroize;
+
 // Internal macros. Must come first!
 #[macro_use]
 pub(crate) mod macros;

--- a/src/montgomery.rs
+++ b/src/montgomery.rs
@@ -17,7 +17,7 @@
 //! Montgomery arithmetic works not on the curve itself, but on the
 //! \\(u\\)-line, which discards sign information and unifies the curve
 //! and its quadratic twist.  See [_Montgomery curves and their
-//! arithmetic_][costello-smith] by Costello and Smith for more details.  
+//! arithmetic_][costello-smith] by Costello and Smith for more details.
 //!
 //! The `MontgomeryPoint` struct contains the affine \\(u\\)-coordinate
 //! \\(u\_0(P)\\) of a point \\(P\\) on either the curve or the twist.
@@ -61,6 +61,8 @@ use subtle::Choice;
 use subtle::ConditionallySelectable;
 use subtle::ConstantTimeEq;
 
+use zeroize::Zeroize;
+
 /// Holds the \\(u\\)-coordinate of a point on the Montgomery form of
 /// Curve25519 or its twist.
 #[derive(Copy, Clone, Debug)]
@@ -89,6 +91,12 @@ impl PartialEq for MontgomeryPoint {
 }
 
 impl Eq for MontgomeryPoint {}
+
+impl Zeroize for MontgomeryPoint {
+    fn zeroize(&mut self) {
+        self.0.zeroize();
+    }
+}
 
 impl MontgomeryPoint {
     /// View this `MontgomeryPoint` as an array of bytes.
@@ -335,7 +343,7 @@ mod test {
     #[test]
     fn montgomery_to_edwards_rejects_twist() {
         let one = FieldElement::one();
-        
+
         // u = 2 corresponds to a point on the twist.
         let two = MontgomeryPoint((&one+&one).to_bytes());
 

--- a/src/montgomery.rs
+++ b/src/montgomery.rs
@@ -65,7 +65,7 @@ use zeroize::Zeroize;
 
 /// Holds the \\(u\\)-coordinate of a point on the Montgomery form of
 /// Curve25519 or its twist.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Zeroize)]
 pub struct MontgomeryPoint(pub [u8; 32]);
 
 /// Equality of `MontgomeryPoint`s is defined mod p.
@@ -91,12 +91,6 @@ impl PartialEq for MontgomeryPoint {
 }
 
 impl Eq for MontgomeryPoint {}
-
-impl Zeroize for MontgomeryPoint {
-    fn zeroize(&mut self) {
-        self.0.zeroize();
-    }
-}
 
 impl MontgomeryPoint {
     /// View this `MontgomeryPoint` as an array of bytes.

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -160,6 +160,8 @@ use subtle::Choice;
 use subtle::ConditionallySelectable;
 use subtle::ConstantTimeEq;
 
+use zeroize::Zeroize;
+
 use backend;
 use constants;
 
@@ -499,6 +501,12 @@ impl From<u128> for Scalar {
         let mut s_bytes = [0u8; 32];
         LittleEndian::write_u128(&mut s_bytes, x);
         Scalar{ bytes: s_bytes }
+    }
+}
+
+impl Zeroize for Scalar {
+    fn zeroize(&mut self) {
+        self.bytes.zeroize();
     }
 }
 

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -182,7 +182,7 @@ type UnpackedScalar = backend::u32::scalar::Scalar32;
 
 /// The `Scalar` struct holds an integer \\(s < 2\^{255} \\) which
 /// represents an element of \\(\mathbb Z / \ell\\).
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Zeroize)]
 pub struct Scalar {
     /// `bytes` is a little-endian byte encoding of an integer representing a scalar modulo the
     /// group order.
@@ -501,12 +501,6 @@ impl From<u128> for Scalar {
         let mut s_bytes = [0u8; 32];
         LittleEndian::write_u128(&mut s_bytes, x);
         Scalar{ bytes: s_bytes }
-    }
-}
-
-impl Zeroize for Scalar {
-    fn zeroize(&mut self) {
-        self.bytes.zeroize();
     }
 }
 


### PR DESCRIPTION
This PR implements the [`Zeroize` trait](https://docs.rs/zeroize/latest/zeroize/trait.Zeroize.html) for `Scalar` 
and `MontgomeryPoint`. This enables `x25519-dalek` to use the 
[`zeroize` crate](https://docs.rs/zeroize/0.5.2/zeroize/) to securely zero the memory of secret
keys. The switch to use `zeroize` would be nice because it
has nicer documentation and platform support. The `nightly`
feature in `zeroize` also provides fast byte array zeroing 
via `volatile_set_memory`.