### PR TITLE
add non-zero assert in field batch_invert

### DIFF
--- a/src/field.rs
+++ b/src/field.rs
@@ -154,6 +154,9 @@ impl FieldElement {
             acc = &acc * input;
         }
 
+	// acc is nonzero iff all inputs are nonzero
+        assert_eq!(acc.is_zero().unwrap_u8(), 0);
+
         // Compute the inverse of all products
         acc = acc.invert();
 


### PR DESCRIPTION
All input `FieldElements` **MUST** be nonzero. BUT if there is a `zero FieldElement`, `batch_invert` return an array of zeros instead of an error.
An assertion is needed for robust.
