### PR TITLE
Remove unneeded check for negativity in edwards point decompression

### DIFF
--- a/src/edwards.rs
+++ b/src/edwards.rs
@@ -192,9 +192,7 @@ impl CompressedEdwardsY {
 
         // Flip the sign of X if it's not correct
         let compressed_sign_bit = Choice::from(self.as_bytes()[31] >> 7);
-        let    current_sign_bit = X.is_negative();
-
-        X.conditional_negate(current_sign_bit ^ compressed_sign_bit);
+        X.conditional_negate(compressed_sign_bit);
 
         Some(EdwardsPoint{ X: X, Y: Y, Z: Z, T: &X * &Y })
     }

--- a/src/edwards.rs
+++ b/src/edwards.rs
@@ -190,7 +190,8 @@ impl CompressedEdwardsY {
 
         if is_valid_y_coord.unwrap_u8() != 1u8 { return None; }
 
-        // Flip the sign of X if it's not correct
+         // FieldElement::sqrt_ratio_i always returns the nonnegative square root,
+         // so we negate according to the supplied sign bit.
         let compressed_sign_bit = Choice::from(self.as_bytes()[31] >> 7);
         X.conditional_negate(compressed_sign_bit);
 


### PR DESCRIPTION
The function `FieldElement::sqrt_ratio_i` always returns a positive root
by definition. Therefore the test for negativity in the edwards point
decompression function always returns false and we only need to flip its
sign if `compressed_sign_bit` is set.