### PR TITLE
Remove byteorder-dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,6 @@ harness = false
 
 [dependencies]
 rand_core = { version = "0.3.0", default-features = false }
-byteorder = { version = "^1.2.3", default-features = false, features = ["i128"] }
 digest = { version = "0.8", default-features = false }
 clear_on_drop = "=0.2.3"
 subtle = { version = "2", default-features = false }
@@ -54,7 +53,6 @@ packed_simd = { version = "0.3.0", features = ["into_bits"], optional = true }
 
 [build-dependencies]
 rand_core = { version = "0.3.0", default-features = false }
-byteorder = { version = "^1.2.3", default-features = false, features = ["i128"] }
 digest = { version = "0.8", default-features = false }
 clear_on_drop = "=0.2.3"
 subtle = { version = "2", default-features = false }

--- a/build.rs
+++ b/build.rs
@@ -14,7 +14,6 @@
 
 #[cfg(all(feature = "alloc", not(feature = "std")))]
 extern crate alloc;
-extern crate byteorder;
 extern crate clear_on_drop;
 extern crate core;
 extern crate digest;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,6 @@ extern crate std;
 #[cfg(all(feature = "nightly", feature = "packed_simd"))]
 extern crate packed_simd;
 
-extern crate byteorder;
 extern crate clear_on_drop;
 pub extern crate digest;
 extern crate rand_core;


### PR DESCRIPTION
This removes the `byteorder`-dependency, which is not needed since 1.32 (raising the minimum Rust version to that). Dropping a dependency is worth the change IMHO.