### PR TITLE
Fix a warning that a temporary value isn't used.

### DIFF
--- a/src/backend/serial/scalar_mul/variable_base.rs
+++ b/src/backend/serial/scalar_mul/variable_base.rs
@@ -25,7 +25,7 @@ pub(crate) fn mul(point: &EdwardsPoint, scalar: &Scalar) -> EdwardsPoint {
     // We sum right-to-left.
 
     // Unwrap first loop iteration to save computing 16*identity
-    let mut tmp2 = ProjectivePoint::identity();
+    let mut tmp2;
     let mut tmp3 = EdwardsPoint::identity();
     let mut tmp1 = &tmp3 + &lookup_table.select(scalar_digits[63]);
     // Now tmp1 = s_63*P in P1xP1 coords


### PR DESCRIPTION
rustc doesn't seem smart enough to figure out that when doing:

```rust
let mut tmp1 = T;
let mut tmp2 = T;
let mut tmp3 = T;
for i in 0..63 {
    // ...
    tmp1 = tmp2.double();
    tmp3 = tmp1.to_extended();
    tmp1 = tmp3 + foo;
}
```

that the tmp2 variable is actually used.  This silences that erroneous warning.