### PR TITLE
try to fix panic at CompressedRistretto from_slice

### DIFF
--- a/src/ristretto.rs
+++ b/src/ristretto.rs
@@ -235,9 +235,13 @@ impl CompressedRistretto {
     /// If the input `bytes` slice does not have a length of 32.
     pub fn from_slice(bytes: &[u8]) -> CompressedRistretto {
         let mut tmp = [0u8; 32];
-
-        tmp.copy_from_slice(bytes);
-
+        if bytes.len() != 32 {
+            let byte_tmp =&[0u8; 32];
+            tmp.copy_from_slice(byte_tmp);
+        }
+        else {
+            tmp.copy_from_slice(bytes);
+        }
         CompressedRistretto(tmp)
     }
 


### PR DESCRIPTION
Hello, I found that the function "from_silce"  in src/ristretto.rs will happen a panic when receiving a slice of incorrect length. Maybe this unreasonable. And then I try to fix it.

Test main.rs like this
```rust
extern crate curve25519_dalek;
use curve25519_dalek::ristretto;
use curve25519_dalek::scalar::Scalar;

fn main() {
    let test_u8 = [1, 2, 3, 4];
    let test_point = ristretto::CompressedRistretto::from_slice(&test_u8);
    println!("test_point = {:?}", test_point);
}
```

Then I got this:
```rust
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `32`,
 right: `0`: destination and source slices have different lengths', src/libcore/slice/mod.rs:2119:9
stack backtrace:
```