### PR TITLE
Make rand_core an optional dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ harness = false
 # match exactly, since the build.rs uses the crate itself as a library.
 
 [dependencies]
-rand_core = { version = "0.3.0", default-features = false }
+rand_core = { version = "0.3.0", default-features = false, optional = true }
 byteorder = { version = "^1.2.3", default-features = false, features = ["i128"] }
 digest = { version = "0.8", default-features = false }
 clear_on_drop = "=0.2.3"
@@ -53,7 +53,7 @@ serde = { version = "1.0", optional = true }
 packed_simd = { version = "0.3.0", features = ["into_bits"], optional = true }
 
 [build-dependencies]
-rand_core = { version = "0.3.0", default-features = false }
+rand_core = { version = "0.3.0", default-features = false, optional = true }
 byteorder = { version = "^1.2.3", default-features = false, features = ["i128"] }
 digest = { version = "0.8", default-features = false }
 clear_on_drop = "=0.2.3"

--- a/build.rs
+++ b/build.rs
@@ -18,6 +18,7 @@ extern crate byteorder;
 extern crate clear_on_drop;
 extern crate core;
 extern crate digest;
+#[cfg(feature = "rand_core")]
 extern crate rand_core;
 extern crate subtle;
 

--- a/src/edwards.rs
+++ b/src/edwards.rs
@@ -1244,6 +1244,7 @@ mod test {
         assert!(P1.compress().to_bytes() == P2.compress().to_bytes());
     }
 
+    #[cfg(feature = "rand_core")]
     #[test]
     fn vartime_precomputed_vs_nonprecomputed_multiscalar() {
         let mut rng = rand::thread_rng();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@ extern crate packed_simd;
 extern crate byteorder;
 extern crate clear_on_drop;
 pub extern crate digest;
+#[cfg(feature = "rand_core")]
 extern crate rand_core;
 #[cfg(all(test, feature = "stage2_build"))]
 extern crate rand_os;

--- a/src/ristretto.rs
+++ b/src/ristretto.rs
@@ -164,6 +164,7 @@ use core::ops::{Add, Neg, Sub};
 use core::ops::{AddAssign, SubAssign};
 use core::ops::{Mul, MulAssign};
 
+#[cfg(feature = "rand_core")]
 use rand_core::{CryptoRng, RngCore};
 
 use digest::generic_array::typenum::U64;
@@ -638,6 +639,7 @@ impl RistrettoPoint {
     /// discrete log of the output point with respect to any other
     /// point should be unknown.  The map is applied twice and the
     /// results are added, to ensure a uniform distribution.
+    #[cfg(feature = "rand_core")]
     pub fn random<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
         let mut uniform_bytes = [0u8; 64];
         rng.fill_bytes(&mut uniform_bytes);
@@ -1320,6 +1322,7 @@ mod test {
         }
     }
 
+    #[cfg(feature = "rand_core")]
     #[test]
     fn vartime_precomputed_vs_nonprecomputed_multiscalar() {
         let mut rng = rand::thread_rng();

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -151,6 +151,7 @@ use core::ops::{Sub, SubAssign};
 #[allow(unused_imports)]
 use prelude::*;
 
+#[cfg(feature = "rand_core")]
 use rand_core::{CryptoRng, RngCore};
 
 use digest::generic_array::typenum::U64;
@@ -527,6 +528,7 @@ impl Scalar {
     /// let mut csprng: OsRng = OsRng::new().unwrap();
     /// let a: Scalar = Scalar::random(&mut csprng);
     /// # }
+    #[cfg(feature = "rand_core")]
     pub fn random<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
         let mut scalar_bytes = [0u8; 64];
         rng.fill_bytes(&mut scalar_bytes);


### PR DESCRIPTION
Currently it's confusing to build curve25519-dalek on `no_std` targets due to the following Cargo bug:

https://github.com/rust-lang/cargo/issues/4866

If the `rand_core/std` feature is activated by any of the `build-dependencies` or `dev-dependencies` of the crate attempting to include `curve25519-dalek` (even vicariously through`ed25519-dalek`) then `no_std` builds will fail to link as `rand_core` will link `std`.

Making `rand_core` an optional dependency improves the ergonomics for `no_std` users by eliminating one of the two problematic crates which `curve25519-dalek` has hard dependencies on (the other is `byteorder`).