### PR TITLE
Remove dev-dependency on deprecated rand_os crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ features = ["nightly", "simd_backend"]
 travis-ci = { repository = "dalek-cryptography/curve25519-dalek", branch = "master"}
 
 [dev-dependencies]
-rand_os = "0.2"
 sha2 = { version = "0.8", default-features = false }
 bincode = "1"
 criterion = "0.2"

--- a/benches/dalek_benchmarks.rs
+++ b/benches/dalek_benchmarks.rs
@@ -247,7 +247,7 @@ mod ristretto_benches {
         c.bench_function_over_inputs(
             "Batch Ristretto double-and-encode",
             |b, &&size| {
-                let mut rng = OsRng::new().unwrap();
+                let mut rng = OsRng;
                 let points: Vec<RistrettoPoint> = (0..size)
                     .map(|_| RistrettoPoint::random(&mut rng))
                     .collect();
@@ -299,7 +299,7 @@ mod scalar_benches {
         c.bench_function_over_inputs(
             "Batch scalar inversion",
             |b, &&size| {
-                let mut rng = OsRng::new().unwrap();
+                let mut rng = OsRng;
                 let scalars: Vec<Scalar> = (0..size).map(|_| Scalar::random(&mut rng)).collect();
                 b.iter(|| {
                     let mut s = scalars.clone();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,8 +44,6 @@ extern crate packed_simd;
 extern crate byteorder;
 pub extern crate digest;
 extern crate rand_core;
-#[cfg(test)]
-extern crate rand_os;
 extern crate zeroize;
 
 // Used for traits related to constant-time code.

--- a/src/montgomery.rs
+++ b/src/montgomery.rs
@@ -310,8 +310,7 @@ mod test {
     use constants;
     use super::*;
 
-    #[cfg(feature = "rand")]
-    use rand_os::OsRng;
+    use rand_core::OsRng;
 
     #[test]
     #[cfg(feature = "serde")]
@@ -380,10 +379,9 @@ mod test {
         assert_eq!(u18, u18_unred);
     }
 
-    #[cfg(feature = "rand")]
     #[test]
     fn montgomery_ladder_matches_edwards_scalarmult() {
-        let mut csprng: OsRng = OsRng::new().unwrap();
+        let mut csprng: OsRng = OsRng;
 
         let s: Scalar = Scalar::random(&mut csprng);
         let p_edwards: EdwardsPoint = &constants::ED25519_BASEPOINT_TABLE * &s;

--- a/src/ristretto.rs
+++ b/src/ristretto.rs
@@ -485,13 +485,13 @@ impl RistrettoPoint {
     /// ```
     /// # extern crate curve25519_dalek;
     /// # use curve25519_dalek::ristretto::RistrettoPoint;
-    /// extern crate rand_os;
-    /// use rand_os::OsRng;
+    /// extern crate rand_core;
+    /// use rand_core::OsRng;
     ///
     /// # // Need fn main() here in comment so the doctest compiles
     /// # // See https://doc.rust-lang.org/book/documentation.html#documentation-as-tests
     /// # fn main() {
-    /// let mut rng = OsRng::new().unwrap();
+    /// let mut rng = OsRng;
     /// let points: Vec<RistrettoPoint> =
     ///     (0..32).map(|_| RistrettoPoint::random(&mut rng)).collect();
     ///
@@ -1084,8 +1084,7 @@ impl Debug for RistrettoPoint {
 
 #[cfg(test)]
 mod test {
-    #[cfg(feature = "rand")]
-    use rand_os::OsRng;
+    use rand_core::OsRng;
 
     use scalar::Scalar;
     use constants;
@@ -1233,10 +1232,9 @@ mod test {
         }
     }
 
-    #[cfg(feature = "rand")]
     #[test]
     fn four_torsion_random() {
-        let mut rng = OsRng::new().unwrap();
+        let mut rng = OsRng;
         let B = &constants::RISTRETTO_BASEPOINT_TABLE;
         let P = B * &Scalar::random(&mut rng);
         let P_coset = P.coset4();
@@ -1296,10 +1294,9 @@ mod test {
         }
     }
 
-    #[cfg(feature = "rand")]
     #[test]
     fn random_roundtrip() {
-        let mut rng = OsRng::new().unwrap();
+        let mut rng = OsRng;
         let B = &constants::RISTRETTO_BASEPOINT_TABLE;
         for _ in 0..100 {
             let P = B * &Scalar::random(&mut rng);
@@ -1309,10 +1306,9 @@ mod test {
         }
     }
 
-    #[cfg(feature = "rand")]
     #[test]
     fn double_and_compress_1024_random_points() {
-        let mut rng = OsRng::new().unwrap();
+        let mut rng = OsRng;
 
         let points: Vec<RistrettoPoint> =
             (0..1024).map(|_| RistrettoPoint::random(&mut rng)).collect();

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -536,15 +536,15 @@ impl Scalar {
     /// # Example
     ///
     /// ```
-    /// extern crate rand_os;
+    /// extern crate rand_core;
     /// # extern crate curve25519_dalek;
     /// #
     /// # fn main() {
     /// use curve25519_dalek::scalar::Scalar;
     ///
-    /// use rand_os::OsRng;
+    /// use rand_core::OsRng;
     ///
-    /// let mut csprng: OsRng = OsRng::new().unwrap();
+    /// let mut csprng = OsRng;
     /// let a: Scalar = Scalar::random(&mut csprng);
     /// # }
     pub fn random<R: RngCore + CryptoRng>(rng: &mut R) -> Self {


### PR DESCRIPTION
The functionality we were using is now contained in the `rand_core` crate, which we already depend upon.  As far as testing code goes, only benchmarks still depend upon `rand`, as they use `thread_rng`.