### PR TITLE
Fix nostd feature with serde enabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ packed_simd = { version = "0.3.0", features = ["into_bits"], optional = true }
 nightly = ["subtle/nightly", "clear_on_drop/nightly"]
 default = ["std", "u64_backend"]
 std = ["subtle/std", "rand_core/std", "serde/std"]
-alloc = ["subtle/std", "rand_core/std", "serde/alloc"]
+alloc = ["subtle/alloc", "rand_core/alloc", "serde/alloc"]
 yolocrypto = []
 
 # The u32 backend uses u32s with u64 products.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ byteorder = { version = "^1.2.3", default-features = false, features = ["i128"] 
 digest = { version = "0.8", default-features = false }
 clear_on_drop = "=0.2.3"
 subtle = { version = "2", default-features = false }
-serde = { version = "1.0", default-features = false, optional = true }
+serde = { version = "1.0", default-features = false }
 packed_simd = { version = "0.3.0", features = ["into_bits"], optional = true }
 
 [build-dependencies]
@@ -58,14 +58,14 @@ byteorder = { version = "^1.2.3", default-features = false, features = ["i128"] 
 digest = { version = "0.8", default-features = false }
 clear_on_drop = "=0.2.3"
 subtle = { version = "2", default-features = false }
-serde = { version = "1.0", default-features = false, optional = true }
+serde = { version = "1.0", default-features = false }
 packed_simd = { version = "0.3.0", features = ["into_bits"], optional = true }
 
 [features]
 nightly = ["subtle/nightly", "clear_on_drop/nightly"]
 default = ["std", "u64_backend"]
-std = ["alloc", "subtle/std", "rand_core/std"]
-alloc = []
+std = ["subtle/std", "rand_core/std", "serde/std"]
+alloc = ["rand_core/alloc", "serde/alloc"]
 yolocrypto = []
 
 # The u32 backend uses u32s with u64 products.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ byteorder = { version = "^1.2.3", default-features = false, features = ["i128"] 
 digest = { version = "0.8", default-features = false }
 clear_on_drop = "=0.2.3"
 subtle = { version = "2", default-features = false }
-serde = { version = "1.0", optional = true }
+serde = { version = "1.0", default-features = false }
 packed_simd = { version = "0.3.0", features = ["into_bits"], optional = true }
 
 [build-dependencies]
@@ -58,14 +58,14 @@ byteorder = { version = "^1.2.3", default-features = false, features = ["i128"] 
 digest = { version = "0.8", default-features = false }
 clear_on_drop = "=0.2.3"
 subtle = { version = "2", default-features = false }
-serde = { version = "1.0", optional = true }
+serde = { version = "1.0", default-features = false }
 packed_simd = { version = "0.3.0", features = ["into_bits"], optional = true }
 
 [features]
 nightly = ["subtle/nightly", "clear_on_drop/nightly"]
 default = ["std", "u64_backend"]
-std = ["alloc", "subtle/std", "rand_core/std"]
-alloc = []
+std = ["alloc", "subtle/std", "rand_core/std", "serde/std"]
+alloc = ["serde/alloc"]
 yolocrypto = []
 
 # The u32 backend uses u32s with u64 products.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ packed_simd = { version = "0.3.0", features = ["into_bits"], optional = true }
 nightly = ["subtle/nightly", "clear_on_drop/nightly"]
 default = ["std", "u64_backend"]
 std = ["subtle/std", "rand_core/std", "serde/std"]
-alloc = ["subtle/alloc", "rand_core/alloc", "serde/alloc"]
+alloc = ["rand_core/alloc", "serde/alloc"]
 yolocrypto = []
 
 # The u32 backend uses u32s with u64 products.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,8 +64,8 @@ packed_simd = { version = "0.3.0", features = ["into_bits"], optional = true }
 [features]
 nightly = ["subtle/nightly", "clear_on_drop/nightly"]
 default = ["std", "u64_backend"]
-std = ["alloc", "subtle/std", "rand_core/std", "serde/std"]
-alloc = ["serde/alloc"]
+std = ["subtle/std", "rand_core/std", "serde/std"]
+alloc = ["subtle/std", "rand_core/std", "serde/alloc"]
 yolocrypto = []
 
 # The u32 backend uses u32s with u64 products.

--- a/src/backend/serial/scalar_mul/mod.rs
+++ b/src/backend/serial/scalar_mul/mod.rs
@@ -21,8 +21,8 @@ pub mod variable_base;
 #[cfg(feature = "stage2_build")]
 pub mod vartime_double_base;
 
-#[cfg(feature = "alloc")]
+#[cfg(any(feature = "alloc", feature = "std"))]
 pub mod straus;
 
-#[cfg(feature = "alloc")]
+#[cfg(any(feature = "alloc", feature = "std"))]
 pub mod precomputed_straus;

--- a/src/backend/vector/scalar_mul/mod.rs
+++ b/src/backend/vector/scalar_mul/mod.rs
@@ -12,8 +12,8 @@ pub mod variable_base;
 
 pub mod vartime_double_base;
 
-#[cfg(feature = "alloc")]
+#[cfg(any(feature = "alloc", feature = "std"))]
 pub mod straus;
 
-#[cfg(feature = "alloc")]
+#[cfg(any(feature = "alloc", feature = "std"))]
 pub mod precomputed_straus;

--- a/src/edwards.rs
+++ b/src/edwards.rs
@@ -614,7 +614,7 @@ impl<'a, 'b> Mul<&'b EdwardsPoint> for &'a Scalar {
 // These use the iterator's size hint and the target settings to
 // forward to a specific backend implementation.
 
-#[cfg(feature = "alloc")]
+#[cfg(any(feature = "alloc", feature = "std"))]
 impl MultiscalarMul for EdwardsPoint {
     type Point = EdwardsPoint;
 
@@ -646,7 +646,7 @@ impl MultiscalarMul for EdwardsPoint {
     }
 }
 
-#[cfg(feature = "alloc")]
+#[cfg(any(feature = "alloc", feature = "std"))]
 impl VartimeMultiscalarMul for EdwardsPoint {
     type Point = EdwardsPoint;
 
@@ -681,10 +681,10 @@ impl VartimeMultiscalarMul for EdwardsPoint {
 // This wraps the inner implementation in a facade type so that we can
 // decouple stability of the inner type from the stability of the
 // outer type.
-#[cfg(feature = "alloc")]
+#[cfg(any(feature = "alloc", feature = "std"))]
 pub struct VartimeEdwardsPrecomputation(scalar_mul::precomputed_straus::VartimePrecomputedStraus);
 
-#[cfg(feature = "alloc")]
+#[cfg(any(feature = "alloc", feature = "std"))]
 impl VartimePrecomputedMultiscalarMul for VartimeEdwardsPrecomputation {
     type Point = EdwardsPoint;
 

--- a/src/field.rs
+++ b/src/field.rs
@@ -135,7 +135,7 @@ impl FieldElement {
     /// Given a slice of public `FieldElements`, replace each with its inverse.
     ///
     /// All input `FieldElements` **MUST** be nonzero.
-    #[cfg(feature = "alloc")]
+    #[cfg(any(feature = "alloc", feature = "std"))]
     pub fn batch_invert(inputs: &mut [FieldElement]) {
         // Montgomery’s Trick and Fast Implementation of Masked AES
         // Genelle, Prouff and Quisquater

--- a/src/ristretto.rs
+++ b/src/ristretto.rs
@@ -494,7 +494,7 @@ impl RistrettoPoint {
     /// }
     /// # }
     /// ```
-    #[cfg(feature = "alloc")]
+    #[cfg(any(feature = "alloc", feature = "std"))]
     pub fn double_and_compress_batch<'a, I>(points: I) -> Vec<CompressedRistretto>
         where I: IntoIterator<Item = &'a RistrettoPoint>
     {
@@ -872,7 +872,7 @@ define_mul_variants!(LHS = Scalar, RHS = RistrettoPoint, Output = RistrettoPoint
 // These use iterator combinators to unwrap the underlying points and
 // forward to the EdwardsPoint implementations.
 
-#[cfg(feature = "alloc")]
+#[cfg(any(feature = "alloc", feature = "std"))]
 impl MultiscalarMul for RistrettoPoint {
     type Point = RistrettoPoint;
 
@@ -890,7 +890,7 @@ impl MultiscalarMul for RistrettoPoint {
     }
 }
 
-#[cfg(feature = "alloc")]
+#[cfg(any(feature = "alloc", feature = "std"))]
 impl VartimeMultiscalarMul for RistrettoPoint {
     type Point = RistrettoPoint;
 
@@ -910,10 +910,10 @@ impl VartimeMultiscalarMul for RistrettoPoint {
 // This wraps the inner implementation in a facade type so that we can
 // decouple stability of the inner type from the stability of the
 // outer type.
-#[cfg(feature = "alloc")]
+#[cfg(any(feature = "alloc", feature = "std"))]
 pub struct VartimeRistrettoPrecomputation(scalar_mul::precomputed_straus::VartimePrecomputedStraus);
 
-#[cfg(feature = "alloc")]
+#[cfg(any(feature = "alloc", feature = "std"))]
 impl VartimePrecomputedMultiscalarMul for VartimeRistrettoPrecomputation {
     type Point = RistrettoPoint;
 

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -729,7 +729,7 @@ impl Scalar {
     /// assert_eq!(scalars[3], Scalar::from(11u64).invert());
     /// # }
     /// ```
-    #[cfg(feature = "alloc")]
+    #[cfg(any(feature = "alloc", feature = "std"))]
     pub fn batch_invert(inputs: &mut [Scalar]) -> Scalar {
         // This code is essentially identical to the FieldElement
         // implementation, and is documented there.  Unfortunately,


### PR DESCRIPTION
This library was previously only nostd compliant when serde was not enabled.  To fix this, serde is no longer an optional dependency, but it is properly handled in both std and alloc modes.
This required handling std and alloc modes separately; previously std mode included alloc.  To separate these modes, it was necessary to expand a number of config checks for alloc mode to also include std.
