### PR TITLE
Update rand_core, rand, rand_os.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,18 +26,18 @@ features = ["nightly", "simd_backend"]
 travis-ci = { repository = "dalek-cryptography/curve25519-dalek", branch = "master"}
 
 [dev-dependencies]
-rand_os = "0.1"
+rand_os = "0.2"
 sha2 = { version = "0.8", default-features = false }
 bincode = "1"
 criterion = "0.2"
-rand = "0.6"
+rand = "0.7"
 
 [[bench]]
 name = "dalek_benchmarks"
 harness = false
 
 [dependencies]
-rand_core = { version = "0.3", default-features = false }
+rand_core = { version = "0.5", default-features = false }
 byteorder = { version = "^1.2.3", default-features = false, features = ["i128"] }
 digest = { version = "0.8", default-features = false }
 subtle = { version = "2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ features = ["nightly", "simd_backend"]
 travis-ci = { repository = "dalek-cryptography/curve25519-dalek", branch = "master"}
 
 [dev-dependencies]
-rand_os = "0.1.0"
+rand_os = "0.1"
 sha2 = { version = "0.8", default-features = false }
 bincode = "1"
 criterion = "0.2"
@@ -37,13 +37,13 @@ name = "dalek_benchmarks"
 harness = false
 
 [dependencies]
-rand_core = { version = "0.3.0", default-features = false }
+rand_core = { version = "0.3", default-features = false }
 byteorder = { version = "^1.2.3", default-features = false, features = ["i128"] }
 digest = { version = "0.8", default-features = false }
 subtle = { version = "2", default-features = false }
 serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
-packed_simd = { version = "0.3.0", features = ["into_bits"], optional = true }
-zeroize = { version = "1.0.0", default-features = false }
+packed_simd = { version = "0.3", features = ["into_bits"], optional = true }
+zeroize = { version = "1", default-features = false }
 
 [features]
 nightly = ["subtle/nightly"]


### PR DESCRIPTION
Of these only `rand_core` is included in the public API; regardless of `rand`
semver tricks, this is a breaking API change, but the major version is already
bumped to include the Serde serialization fixes for #265.