### PR TITLE
Hello Rust 2018 + Zeroize Flag For simple support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ exclude = [
     ".travis.yml",
 ]
 build = "build.rs"
+edition = "2018"
 
 [package.metadata.docs.rs]
 # Disabled for now since this is borked; tracking https://github.com/rust-lang/docs.rs/issues/302
@@ -51,6 +52,8 @@ clear_on_drop = "=0.2.3"
 subtle = { version = "2", default-features = false }
 serde = { version = "1.0", default-features = false, optional = true }
 packed_simd = { version = "0.3.0", features = ["into_bits"], optional = true }
+zeroize = "0.9.1"
+
 
 [build-dependencies]
 rand_core = { version = "0.3.0", default-features = false }
@@ -60,6 +63,8 @@ clear_on_drop = "=0.2.3"
 subtle = { version = "2", default-features = false }
 serde = { version = "1.0", default-features = false, optional = true }
 packed_simd = { version = "0.3.0", features = ["into_bits"], optional = true }
+zeroize = { version = "0.9.1", optional = true }
+
 
 [features]
 nightly = ["subtle/nightly", "clear_on_drop/nightly"]
@@ -67,6 +72,9 @@ default = ["std", "u64_backend"]
 std = ["alloc", "subtle/std", "rand_core/std"]
 alloc = []
 yolocrypto = []
+
+# Clear Types
+zeromem = ["zeroize"]
 
 # The u32 backend uses u32s with u64 products.
 u32_backend = []

--- a/build.rs
+++ b/build.rs
@@ -68,7 +68,7 @@ mod prelude;
 #[path = "src/window.rs"]
 mod window;
 
-use edwards::EdwardsBasepointTable;
+use crate::edwards::EdwardsBasepointTable;
 
 fn main() {
     // Enable the "stage2_build" feature in the main build stage
@@ -85,16 +85,16 @@ fn main() {
         format!(
             "\n
 #[cfg(feature = \"u32_backend\")]
-use backend::serial::u32::field::FieldElement2625;
+use crate::backend::serial::u32::field::FieldElement2625;
 
 #[cfg(feature = \"u64_backend\")]
-use backend::serial::u64::field::FieldElement51;
+use crate::backend::serial::u64::field::FieldElement51;
 
-use edwards::EdwardsBasepointTable;
+use crate::edwards::EdwardsBasepointTable;
 
-use backend::serial::curve_models::AffineNielsPoint;
+use crate::backend::serial::curve_models::AffineNielsPoint;
 
-use window::LookupTable;
+use crate::window::LookupTable;
 
 /// Table containing precomputed multiples of the Ed25519 basepoint \\\\(B = (x, 4/5)\\\\).
 pub const ED25519_BASEPOINT_TABLE: EdwardsBasepointTable = ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN;
@@ -116,16 +116,16 @@ pub const ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = {:?}
         any(target_feature = "avx2", target_feature = "avx512ifma")
     )))]
     {
-        use backend::serial::curve_models::AffineNielsPoint;
-        use window::NafLookupTable8;
+        use crate::backend::serial::curve_models::AffineNielsPoint;
+        use crate::window::NafLookupTable8;
 
-        let B = &constants::ED25519_BASEPOINT_POINT;
+        let B = &crate::constants::ED25519_BASEPOINT_POINT;
         let odd_multiples = NafLookupTable8::<AffineNielsPoint>::from(B);
 
         f.write_all(
             format!(
                 "\n
-use window::NafLookupTable8;
+use crate::window::NafLookupTable8;
 /// Odd multiples of the basepoint `[B, 3B, 5B, 7B, 9B, 11B, 13B, 15B, ..., 127B]`.
 pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsPoint> = {:?};
 \n\n",

--- a/src/backend/serial/curve_models/mod.rs
+++ b/src/backend/serial/curve_models/mod.rs
@@ -128,11 +128,11 @@ use core::ops::{Add, Neg, Sub};
 use subtle::Choice;
 use subtle::ConditionallySelectable;
 
-use constants;
+use crate::constants;
 
-use edwards::EdwardsPoint;
-use field::FieldElement;
-use traits::ValidityCheck;
+use crate::edwards::EdwardsPoint;
+use crate::field::FieldElement;
+use crate::traits::ValidityCheck;
 
 // ------------------------------------------------------------------------
 // Internal point representations
@@ -199,7 +199,7 @@ pub struct ProjectiveNielsPoint {
 // Constructors
 // ------------------------------------------------------------------------
 
-use traits::Identity;
+use crate::traits::Identity;
 
 impl Identity for ProjectivePoint {
     fn identity() -> ProjectivePoint {

--- a/src/backend/serial/scalar_mul/pippenger.rs
+++ b/src/backend/serial/scalar_mul/pippenger.rs
@@ -13,12 +13,12 @@
 
 use core::borrow::Borrow;
 
-use edwards::EdwardsPoint;
-use scalar::Scalar;
-use traits::VartimeMultiscalarMul;
+use crate::edwards::EdwardsPoint;
+use crate::scalar::Scalar;
+use crate::traits::VartimeMultiscalarMul;
 
 #[allow(unused_imports)]
-use prelude::*;
+use crate::prelude::*;
 
 /// Implements a version of Pippenger's algorithm.
 ///
@@ -71,7 +71,7 @@ impl VartimeMultiscalarMul for Pippenger {
         I::Item: Borrow<Scalar>,
         J: IntoIterator<Item = Option<EdwardsPoint>>,
     {
-        use traits::Identity;
+        use crate::traits::Identity;
 
         let mut scalars = scalars.into_iter();
         let size = scalars.by_ref().size_hint().0;
@@ -168,8 +168,8 @@ impl VartimeMultiscalarMul for Pippenger {
 #[cfg(test)]
 mod test {
     use super::*;
-    use constants;
-    use scalar::Scalar;
+    use crate::constants;
+    use crate::scalar::Scalar;
 
     #[test]
     fn test_vartime_pippenger() {

--- a/src/backend/serial/scalar_mul/precomputed_straus.rs
+++ b/src/backend/serial/scalar_mul/precomputed_straus.rs
@@ -13,17 +13,17 @@
 
 use core::borrow::Borrow;
 
-use backend::serial::curve_models::{
+use crate::backend::serial::curve_models::{
     AffineNielsPoint, CompletedPoint, ProjectiveNielsPoint, ProjectivePoint,
 };
-use edwards::EdwardsPoint;
-use scalar::Scalar;
-use traits::Identity;
-use traits::VartimePrecomputedMultiscalarMul;
-use window::{NafLookupTable5, NafLookupTable8};
+use crate::edwards::EdwardsPoint;
+use crate::scalar::Scalar;
+use crate::traits::Identity;
+use crate::traits::VartimePrecomputedMultiscalarMul;
+use crate::window::{NafLookupTable5, NafLookupTable8};
 
 #[allow(unused_imports)]
-use prelude::*;
+use crate::prelude::*;
 
 pub struct VartimePrecomputedStraus {
     static_lookup_tables: Vec<NafLookupTable8<AffineNielsPoint>>,

--- a/src/backend/serial/scalar_mul/straus.rs
+++ b/src/backend/serial/scalar_mul/straus.rs
@@ -14,13 +14,13 @@
 
 use core::borrow::Borrow;
 
-use edwards::EdwardsPoint;
-use scalar::Scalar;
-use traits::MultiscalarMul;
-use traits::VartimeMultiscalarMul;
+use crate::edwards::EdwardsPoint;
+use crate::scalar::Scalar;
+use crate::traits::MultiscalarMul;
+use crate::traits::VartimeMultiscalarMul;
 
 #[allow(unused_imports)]
-use prelude::*;
+use crate::prelude::*;
 
 /// Perform multiscalar multiplication by the interleaved window
 /// method, also known as Straus' method (since it was apparently
@@ -108,9 +108,9 @@ impl MultiscalarMul for Straus {
     {
         use clear_on_drop::ClearOnDrop;
 
-        use backend::serial::curve_models::ProjectiveNielsPoint;
-        use window::LookupTable;
-        use traits::Identity;
+        use crate::backend::serial::curve_models::ProjectiveNielsPoint;
+        use crate::window::LookupTable;
+        use crate::traits::Identity;
 
         let lookup_tables: Vec<_> = points
             .into_iter()
@@ -159,9 +159,9 @@ impl VartimeMultiscalarMul for Straus {
         I::Item: Borrow<Scalar>,
         J: IntoIterator<Item = Option<EdwardsPoint>>,
     {
-        use backend::serial::curve_models::{CompletedPoint, ProjectiveNielsPoint, ProjectivePoint};
-        use window::NafLookupTable5;
-        use traits::Identity;
+        use crate::backend::serial::curve_models::{CompletedPoint, ProjectiveNielsPoint, ProjectivePoint};
+        use crate::window::NafLookupTable5;
+        use crate::traits::Identity;
 
         let nafs: Vec<_> = scalars
             .into_iter()

--- a/src/backend/serial/scalar_mul/variable_base.rs
+++ b/src/backend/serial/scalar_mul/variable_base.rs
@@ -1,10 +1,10 @@
 #![allow(non_snake_case)]
 
-use traits::Identity;
-use scalar::Scalar;
-use edwards::EdwardsPoint;
-use backend::serial::curve_models::{ProjectiveNielsPoint, ProjectivePoint};
-use window::LookupTable;
+use crate::traits::Identity;
+use crate::scalar::Scalar;
+use crate::edwards::EdwardsPoint;
+use crate::backend::serial::curve_models::{ProjectiveNielsPoint, ProjectivePoint};
+use crate::window::LookupTable;
 
 /// Perform constant-time, variable-base scalar multiplication.
 pub(crate) fn mul(point: &EdwardsPoint, scalar: &Scalar) -> EdwardsPoint {

--- a/src/backend/serial/scalar_mul/vartime_double_base.rs
+++ b/src/backend/serial/scalar_mul/vartime_double_base.rs
@@ -9,12 +9,12 @@
 // - Henry de Valence <hdevalence@hdevalence.ca>
 #![allow(non_snake_case)]
 
-use constants;
-use traits::Identity;
-use scalar::Scalar;
-use edwards::EdwardsPoint;
-use backend::serial::curve_models::{ProjectiveNielsPoint, ProjectivePoint};
-use window::NafLookupTable5;
+use crate::constants;
+use crate::traits::Identity;
+use crate::scalar::Scalar;
+use crate::edwards::EdwardsPoint;
+use crate::backend::serial::curve_models::{ProjectiveNielsPoint, ProjectivePoint};
+use crate::window::NafLookupTable5;
 
 /// Compute \\(aA + bB\\) in variable time, where \\(B\\) is the Ed25519 basepoint.
 pub fn mul(a: &Scalar, A: &EdwardsPoint, b: &Scalar) -> EdwardsPoint {

--- a/src/backend/serial/u32/constants.rs
+++ b/src/backend/serial/u32/constants.rs
@@ -12,9 +12,9 @@
 //! and useful field elements like `sqrt(-1)`), as well as
 //! lookup tables of pre-computed points.
 
-use backend::serial::u32::field::FieldElement2625;
-use backend::serial::u32::scalar::Scalar29;
-use edwards::EdwardsPoint;
+use crate::backend::serial::u32::field::FieldElement2625;
+use crate::backend::serial::u32::scalar::Scalar29;
+use crate::edwards::EdwardsPoint;
 
 /// Edwards `d` value, equal to `-121665/121666 mod p`.
 pub(crate) const EDWARDS_D: FieldElement2625       = FieldElement2625([

--- a/src/backend/serial/u32/scalar.rs
+++ b/src/backend/serial/u32/scalar.rs
@@ -13,7 +13,7 @@
 use core::fmt::Debug;
 use core::ops::{Index, IndexMut};
 
-use constants;
+use crate::constants;
 
 /// The `Scalar29` struct represents an element in ℤ/lℤ as 9 29-bit limbs
 #[derive(Copy,Clone)]

--- a/src/backend/serial/u64/constants.rs
+++ b/src/backend/serial/u64/constants.rs
@@ -10,9 +10,9 @@
 
 //! This module contains backend-specific constant values, such as the 64-bit limbs of curve constants.
 
-use backend::serial::u64::field::FieldElement51;
-use backend::serial::u64::scalar::Scalar52;
-use edwards::EdwardsPoint;
+use crate::backend::serial::u64::field::FieldElement51;
+use crate::backend::serial::u64::scalar::Scalar52;
+use crate::edwards::EdwardsPoint;
 
 /// Edwards `d` value, equal to `-121665/121666 mod p`.
 pub(crate) const EDWARDS_D: FieldElement51 = FieldElement51([929955233495203, 466365720129213, 1662059464998953, 2033849074728123, 1442794654840575]);

--- a/src/backend/serial/u64/scalar.rs
+++ b/src/backend/serial/u64/scalar.rs
@@ -14,7 +14,7 @@
 use core::fmt::Debug;
 use core::ops::{Index, IndexMut};
 
-use constants;
+use crate::constants;
 
 /// The `Scalar52` struct represents an element in
 /// \\(\mathbb Z / \ell \mathbb Z\\) as 5 \\(52\\)-bit limbs.

--- a/src/backend/vector/avx2/constants.rs
+++ b/src/backend/vector/avx2/constants.rs
@@ -12,9 +12,9 @@
 
 use packed_simd::u32x8;
 
-use backend::vector::avx2::edwards::{CachedPoint, ExtendedPoint};
-use backend::vector::avx2::field::FieldElement2625x4;
-use window::NafLookupTable8;
+use crate::backend::vector::avx2::edwards::{CachedPoint, ExtendedPoint};
+use crate::backend::vector::avx2::field::FieldElement2625x4;
+use crate::window::NafLookupTable8;
 
 /// The identity element as an `ExtendedPoint`.
 pub(crate) static EXTENDEDPOINT_IDENTITY: ExtendedPoint = ExtendedPoint(FieldElement2625x4([

--- a/src/backend/vector/avx2/edwards.rs
+++ b/src/backend/vector/avx2/edwards.rs
@@ -40,10 +40,10 @@ use core::ops::{Add, Neg, Sub};
 use subtle::Choice;
 use subtle::ConditionallySelectable;
 
-use edwards;
-use window::{LookupTable, NafLookupTable5, NafLookupTable8};
+use crate::edwards;
+use crate::window::{LookupTable, NafLookupTable5, NafLookupTable8};
 
-use traits::Identity;
+use crate::traits::Identity;
 
 use super::constants;
 use super::field::{FieldElement2625x4, Lanes, Shuffle};
@@ -329,7 +329,7 @@ mod test {
     use super::*;
 
     fn serial_add(P: edwards::EdwardsPoint, Q: edwards::EdwardsPoint) -> edwards::EdwardsPoint {
-        use backend::serial::u64::field::FieldElement51;
+        use crate::backend::serial::u64::field::FieldElement51;
 
         let (X1, Y1, Z1, T1) = (P.X, P.Y, P.Z, P.T);
         let (X2, Y2, Z2, T2) = (Q.X, Q.Y, Q.Z, Q.T);

--- a/src/backend/vector/avx2/field.rs
+++ b/src/backend/vector/avx2/field.rs
@@ -42,8 +42,8 @@ const D_LANES64: u8 = 0b11_00_00_00;
 use core::ops::{Add, Mul, Neg};
 use packed_simd::{i32x8, u32x8, u64x4, IntoBits};
 
-use backend::vector::avx2::constants::{P_TIMES_16_HI, P_TIMES_16_LO, P_TIMES_2_HI, P_TIMES_2_LO};
-use backend::serial::u64::field::FieldElement51;
+use crate::backend::vector::avx2::constants::{P_TIMES_16_HI, P_TIMES_16_LO, P_TIMES_2_HI, P_TIMES_2_LO};
+use crate::backend::serial::u64::field::FieldElement51;
 
 /// Unpack 32-bit lanes into 64-bit lanes:
 /// ```ascii,no_run

--- a/src/backend/vector/ifma/constants.rs
+++ b/src/backend/vector/ifma/constants.rs
@@ -11,7 +11,7 @@
 
 use packed_simd::u64x4;
 
-use window::NafLookupTable8;
+use crate::window::NafLookupTable8;
 
 use super::edwards::{CachedPoint, ExtendedPoint};
 use super::field::{F51x4Reduced, F51x4Unreduced};

--- a/src/backend/vector/ifma/edwards.rs
+++ b/src/backend/vector/ifma/edwards.rs
@@ -9,15 +9,15 @@
 
 #![allow(non_snake_case)]
 
-use traits::Identity;
+use crate::traits::Identity;
 
 use std::ops::{Add, Neg, Sub};
 
 use subtle::Choice;
 use subtle::ConditionallySelectable;
 
-use edwards;
-use window::{LookupTable, NafLookupTable5, NafLookupTable8};
+use crate::edwards;
+use crate::window::{LookupTable, NafLookupTable5, NafLookupTable8};
 
 use super::constants;
 use super::field::{F51x4Reduced, F51x4Unreduced, Lanes, Shuffle};

--- a/src/backend/vector/ifma/field.rs
+++ b/src/backend/vector/ifma/field.rs
@@ -12,7 +12,7 @@
 use core::ops::{Add, Mul, Neg};
 use packed_simd::{u64x4, IntoBits};
 
-use backend::serial::u64::field::FieldElement51;
+use crate::backend::serial::u64::field::FieldElement51;
 
 #[allow(improper_ctypes)]
 extern "C" {

--- a/src/backend/vector/scalar_mul/pippenger.rs
+++ b/src/backend/vector/scalar_mul/pippenger.rs
@@ -11,13 +11,13 @@
 
 use core::borrow::Borrow;
 
-use backend::vector::{CachedPoint, ExtendedPoint};
-use edwards::EdwardsPoint;
-use scalar::Scalar;
-use traits::{Identity, VartimeMultiscalarMul};
+use crate::backend::vector::{CachedPoint, ExtendedPoint};
+use crate::edwards::EdwardsPoint;
+use crate::scalar::Scalar;
+use crate::traits::{Identity, VartimeMultiscalarMul};
 
 #[allow(unused_imports)]
-use prelude::*;
+use crate::prelude::*;
 
 /// Implements a version of Pippenger's algorithm.
 ///
@@ -128,8 +128,8 @@ impl VartimeMultiscalarMul for Pippenger {
 #[cfg(test)]
 mod test {
     use super::*;
-    use constants;
-    use scalar::Scalar;
+    use crate::constants;
+    use crate::scalar::Scalar;
 
     #[test]
     fn test_vartime_pippenger() {

--- a/src/backend/vector/scalar_mul/precomputed_straus.rs
+++ b/src/backend/vector/scalar_mul/precomputed_straus.rs
@@ -13,15 +13,15 @@
 
 use core::borrow::Borrow;
 
-use backend::vector::{CachedPoint, ExtendedPoint};
-use edwards::EdwardsPoint;
-use scalar::Scalar;
-use traits::Identity;
-use traits::VartimePrecomputedMultiscalarMul;
-use window::{NafLookupTable5, NafLookupTable8};
+use crate::backend::vector::{CachedPoint, ExtendedPoint};
+use crate::edwards::EdwardsPoint;
+use crate::scalar::Scalar;
+use crate::traits::Identity;
+use crate::traits::VartimePrecomputedMultiscalarMul;
+use crate::window::{NafLookupTable5, NafLookupTable8};
 
 #[allow(unused_imports)]
-use prelude::*;
+use crate::prelude::*;
 
 
 pub struct VartimePrecomputedStraus {

--- a/src/backend/vector/scalar_mul/straus.rs
+++ b/src/backend/vector/scalar_mul/straus.rs
@@ -14,14 +14,14 @@ use core::borrow::Borrow;
 
 use clear_on_drop::ClearOnDrop;
 
-use backend::vector::{CachedPoint, ExtendedPoint};
-use edwards::EdwardsPoint;
-use scalar::Scalar;
-use window::{LookupTable, NafLookupTable5};
-use traits::{Identity, MultiscalarMul, VartimeMultiscalarMul};
+use crate::backend::vector::{CachedPoint, ExtendedPoint};
+use crate::edwards::EdwardsPoint;
+use crate::scalar::Scalar;
+use crate::window::{LookupTable, NafLookupTable5};
+use crate::traits::{Identity, MultiscalarMul, VartimeMultiscalarMul};
 
 #[allow(unused_imports)]
-use prelude::*;
+use crate::prelude::*;
 
 /// Multiscalar multiplication using interleaved window / Straus'
 /// method.  See the `Straus` struct in the serial backend for more

--- a/src/backend/vector/scalar_mul/variable_base.rs
+++ b/src/backend/vector/scalar_mul/variable_base.rs
@@ -1,10 +1,10 @@
 #![allow(non_snake_case)]
 
-use backend::vector::{CachedPoint, ExtendedPoint};
-use edwards::EdwardsPoint;
-use scalar::Scalar;
-use traits::Identity;
-use window::LookupTable;
+use crate::backend::vector::{CachedPoint, ExtendedPoint};
+use crate::edwards::EdwardsPoint;
+use crate::scalar::Scalar;
+use crate::traits::Identity;
+use crate::window::LookupTable;
 
 /// Perform constant-time, variable-base scalar multiplication.
 pub fn mul(point: &EdwardsPoint, scalar: &Scalar) -> EdwardsPoint {

--- a/src/backend/vector/scalar_mul/vartime_double_base.rs
+++ b/src/backend/vector/scalar_mul/vartime_double_base.rs
@@ -9,12 +9,12 @@
 // - Henry de Valence <hdevalence@hdevalence.ca>
 #![allow(non_snake_case)]
 
-use backend::vector::BASEPOINT_ODD_LOOKUP_TABLE;
-use backend::vector::{CachedPoint, ExtendedPoint};
-use edwards::EdwardsPoint;
-use scalar::Scalar;
-use traits::Identity;
-use window::NafLookupTable5;
+use crate::backend::vector::BASEPOINT_ODD_LOOKUP_TABLE;
+use crate::backend::vector::{CachedPoint, ExtendedPoint};
+use crate::edwards::EdwardsPoint;
+use crate::scalar::Scalar;
+use crate::traits::Identity;
+use crate::window::NafLookupTable5;
 
 /// Compute \\(aA + bB\\) in variable time, where \\(B\\) is the Ed25519 basepoint.
 pub fn mul(a: &Scalar, A: &EdwardsPoint, b: &Scalar) -> EdwardsPoint {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -27,16 +27,16 @@
 
 #![allow(non_snake_case)]
 
-use edwards::CompressedEdwardsY;
-use ristretto::RistrettoPoint;
-use ristretto::CompressedRistretto;
-use montgomery::MontgomeryPoint;
-use scalar::Scalar;
+use crate::edwards::CompressedEdwardsY;
+use crate::ristretto::RistrettoPoint;
+use crate::ristretto::CompressedRistretto;
+use crate::montgomery::MontgomeryPoint;
+use crate::scalar::Scalar;
 
 #[cfg(feature = "u64_backend")]
-pub use backend::serial::u64::constants::*;
+pub use crate::backend::serial::u64::constants::*;
 #[cfg(feature = "u32_backend")]
-pub use backend::serial::u32::constants::*;
+pub use crate::backend::serial::u32::constants::*;
 
 /// The Ed25519 basepoint, in `CompressedEdwardsY` format.
 ///
@@ -89,7 +89,7 @@ pub const BASEPOINT_ORDER: Scalar = Scalar{
 include!(concat!(env!("OUT_DIR"), "/basepoint_table.rs"));
 
 #[cfg(feature = "stage2_build")]
-use ristretto::RistrettoBasepointTable;
+use crate::ristretto::RistrettoBasepointTable;
 
 /// The Ristretto basepoint, as a `RistrettoBasepointTable` for scalar multiplication.
 #[cfg(feature = "stage2_build")]
@@ -98,14 +98,14 @@ pub const RISTRETTO_BASEPOINT_TABLE: RistrettoBasepointTable
 
 #[cfg(test)]
 mod test {
-    use field::FieldElement;
-    use traits::{IsIdentity, ValidityCheck};
-    use constants;
+    use crate::field::FieldElement;
+    use crate::traits::{IsIdentity, ValidityCheck};
+    use crate::constants;
 
     #[test]
     fn test_eight_torsion() {
         for i in 0..8 {
-            let Q = constants::EIGHT_TORSION[i].mul_by_pow_2(3);
+            let Q = crate::constants::EIGHT_TORSION[i].mul_by_pow_2(3);
             assert!(Q.is_valid());
             assert!(Q.is_identity());
         }
@@ -114,7 +114,7 @@ mod test {
     #[test]
     fn test_four_torsion() {
         for i in (0..8).filter(|i| i % 2 == 0) {
-            let Q = constants::EIGHT_TORSION[i].mul_by_pow_2(2);
+            let Q = crate::constants::EIGHT_TORSION[i].mul_by_pow_2(2);
             assert!(Q.is_valid());
             assert!(Q.is_identity());
         }
@@ -123,7 +123,7 @@ mod test {
     #[test]
     fn test_two_torsion() {
         for i in (0..8).filter(|i| i % 4 == 0) {
-            let Q = constants::EIGHT_TORSION[i].mul_by_pow_2(1);
+            let Q = crate::constants::EIGHT_TORSION[i].mul_by_pow_2(1);
             assert!(Q.is_valid());
             assert!(Q.is_identity());
         }
@@ -133,9 +133,9 @@ mod test {
     #[test]
     fn test_sqrt_minus_one() {
         let minus_one = FieldElement::minus_one();
-        let sqrt_m1_sq = &constants::SQRT_M1 * &constants::SQRT_M1;
+        let sqrt_m1_sq = &crate::constants::SQRT_M1 * &constants::SQRT_M1;
         assert_eq!(minus_one,  sqrt_m1_sq);
-        assert_eq!(constants::SQRT_M1.is_negative().unwrap_u8(), 0);
+        assert_eq!(crate::constants::SQRT_M1.is_negative().unwrap_u8(), 0);
     }
 
     #[test]
@@ -143,7 +143,7 @@ mod test {
         let minus_one = FieldElement::minus_one();
         let (was_nonzero_square, invsqrt_m1) = minus_one.invsqrt();
         assert_eq!(was_nonzero_square.unwrap_u8(), 1u8);
-        let sign_test_sqrt  = &invsqrt_m1 * &constants::SQRT_M1;
+        let sign_test_sqrt  = &invsqrt_m1 * &crate::constants::SQRT_M1;
         assert_eq!(sign_test_sqrt, minus_one);
     }
 
@@ -151,33 +151,33 @@ mod test {
     #[test]
     #[cfg(feature = "u32_backend")]
     fn test_d_vs_ratio() {
-        use backend::serial::u32::field::FieldElement2625;
+        use crate::backend::serial::u32::field::FieldElement2625;
         let a = -&FieldElement2625([121665,0,0,0,0,0,0,0,0,0]);
         let b =   FieldElement2625([121666,0,0,0,0,0,0,0,0,0]);
         let d = &a * &b.invert();
         let d2 = &d + &d;
-        assert_eq!(d, constants::EDWARDS_D);
-        assert_eq!(d2, constants::EDWARDS_D2);
+        assert_eq!(d, crate::constants::EDWARDS_D);
+        assert_eq!(d2, crate::constants::EDWARDS_D2);
     }
 
     /// Test that d = -121665/121666
     #[test]
     #[cfg(feature = "u64_backend")]
     fn test_d_vs_ratio() {
-        use backend::serial::u64::field::FieldElement51;
+        use crate::backend::serial::u64::field::FieldElement51;
         let a = -&FieldElement51([121665,0,0,0,0]);
         let b =   FieldElement51([121666,0,0,0,0]);
         let d = &a * &b.invert();
         let d2 = &d + &d;
-        assert_eq!(d, constants::EDWARDS_D);
-        assert_eq!(d2, constants::EDWARDS_D2);
+        assert_eq!(d, crate::constants::EDWARDS_D);
+        assert_eq!(d2, crate::constants::EDWARDS_D2);
     }
 
     #[test]
     fn test_sqrt_ad_minus_one() {
         let a = FieldElement::minus_one();
-        let ad_minus_one = &(&a * &constants::EDWARDS_D) + &a;
-        let should_be_ad_minus_one = constants::SQRT_AD_MINUS_ONE.square();
+        let ad_minus_one = &(&a * &crate::constants::EDWARDS_D) + &a;
+        let should_be_ad_minus_one = crate::constants::SQRT_AD_MINUS_ONE.square();
         assert_eq!(should_be_ad_minus_one, ad_minus_one);
     }
 

--- a/src/edwards.rs
+++ b/src/edwards.rs
@@ -105,41 +105,41 @@ use subtle::ConditionallyNegatable;
 use subtle::ConditionallySelectable;
 use subtle::ConstantTimeEq;
 
-use constants;
+use crate::constants;
 
-use field::FieldElement;
-use scalar::Scalar;
+use crate::field::FieldElement;
+use crate::scalar::Scalar;
 
-use montgomery::MontgomeryPoint;
+use crate::montgomery::MontgomeryPoint;
 
-use backend::serial::curve_models::AffineNielsPoint;
-use backend::serial::curve_models::CompletedPoint;
-use backend::serial::curve_models::ProjectiveNielsPoint;
-use backend::serial::curve_models::ProjectivePoint;
+use crate::backend::serial::curve_models::AffineNielsPoint;
+use crate::backend::serial::curve_models::CompletedPoint;
+use crate::backend::serial::curve_models::ProjectiveNielsPoint;
+use crate::backend::serial::curve_models::ProjectivePoint;
 
-use window::LookupTable;
+use crate::window::LookupTable;
 
 #[allow(unused_imports)]
-use prelude::*;
+use crate::prelude::*;
 
-use traits::ValidityCheck;
-use traits::{Identity, IsIdentity};
+use crate::traits::ValidityCheck;
+use crate::traits::{Identity, IsIdentity};
 
 #[cfg(any(feature = "alloc", feature = "std"))]
-use traits::MultiscalarMul;
+use crate::traits::MultiscalarMul;
 #[cfg(any(feature = "alloc", feature = "std"))]
-use traits::{VartimeMultiscalarMul, VartimePrecomputedMultiscalarMul};
+use crate::traits::{VartimeMultiscalarMul, VartimePrecomputedMultiscalarMul};
 
 #[cfg(not(all(
     feature = "simd_backend",
     any(target_feature = "avx2", target_feature = "avx512ifma")
 )))]
-use backend::serial::scalar_mul;
+use crate::backend::serial::scalar_mul;
 #[cfg(all(
     feature = "simd_backend",
     any(target_feature = "avx2", target_feature = "avx512ifma")
 ))]
-use backend::vector::scalar_mul;
+use crate::backend::vector::scalar_mul;
 
 // ------------------------------------------------------------------------
 // Compressed points
@@ -940,10 +940,10 @@ impl Debug for EdwardsBasepointTable {
 
 #[cfg(all(test, feature = "stage2_build"))]
 mod test {
-    use field::FieldElement;
-    use scalar::Scalar;
+    use crate::field::FieldElement;
+    use crate::scalar::Scalar;
     use subtle::ConditionallySelectable;
-    use constants;
+    use crate::constants;
     use super::*;
 
     /// X coordinate of the basepoint.
@@ -1259,7 +1259,7 @@ mod test {
     fn vartime_precomputed_vs_nonprecomputed_multiscalar() {
         let mut rng = rand::thread_rng();
 
-        let B = &::constants::ED25519_BASEPOINT_TABLE;
+        let B = &constants::ED25519_BASEPOINT_TABLE;
 
         let static_scalars = (0..128)
             .map(|_| Scalar::random(&mut rng))
@@ -1286,7 +1286,7 @@ mod test {
             &dynamic_points,
         );
 
-        use traits::VartimeMultiscalarMul;
+        use crate::traits::VartimeMultiscalarMul;
         let Q = EdwardsPoint::vartime_multiscalar_mul(
             static_scalars.iter().chain(dynamic_scalars.iter()),
             static_points.iter().chain(dynamic_points.iter()),

--- a/src/field.rs
+++ b/src/field.rs
@@ -29,28 +29,28 @@ use subtle::ConditionallyNegatable;
 use subtle::Choice;
 use subtle::ConstantTimeEq;
 
-use constants;
-use backend;
+use crate::constants;
+use crate::backend;
 
 #[cfg(feature = "u64_backend")]
-pub use backend::serial::u64::field::*;
+pub use crate::backend::serial::u64::field::*;
 /// A `FieldElement` represents an element of the field
 /// \\( \mathbb Z / (2\^{255} - 19)\\).
 ///
 /// The `FieldElement` type is an alias for one of the platform-specific
 /// implementations.
 #[cfg(feature = "u64_backend")]
-pub type FieldElement = backend::serial::u64::field::FieldElement51;
+pub type FieldElement = crate::backend::serial::u64::field::FieldElement51;
 
 #[cfg(feature = "u32_backend")]
-pub use backend::serial::u32::field::*;
+pub use crate::backend::serial::u32::field::*;
 /// A `FieldElement` represents an element of the field
 /// \\( \mathbb Z / (2\^{255} - 19)\\).
 ///
 /// The `FieldElement` type is an alias for one of the platform-specific
 /// implementations.
 #[cfg(feature = "u32_backend")]
-pub type FieldElement = backend::serial::u32::field::FieldElement2625;
+pub type FieldElement = crate::backend::serial::u32::field::FieldElement2625;
 
 impl Eq for FieldElement {}
 
@@ -274,7 +274,7 @@ impl FieldElement {
 
 #[cfg(test)]
 mod test {
-    use field::*;
+    use crate::field::*;
     use subtle::ConditionallyNegatable;
 
     /// Random element a of GF(2^255-19), from Sage

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,11 @@ extern crate std;
 #[cfg(all(feature = "nightly", feature = "packed_simd"))]
 extern crate packed_simd;
 
+
+#[cfg(feature = "zeromem")]
+extern crate zeroize;
+
+
 extern crate byteorder;
 extern crate clear_on_drop;
 pub extern crate digest;

--- a/src/montgomery.rs
+++ b/src/montgomery.rs
@@ -50,12 +50,12 @@
 
 use core::ops::{Mul, MulAssign};
 
-use constants::APLUS2_OVER_FOUR;
-use edwards::{CompressedEdwardsY, EdwardsPoint};
-use field::FieldElement;
-use scalar::Scalar;
+use crate::constants::APLUS2_OVER_FOUR;
+use crate::edwards::{CompressedEdwardsY, EdwardsPoint};
+use crate::field::FieldElement;
+use crate::scalar::Scalar;
 
-use traits::Identity;
+use crate::traits::Identity;
 
 use subtle::Choice;
 use subtle::ConditionallySelectable;
@@ -89,6 +89,18 @@ impl PartialEq for MontgomeryPoint {
 }
 
 impl Eq for MontgomeryPoint {}
+
+#[cfg(feature = "zeromem")]
+use zeroize::Zeroize;
+
+#[cfg(feature = "zeromem")]
+impl Zeroize for MontgomeryPoint {
+    fn zeroize(&mut self) {
+        self.0.zeroize();
+        debug_assert!(self.0.iter().all(|b| *b == 0));
+    }
+}
+
 
 impl MontgomeryPoint {
     /// View this `MontgomeryPoint` as an array of bytes.
@@ -301,7 +313,7 @@ impl<'a, 'b> Mul<&'b MontgomeryPoint> for &'a Scalar {
 
 #[cfg(all(test, feature = "stage2_build"))]
 mod test {
-    use constants;
+    use crate::constants;
     use super::*;
 
     #[cfg(feature = "rand")]

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -149,7 +149,7 @@ use core::ops::{Mul, MulAssign};
 use core::ops::{Sub, SubAssign};
 
 #[allow(unused_imports)]
-use prelude::*;
+use crate::prelude::*;
 
 use rand_core::{CryptoRng, RngCore};
 
@@ -160,22 +160,24 @@ use subtle::Choice;
 use subtle::ConditionallySelectable;
 use subtle::ConstantTimeEq;
 
-use backend;
-use constants;
+use crate::backend;
+use crate::constants;
+
+
 
 /// An `UnpackedScalar` represents an element of the field GF(l), optimized for speed.
 ///
 /// This is a type alias for one of the scalar types in the `backend`
 /// module.
 #[cfg(feature = "u64_backend")]
-type UnpackedScalar = backend::serial::u64::scalar::Scalar52;
+type UnpackedScalar = crate::backend::serial::u64::scalar::Scalar52;
 
 /// An `UnpackedScalar` represents an element of the field GF(l), optimized for speed.
 ///
 /// This is a type alias for one of the scalar types in the `backend`
 /// module.
 #[cfg(feature = "u32_backend")]
-type UnpackedScalar = backend::serial::u32::scalar::Scalar29;
+type UnpackedScalar = crate::backend::serial::u32::scalar::Scalar29;
 
 
 /// The `Scalar` struct holds an integer \\(s < 2\^{255} \\) which
@@ -406,6 +408,18 @@ impl<'de> Deserialize<'de> for Scalar {
         deserializer.deserialize_bytes(ScalarVisitor)
     }
 }
+
+#[cfg(feature = "zeromem")]
+use zeroize::Zeroize;
+
+#[cfg(feature = "zeromem")]
+impl Zeroize for Scalar {
+    fn zeroize(&mut self) {
+        self.bytes.zeroize();
+        debug_assert!(self.bytes.iter().all(|b| *b == 0));
+    }
+}
+
 
 impl<T> Product<T> for Scalar
 where

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -16,7 +16,7 @@ use core::borrow::Borrow;
 
 use subtle;
 
-use scalar::Scalar;
+use crate::scalar::Scalar;
 
 // ------------------------------------------------------------------------
 // Public Traits

--- a/src/window.rs
+++ b/src/window.rs
@@ -19,11 +19,10 @@ use subtle::ConditionallySelectable;
 use subtle::ConstantTimeEq;
 use subtle::Choice;
 
-use traits::Identity;
-
-use edwards::EdwardsPoint;
-use backend::serial::curve_models::ProjectiveNielsPoint;
-use backend::serial::curve_models::AffineNielsPoint;
+use crate::traits::Identity;
+use crate::edwards::EdwardsPoint;
+use crate::backend::serial::curve_models::ProjectiveNielsPoint;
+use crate::backend::serial::curve_models::AffineNielsPoint;
 
 /// A lookup table of precomputed multiples of a point \\(P\\), used to
 /// compute \\( xP \\) for \\( -8 \leq x \leq 8 \\).


### PR DESCRIPTION
Hello,

I have updated the crate to rust 2018. Also I have seen there is some discussion already with removing the clear_on_drop crate for zeroize. As the scalar type can be used as a secret key in constructions like Schnorr it is important that it support such a feature. During this transition period from clear_on_drop I think that adding zeroize behind a feature tag allowing crate users to explicitly call it when needed upstream is a good place to start and doesn't break anyone else usage. I do think that overtime to consolidate behind one library.

thanks