### PR TITLE
`curve_models` Comment fix

### DIFF
--- a/src/edwards.rs
+++ b/src/edwards.rs
@@ -84,7 +84,7 @@
 //! successful decompression of a compressed point, or else by
 //! operations on other (valid) `EdwardsPoint`s.
 //!
-//! [curve_models]: https://doc-internal.dalek.rs/curve25519_dalek/curve_models/index.html
+//! [curve_models]: https://doc-internal.dalek.rs/curve25519_dalek/backend/serial/curve_models/index.html
 
 // We allow non snake_case names because coordinates in projective space are
 // traditionally denoted by the capitalisation of their respective

--- a/src/field.rs
+++ b/src/field.rs
@@ -154,6 +154,9 @@ impl FieldElement {
             acc = &acc * input;
         }
 
+	// acc is nonzero iff all inputs are nonzero
+        assert_eq!(acc.is_zero().unwrap_u8(), 0);
+
         // Compute the inverse of all products
         acc = acc.invert();
 


### PR DESCRIPTION
The comment link (`https://doc-internal.dalek.rs/curve25519_dalek/curve_models/index.html`) for `curve_models` mismatch the actual link：`https://doc-internal.dalek.rs/curve25519_dalek/backend/serial/curve_models/index.html` .