### PR TITLE
Turn off default serde features but keep it as an optional dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ byteorder = { version = "^1.2.3", default-features = false, features = ["i128"] 
 digest = { version = "0.8", default-features = false }
 clear_on_drop = "=0.2.3"
 subtle = { version = "2", default-features = false }
-serde = { version = "1.0", optional = true }
+serde = { version = "1.0", default-features = false, optional = true }
 packed_simd = { version = "0.3.0", features = ["into_bits"], optional = true }
 
 [build-dependencies]
@@ -58,7 +58,7 @@ byteorder = { version = "^1.2.3", default-features = false, features = ["i128"] 
 digest = { version = "0.8", default-features = false }
 clear_on_drop = "=0.2.3"
 subtle = { version = "2", default-features = false }
-serde = { version = "1.0", optional = true }
+serde = { version = "1.0", default-features = false, optional = true }
 packed_simd = { version = "0.3.0", features = ["into_bits"], optional = true }
 
 [features]


### PR DESCRIPTION
This is an updated version of #247 with a much more minimal change; it simply turns off default features for the serde dependency.  This was suggested by @tarcieri in #247.  

I had initially tried this, but the lack of no_std support in merlin made it look like it was not sufficient.  With updated merlin in place, it works perfectly in my no_std environment.
