### PR TITLE
Make Scalar::from_bits a const fn.

### DIFF
--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -243,7 +243,7 @@ impl Scalar {
     /// This function is intended for applications like X25519 which
     /// require specific bit-patterns when performing scalar
     /// multiplication.
-    pub fn from_bits(bytes: [u8; 32]) -> Scalar {
+    pub const fn from_bits(bytes: [u8; 32]) -> Scalar {
         let mut s = Scalar{bytes};
         // Ensure that s < 2^255 by masking the high bit
         s.bytes[31] &= 0b0111_1111;


### PR DESCRIPTION
`const_fn` is stable since Rust 1.31 (https://github.com/rust-lang/rust/pull/54835) and enables calling `Scalar::from_bits(..)` from other const fn contexts, potentially saving some overhead here and there.

Especially useful in contexts where constants are being built from a bit pattern.

---

My use case is a constructor for a certain large number, where I'd rather start from a slice and set the correct bits that just hardcode in all 32 bytes at once.

I'm not 100% sure about the compatibility guarantees when switching an existing function to `const`, but I imagine it shouldn't interfere anywhere, since the whole test suite still passes.

The other constructors use a call to `.reduce()`, so I didn't bother looking deeper whether they can be made `const` too.