### PR TITLE
Fix link to AVX2 docs

### DIFF
--- a/src/backend/vector/avx2/mod.rs
+++ b/src/backend/vector/avx2/mod.rs
@@ -19,7 +19,7 @@
 // missing).
 #![cfg_attr(
     all(feature = "nightly", feature = "stage2_build"),
-    doc(include = "../../docs/avx2-notes.md")
+    doc(include = "../../../../docs/avx2-notes.md")
 )]
 
 pub(crate) mod field;

--- a/src/backend/vector/ifma/mod.rs
+++ b/src/backend/vector/ifma/mod.rs
@@ -9,7 +9,7 @@
 
 #![cfg_attr(
     all(feature = "nightly", feature = "stage2_build"),
-    doc(include = "../../docs/ifma-notes.md")
+    doc(include = "../../../../docs/ifma-notes.md")
 )]
 
 pub mod field;

--- a/src/backend/vector/mod.rs
+++ b/src/backend/vector/mod.rs
@@ -19,7 +19,7 @@
 // missing).
 #![cfg_attr(
     all(feature = "nightly", feature = "stage2_build"),
-    doc(include = "../../docs/parallel-formulas.md")
+    doc(include = "../../../docs/parallel-formulas.md")
 )]
 
 #[cfg(not(any(target_feature = "avx2", target_feature = "avx512ifma", rustdoc)))]


### PR DESCRIPTION
Currently the library doesn't compile on `nightly` when the `avx2_backend` is enabled; this PR fixes it by fixing the links to the relevant docs.