### PR TITLE
Pippenger bugfix

### DIFF
--- a/src/backend/serial/scalar_mul/pippenger.rs
+++ b/src/backend/serial/scalar_mul/pippenger.rs
@@ -125,7 +125,8 @@ impl VartimeMultiscalarMul for Pippenger {
             // Note: if we add support for precomputed lookup tables,
             // we'll be adding/subtracting point premultiplied by `digits[i]` to buckets[0].
             for (digits, pt) in scalars_points.iter() {
-                let digit = digits[digit_index];
+                // Widen digit so that we don't run into edge cases when w=8.
+                let digit = digits[digit_index] as i16;
                 if digit > 0 {
                     let b = (digit - 1) as usize;
                     buckets[b] = (&buckets[b] + pt).to_extended();

--- a/src/backend/serial/scalar_mul/pippenger.rs
+++ b/src/backend/serial/scalar_mul/pippenger.rs
@@ -88,14 +88,14 @@ impl VartimeMultiscalarMul for Pippenger {
         };
 
         let max_digit: usize = 1 << w;
-        let digits_count: usize = (256 + w - 1) / w; // == ceil(256/w)
+        let digits_count: usize = Scalar::to_radix_2w_size_hint(w);
         let buckets_count: usize = max_digit / 2; // digits are signed+centered hence 2^w/2, excluding 0-th bucket
 
         // Collect optimized scalars and points in buffers for repeated access
         // (scanning the whole set per digit position).
         let scalars = scalars
             .into_iter()
-            .map(|s| s.borrow().to_radix_2w(w).0);
+            .map(|s| s.borrow().to_radix_2w(w));
 
         let points = points
             .into_iter()

--- a/src/backend/serial/scalar_mul/precomputed_straus.rs
+++ b/src/backend/serial/scalar_mul/precomputed_straus.rs
@@ -85,7 +85,7 @@ impl VartimePrecomputedMultiscalarMul for VartimePrecomputedStraus {
         // nonzero NAF coefficient, but since we might have a lot of
         // them to search, it's not clear it's worthwhile to check.
         let mut S = ProjectivePoint::identity();
-        for j in (0..255).rev() {
+        for j in (0..256).rev() {
             let mut R: CompletedPoint = S.double();
 
             for i in 0..dp {

--- a/src/backend/serial/scalar_mul/straus.rs
+++ b/src/backend/serial/scalar_mul/straus.rs
@@ -179,7 +179,7 @@ impl VartimeMultiscalarMul for Straus {
 
         let mut r = ProjectivePoint::identity();
 
-        for i in (0..255).rev() {
+        for i in (0..256).rev() {
             let mut t: CompletedPoint = r.double();
 
             for (naf, lookup_table) in nafs.iter().zip(lookup_tables.iter()) {

--- a/src/backend/serial/scalar_mul/vartime_double_base.rs
+++ b/src/backend/serial/scalar_mul/vartime_double_base.rs
@@ -23,7 +23,7 @@ pub fn mul(a: &Scalar, A: &EdwardsPoint, b: &Scalar) -> EdwardsPoint {
 
     // Find starting index
     let mut i: usize = 255;
-    for j in (0..255).rev() {
+    for j in (0..256).rev() {
         i = j;
         if a_naf[i] != 0 || b_naf[i] != 0 {
             break;

--- a/src/backend/vector/scalar_mul/pippenger.rs
+++ b/src/backend/vector/scalar_mul/pippenger.rs
@@ -82,7 +82,8 @@ impl VartimeMultiscalarMul for Pippenger {
             // Note: if we add support for precomputed lookup tables,
             // we'll be adding/subtractiong point premultiplied by `digits[i]` to buckets[0].
             for (digits, pt) in scalars_points.iter() {
-                let digit = digits[digit_index];
+                // Widen digit so that we don't run into edge cases when w=8.
+                let digit = digits[digit_index] as i16;
                 if digit > 0 {
                     let b = (digit - 1) as usize;
                     buckets[b] = &buckets[b] + pt;

--- a/src/backend/vector/scalar_mul/pippenger.rs
+++ b/src/backend/vector/scalar_mul/pippenger.rs
@@ -45,14 +45,14 @@ impl VartimeMultiscalarMul for Pippenger {
         };
 
         let max_digit: usize = 1 << w;
-        let digits_count: usize = (256 + w - 1) / w; // == ceil(256/w)
+        let digits_count: usize = Scalar::to_radix_2w_size_hint(w);
         let buckets_count: usize = max_digit / 2; // digits are signed+centered hence 2^w/2, excluding 0-th bucket
 
         // Collect optimized scalars and points in a buffer for repeated access
         // (scanning the whole collection per each digit position).
         let scalars = scalars
             .into_iter()
-            .map(|s| s.borrow().to_radix_2w(w).0);
+            .map(|s| s.borrow().to_radix_2w(w));
 
         let points = points
             .into_iter()

--- a/src/backend/vector/scalar_mul/precomputed_straus.rs
+++ b/src/backend/vector/scalar_mul/precomputed_straus.rs
@@ -84,7 +84,7 @@ impl VartimePrecomputedMultiscalarMul for VartimePrecomputedStraus {
         // nonzero NAF coefficient, but since we might have a lot of
         // them to search, it's not clear it's worthwhile to check.
         let mut R = ExtendedPoint::identity();
-        for j in (0..255).rev() {
+        for j in (0..256).rev() {
             R = R.double();
 
             for i in 0..dp {

--- a/src/backend/vector/scalar_mul/straus.rs
+++ b/src/backend/vector/scalar_mul/straus.rs
@@ -94,7 +94,7 @@ impl VartimeMultiscalarMul for Straus {
 
         let mut Q = ExtendedPoint::identity();
 
-        for i in (0..255).rev() {
+        for i in (0..256).rev() {
             Q = Q.double();
 
             for (naf, lookup_table) in nafs.iter().zip(lookup_tables.iter()) {

--- a/src/backend/vector/scalar_mul/vartime_double_base.rs
+++ b/src/backend/vector/scalar_mul/vartime_double_base.rs
@@ -23,7 +23,7 @@ pub fn mul(a: &Scalar, A: &EdwardsPoint, b: &Scalar) -> EdwardsPoint {
 
     // Find starting index
     let mut i: usize = 255;
-    for j in (0..255).rev() {
+    for j in (0..256).rev() {
         i = j;
         if a_naf[i] != 0 || b_naf[i] != 0 {
             break;

--- a/src/edwards.rs
+++ b/src/edwards.rs
@@ -1255,6 +1255,71 @@ mod test {
         assert!(P1.compress().to_bytes() == P2.compress().to_bytes());
     }
 
+    // A single iteration of a consistency check for MSM.
+    fn multiscalar_consistency_iter(n: usize) {
+        use core::iter;
+        let mut rng = rand::thread_rng();
+
+        // Construct random coefficients x0, ..., x_{n-1},
+        // followed by some extra hardcoded ones.
+        let xs = (0..n)
+            .map(|_| Scalar::random(&mut rng))
+            .collect::<Vec<_>>();
+        let check = xs.iter()
+            .map(|xi| xi * xi)
+            .sum::<Scalar>();
+
+        // Construct points G_i = x_i * B
+        let Gs = xs.iter()
+            .map(|xi| xi * &constants::ED25519_BASEPOINT_TABLE)
+            .collect::<Vec<_>>();
+
+        // Compute H1 = <xs, Gs> (consttime)
+        let H1 = EdwardsPoint::multiscalar_mul(&xs, &Gs);
+        // Compute H2 = <xs, Gs> (vartime)
+        let H2 = EdwardsPoint::vartime_multiscalar_mul(&xs, &Gs);
+        // Compute H3 = <xs, Gs> = sum(xi^2) * B
+        let H3 = &check * &constants::ED25519_BASEPOINT_TABLE;
+
+        assert_eq!(H1, H3);
+        assert_eq!(H2, H3);
+    }
+
+    // Use different multiscalar sizes to hit different internal
+    // parameters.
+
+    #[test]
+    fn multiscalar_consistency_n_100() {
+        let iters = 50;
+        for _ in 0..iters {
+            multiscalar_consistency_iter(100);
+        }
+    }
+
+    #[test]
+    fn multiscalar_consistency_n_250() {
+        let iters = 50;
+        for _ in 0..iters {
+            multiscalar_consistency_iter(250);
+        }
+    }
+
+    #[test]
+    fn multiscalar_consistency_n_500() {
+        let iters = 50;
+        for _ in 0..iters {
+            multiscalar_consistency_iter(500);
+        }
+    }
+
+    #[test]
+    fn multiscalar_consistency_n_1000() {
+        let iters = 50;
+        for _ in 0..iters {
+            multiscalar_consistency_iter(1000);
+        }
+    }
+
     #[test]
     fn vartime_precomputed_vs_nonprecomputed_multiscalar() {
         let mut rng = rand::thread_rng();

--- a/src/edwards.rs
+++ b/src/edwards.rs
@@ -1264,6 +1264,8 @@ mod test {
         // followed by some extra hardcoded ones.
         let xs = (0..n)
             .map(|_| Scalar::random(&mut rng))
+            // The largest scalar allowed by the type system, 2^255-1
+            .chain(iter::once(Scalar::from_bits([0xff; 32])))
             .collect::<Vec<_>>();
         let check = xs.iter()
             .map(|xi| xi * xi)


### PR DESCRIPTION
The Pippenger implementation in 1.2.0 (yanked) had a bug, diagnosed by @oleganza; at the largest problem sizes (using w=8), the signed digits fill the value range of an i8, and so doing computation on them to calculate the bucket index could hit an overflow.

The CI missed catching this because the test suite didn't check all the problem sizes, which I fixed in this PR.  Adding a check that the multiscalar functions work on manually-constructed extremal scalar values (which are allowed by the `Scalar` type for X/Ed25519 compatibility but aren't used as inputs to the multiscalar functions) revealed a bug in the NAF-using computation, which has no security content but has been present since the first version of the library (cc @isislovecruft); there's more details in the commit messages.