### PR TITLE
Bump criterion version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ travis-ci = { repository = "dalek-cryptography/curve25519-dalek", branch = "mast
 [dev-dependencies]
 sha2 = { version = "0.8", default-features = false }
 bincode = "1"
-criterion = "0.2"
+criterion = "0.3.0"
 rand = "0.7"
 
 [[bench]]


### PR DESCRIPTION
Note this allows the use of benchmark comparison tooling such as [critcmp](https://github.com/BurntSushi/critcmp).