### PR TITLE
Added constants to reduce recalculations in elligator_risteretto_flavor

### DIFF
--- a/src/backend/serial/u32/constants.rs
+++ b/src/backend/serial/u32/constants.rs
@@ -18,6 +18,11 @@ use backend::serial::u32::scalar::Scalar29;
 use edwards::{EdwardsBasepointTable, EdwardsPoint};
 use window::{LookupTable, NafLookupTable8};
 
+/// The value of minus one, equal to `-&FieldElement::one()`
+pub(crate) const MINUS_ONE: FieldElement2625 = FieldElement2625([
+    67108844, 33554431, 67108863, 33554431, 67108863, 33554431, 67108863, 33554431, 67108863, 33554431
+]);
+
 /// Edwards `d` value, equal to `-121665/121666 mod p`.
 pub(crate) const EDWARDS_D: FieldElement2625 = FieldElement2625([
     56195235, 13857412, 51736253, 6949390, 114729, 24766616, 60832955, 30306712, 48412415, 21499315,
@@ -26,6 +31,16 @@ pub(crate) const EDWARDS_D: FieldElement2625 = FieldElement2625([
 /// Edwards `2*d` value, equal to `2*(-121665/121666) mod p`.
 pub(crate) const EDWARDS_D2: FieldElement2625 = FieldElement2625([
     45281625, 27714825, 36363642, 13898781, 229458, 15978800, 54557047, 27058993, 29715967, 9444199,
+]);
+
+/// One minus edwards `d` value squared, equal to `(1 - (-121665/121666) mod p) pow 2`
+pub(crate) const ONE_MINUS_EDWARDS_D_SQUARED: FieldElement2625 =  FieldElement2625([
+    6275446, 16937061, 44170319, 29780721, 11667076, 7397348, 39186143, 1766194, 42675006, 672202
+]);
+
+/// Edwards `d` value minus one squared, equal to `(((-121665/121666) mod p) - 1) pow 2`
+pub(crate) const EDWARDS_D_MINUS_ONE_SQUARED: FieldElement2625 =  FieldElement2625([
+    15551776, 22456977, 53683765, 23429360, 55212328, 10178283, 40474537, 4729243, 61826754, 23438029
 ]);
 
 /// `= sqrt(a*d - 1)`, where `a = -1 (mod p)`, `d` are the Edwards curve parameters.

--- a/src/backend/serial/u64/constants.rs
+++ b/src/backend/serial/u64/constants.rs
@@ -16,6 +16,15 @@ use backend::serial::u64::scalar::Scalar52;
 use edwards::{EdwardsBasepointTable, EdwardsPoint};
 use window::{LookupTable, NafLookupTable8};
 
+/// The value of minus one, equal to `-&FieldElement::one()`
+pub(crate) const MINUS_ONE: FieldElement51 = FieldElement51([
+    2251799813685228,
+    2251799813685247,
+    2251799813685247,
+    2251799813685247,
+    2251799813685247
+]);
+
 /// Edwards `d` value, equal to `-121665/121666 mod p`.
 pub(crate) const EDWARDS_D: FieldElement51 = FieldElement51([
     929955233495203,
@@ -32,6 +41,24 @@ pub(crate) const EDWARDS_D2: FieldElement51 = FieldElement51([
     1072319116312658,
     1815898335770999,
     633789495995903,
+]);
+
+/// One minus edwards `d` value squared, equal to `(1 - (-121665/121666) mod p) pow 2`
+pub(crate) const ONE_MINUS_EDWARDS_D_SQUARED: FieldElement51 = FieldElement51([
+    1136626929484150,
+    1998550399581263,
+    496427632559748,
+    118527312129759,
+    45110755273534
+]);
+
+/// Edwards `d` value minus one squared, equal to `(((-121665/121666) mod p) - 1) pow 2`
+pub(crate) const EDWARDS_D_MINUS_ONE_SQUARED: FieldElement51 = FieldElement51([
+    1507062230895904,
+    1572317787530805,
+    683053064812840,
+    317374165784489,
+    1572899562415810
 ]);
 
 /// `= sqrt(a*d - 1)`, where `a = -1 (mod p)`, `d` are the Edwards curve parameters.

--- a/src/ristretto.rs
+++ b/src/ristretto.rs
@@ -598,14 +598,16 @@ impl RistrettoPoint {
     /// This method is not public because it's just used for hashing
     /// to a point -- proper elligator support is deferred for now.
     pub(crate) fn elligator_ristretto_flavor(r_0: &FieldElement) -> RistrettoPoint {
-        let (i, d) = (&constants::SQRT_M1, &constants::EDWARDS_D);
+        let i = &constants::SQRT_M1;
+        let d = &constants::EDWARDS_D;
+        let one_minus_d_sq = &constants::ONE_MINUS_EDWARDS_D_SQUARED;
+        let d_minus_one_sq = &constants::EDWARDS_D_MINUS_ONE_SQUARED;
+        let mut c = constants::MINUS_ONE;
+
         let one = FieldElement::one();
-        let one_minus_d_sq = &one - &d.square();
-        let d_minus_one_sq = (d - &one).square();
 
         let r = i * &r_0.square();
         let N_s = &(&r + &one) * &one_minus_d_sq;
-        let mut c = -&one;
         let D = &(&c - &(d * &r)) * &(&r + d);
 
         let (Ns_D_is_sq, mut s) = FieldElement::sqrt_ratio_i(&N_s, &D);


### PR DESCRIPTION
This should fix #224. 

The link in that issue refers to a different line in the codebase, so it's possible I have updated the wrong functions.

The values are based on the original calculation, but please double-check them.