### PR TITLE
JSON serialization for Scalar / Ristretto / Edwards types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
   # Tests the avx2 backend
   - TEST_COMMAND=test EXTRA_FLAGS='--no-default-features' FEATURES='std avx2_backend'
   # Tests serde support and default feature selection
-  - TEST_COMMAND=test EXTRA_FLAGS='' FEATURES='serde serde_json'
+  - TEST_COMMAND=test EXTRA_FLAGS='' FEATURES='serde'
   # Tests building without std. We have to select a backend, so we select the one
   # most likely to be useful in an embedded environment.
   - TEST_COMMAND=build EXTRA_FLAGS='--no-default-features' FEATURES='u32_backend'

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
   # Tests the avx2 backend
   - TEST_COMMAND=test EXTRA_FLAGS='--no-default-features' FEATURES='std avx2_backend'
   # Tests serde support and default feature selection
-  - TEST_COMMAND=test EXTRA_FLAGS='' FEATURES='serde'
+  - TEST_COMMAND=test EXTRA_FLAGS='' FEATURES='serde serde_json'
   # Tests building without std. We have to select a backend, so we select the one
   # most likely to be useful in an embedded environment.
   - TEST_COMMAND=build EXTRA_FLAGS='--no-default-features' FEATURES='u32_backend'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ byteorder = { version = "^1.2.3", default-features = false, features = ["i128"] 
 digest = { version = "0.8", default-features = false }
 clear_on_drop = "=0.2.3"
 subtle = { version = "2", default-features = false }
-serde = { version = "1.0", default-features = false, optional = true }
+serde_crate = { package = "serde", version = "1.0", default-features = false, optional = true }
 hex = { version = "0.3.2", default-features = false, optional = true }
 packed_simd = { version = "0.3.0", features = ["into_bits"], optional = true }
 
@@ -60,7 +60,7 @@ byteorder = { version = "^1.2.3", default-features = false, features = ["i128"] 
 digest = { version = "0.8", default-features = false }
 clear_on_drop = "=0.2.3"
 subtle = { version = "2", default-features = false }
-serde = { version = "1.0", default-features = false, optional = true }
+serde_crate = { package = "serde", version = "1.0", default-features = false, optional = true }
 hex = { version = "0.3.2", default-features = false, optional = true }
 packed_simd = { version = "0.3.0", features = ["into_bits"], optional = true }
 
@@ -68,6 +68,7 @@ packed_simd = { version = "0.3.0", features = ["into_bits"], optional = true }
 nightly = ["subtle/nightly", "clear_on_drop/nightly"]
 default = ["std", "u64_backend"]
 std = ["alloc", "subtle/std", "rand_core/std"]
+serde = ["serde_crate", "hex"]
 alloc = []
 yolocrypto = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ travis-ci = { repository = "dalek-cryptography/curve25519-dalek", branch = "mast
 rand_os = "0.1.0"
 sha2 = { version = "0.8", default-features = false }
 bincode = "1"
+serde_json = "1"
 criterion = "0.2"
 rand = "0.6"
 
@@ -50,6 +51,7 @@ digest = { version = "0.8", default-features = false }
 clear_on_drop = "=0.2.3"
 subtle = { version = "2", default-features = false }
 serde = { version = "1.0", default-features = false, optional = true }
+hex = { version = "0.3.2", default-features = false, optional = true }
 packed_simd = { version = "0.3.0", features = ["into_bits"], optional = true }
 
 [build-dependencies]
@@ -59,6 +61,7 @@ digest = { version = "0.8", default-features = false }
 clear_on_drop = "=0.2.3"
 subtle = { version = "2", default-features = false }
 serde = { version = "1.0", default-features = false, optional = true }
+hex = { version = "0.3.2", default-features = false, optional = true }
 packed_simd = { version = "0.3.0", features = ["into_bits"], optional = true }
 
 [features]

--- a/build.rs
+++ b/build.rs
@@ -28,7 +28,7 @@ use std::path::Path;
 //
 // For instance, this shouldn't exist here at all, but it does.
 #[cfg(feature = "serde")]
-extern crate serde;
+extern crate serde_crate as serde;
 
 // Macros come first!
 #[path = "src/macros.rs"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,10 +54,10 @@ extern crate subtle;
 #[cfg(all(test, feature = "serde"))]
 extern crate bincode;
 #[cfg(feature = "serde")]
-extern crate serde;
+extern crate serde_crate as serde;
 #[cfg(all(test, feature = "serde"))]
 extern crate serde_json;
-#[cfg(all(feature = "serde", feature = "hex"))]
+#[cfg(feature = "serde")]
 extern crate hex;
 
 // Internal macros. Must come first!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,10 @@ extern crate subtle;
 extern crate bincode;
 #[cfg(feature = "serde")]
 extern crate serde;
+#[cfg(all(test, feature = "serde"))]
+extern crate serde_json;
+#[cfg(all(feature = "serde", feature = "hex"))]
+extern crate hex;
 
 // Internal macros. Must come first!
 #[macro_use]

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -1673,7 +1673,7 @@ mod test {
     fn serde_json_scalar_roundtrip() {
         use serde_json;
         let output = serde_json::to_string(&X).unwrap();
-        assert_eq!(&output, "\"4e5ab4345d4708845913b4641bc27d5252a585101bcc4244d449f4a879d9f204\"");
+        assert_eq!(output, "\"4e5ab4345d4708845913b4641bc27d5252a585101bcc4244d449f4a879d9f204\"");
         let parsed: Scalar = serde_json::from_str(&output).unwrap();
         assert_eq!(parsed, X);
     }

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -386,14 +386,7 @@ impl Serialize for Scalar {
         where S: Serializer
     {
         if serializer.is_human_readable() {
-            #[cfg(feature = "hex")]
-            {
-                serializer.serialize_str(&hex::encode(self.reduce().as_bytes()))
-            }
-            #[cfg(not(feature = "hex"))]
-            {
-                serializer.serialize_bytes(self.reduce().as_bytes())
-            }
+            serializer.serialize_str(&hex::encode(self.reduce().as_bytes()))
         } else {
             serializer.serialize_bytes(self.reduce().as_bytes())
         }
@@ -414,7 +407,6 @@ impl<'de> Deserialize<'de> for Scalar {
                 formatter.write_str("a canonically-encoded 32-byte scalar value")
             }
 
-            #[cfg(feature = "hex")]
             fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
                 where E: serde::de::Error
             {


### PR DESCRIPTION
## Problem

Current version of the library encodes scalars and points as serde type "byte array". In `serde_json` this gets encoded into array of numbers. During deserialization this becomes a "sequence" serde type (aka "vector of json values"), which is not provided when the dalek deserializer asks for "byte array", and causes a deserialization failure.

Another issue with JSON is that `HashMap<CompressedRistretto,...>` currently attempts to serialize with array as a key, while JSON only permits strings as keys. This is also fixed with this patch.

## Suggestion

To fix this problem I suggest having built-in serialization of binary data as hex string for "human-readable" serializers. This means that users of binary serializers such as bincode, XDR, protobufs etc could still use efficient binary representation (which is also backwards compatible). But the users of the human-readable serializers such as JSON, YAML, TOML, XML do not have to worry if their format specifies "binary string" type (usually they don't).

## Issues

Seems like some binary serializers do not set `is_human_readable` flag to `false`, which is defaulted to `true` ¯\\(ツ)/¯. Some people already filed issues, but it might be impossible to fix this w/o breaking compatibility: https://github.com/3Hren/msgpack-rust/issues/176

Another problem: if someone is successfully using a serializer marked as human-readable (irrespective of whether it's actually true), this patch will alter encoding for them, making binary strings encoded as hex-encoded utf-8 strings. **This may be a blocker for this PR.**

## Alternatives

**1st alternative** is to enable hex-encoding in this crate as a feature-flag, separate from `"serde"` feature.

**2nd alternative** is to have an alternative version of the `serde_json` crate (or an opt-in knob) that does not support schemaless encoding, and explicitly converts byte arrays to hex (or base64) strings and back. Here's PR on `serde_json` introducing optional hex serialization: https://github.com/serde-rs/json/pull/557

**3rd alternative** is to use a serialization proxy such as https://github.com/slowli/hex-buffer-serde, but in a several layers of abstraction it's not always clear at which layer such proxy should be applied: if it's too low, it'll be having same issues as this PR; but if it's too high, it might be hard to penetrate through several nested types to encode specific item in hex.