### PR TITLE
Remove test for validity of randomly generated RistrettoPoints.

### DIFF
--- a/src/ristretto.rs
+++ b/src/ristretto.rs
@@ -1322,19 +1322,6 @@ mod test {
         }
     }
 
-    #[cfg(feature = "rand")]
-    #[test]
-    fn random_is_valid() {
-        let mut rng = OsRng::new().unwrap();
-        for _ in 0..100 {
-            let P = RistrettoPoint::random(&mut rng);
-            // Check that P is on the curve
-            assert!(P.0.is_valid());
-            // Check that P is in the image of the ristretto map
-            P.compress();
-        }
-    }
-
     #[test]
     fn vartime_precomputed_vs_nonprecomputed_multiscalar() {
         let mut rng = rand::thread_rng();


### PR DESCRIPTION
This test is no longer necessary as it originally had a possibility of failure due to the original implementation of the invsqrt() function in the decompression algorithm.  The failure with the current API is nonexistent.

* FIXES #288.