### PR TITLE
fix typo in torsion documentation

### DIFF
--- a/src/backend/serial/u32/constants.rs
+++ b/src/backend/serial/u32/constants.rs
@@ -88,7 +88,7 @@ pub const ED25519_BASEPOINT_POINT: EdwardsPoint = EdwardsPoint{
 /// the array is \\([i]P\\), where \\(P\\) is a point of order \\(8\\)
 /// generating \\(\mathcal E[8]\\).
 ///
-/// Thus \\(\mathcal E[8]\\) is the points indexed by `0,2,4,6`, and
+/// Thus \\(\mathcal E[4]\\) is the points indexed by `0,2,4,6`, and
 /// \\(\mathcal E[2]\\) is the points indexed by `0,4`.
 /// The Ed25519 basepoint has y = 4/5.  This is called `_POINT` to
 /// distinguish it from `_TABLE`, which should be used for scalar

--- a/src/backend/serial/u64/constants.rs
+++ b/src/backend/serial/u64/constants.rs
@@ -66,7 +66,7 @@ pub const ED25519_BASEPOINT_POINT: EdwardsPoint = EdwardsPoint{
 /// the array is \\([i]P\\), where \\(P\\) is a point of order \\(8\\)
 /// generating \\(\mathcal E[8]\\).
 ///
-/// Thus \\(\mathcal E[8]\\) is the points indexed by `0,2,4,6`, and
+/// Thus \\(\mathcal E[4]\\) is the points indexed by `0,2,4,6`, and
 /// \\(\mathcal E[2]\\) is the points indexed by `0,4`.
 pub const EIGHT_TORSION: [EdwardsPoint; 8] = EIGHT_TORSION_INNER_DOC_HIDDEN;
 


### PR DESCRIPTION
simple fix to the documentation around the torsion subgroup of E.