### PR TITLE
Montgomery Elligator Support and Random Point Generation on Edwards Curve

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,8 @@ subtle = { version = "^2.2.1", default-features = false }
 serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
 packed_simd = { version = "0.3", features = ["into_bits"], optional = true }
 zeroize = { version = "1", default-features = false }
+sha2 = "0.8.1"
+rand = "0.7"
 
 [features]
 nightly = ["subtle/nightly"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,8 @@ subtle = { version = "^2.2.1", default-features = false }
 serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
 packed_simd = { version = "0.3", features = ["into_bits"], optional = true }
 zeroize = { version = "1", default-features = false }
-sha2 = "0.8.1"
-rand = "0.7"
+sha2 = { version = "0.8.1", default-features = false}
+rand = { version = "0.7", default-features = false}
 
 [features]
 nightly = ["subtle/nightly"]

--- a/src/backend/serial/u32/constants.rs
+++ b/src/backend/serial/u32/constants.rs
@@ -63,6 +63,10 @@ pub(crate) const SQRT_M1: FieldElement2625 = FieldElement2625([
 pub(crate) const APLUS2_OVER_FOUR: FieldElement2625 =
     FieldElement2625([121666, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
 
+/// `MONT_A` is constant of Curve25519. (This is used internally within the Montgomery elligator.)
+pub(crate) const MONT_A: FieldElement2625 =
+    FieldElement2625([486662, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+
 /// `L` is the order of base point, i.e. 2^252 +
 /// 27742317777372353535851937790883648493
 pub(crate) const L: Scalar29 = Scalar29([

--- a/src/backend/serial/u64/constants.rs
+++ b/src/backend/serial/u64/constants.rs
@@ -91,6 +91,9 @@ pub(crate) const SQRT_M1: FieldElement51 = FieldElement51([
 /// `APLUS2_OVER_FOUR` is (A+2)/4. (This is used internally within the Montgomery ladder.)
 pub(crate) const APLUS2_OVER_FOUR: FieldElement51 = FieldElement51([121666, 0, 0, 0, 0]);
 
+/// `MONT_A` is constant of Curve25519. (This is used internally within the Montgomery elligator.)
+pub(crate) const MONT_A: FieldElement51 = FieldElement51([486662, 0, 0, 0, 0]);
+
 /// `L` is the order of base point, i.e. 2^252 + 27742317777372353535851937790883648493
 pub(crate) const L: Scalar52 = Scalar52([
     0x0002631a5cf5d3ed,

--- a/src/edwards.rs
+++ b/src/edwards.rs
@@ -636,7 +636,10 @@ impl EdwardsPoint {
 
         // Applying Elligator twice and adding the results ensures a
         // uniform distribution.
-        &E_1_opt.expect("First Edwards point!") + &E_2_opt.expect("Second Edwards point!")
+        // 
+        // We multiply the result by 8 to ensure that the new point lies in the
+        // prime order subgroup of Edwards curve.
+        &Scalar::from(8u8)*(&E_1_opt.expect("First Edwards point!") + &E_2_opt.expect("Second Edwards point!"))
     }
 }
 
@@ -1309,12 +1312,13 @@ mod test {
         assert_eq!(bp16.compress(), BASE16_CMPRSSD);
     }
 
-    /// Test the montgomery elligator 
+    /// Test the random edwards point generation using montgomery elligator 
     #[test]
     fn random_edwards(){
-        let msg = "This would work irrespective of what this is!1";
+        let msg = "A seed to test random point generation on Edwards!
+                   This should work for any input string";
         let P = EdwardsPoint::hash_from_bytes::<Sha512>(msg.as_bytes());
-        println!("P: {:?}", P);
+        assert!(ValidityCheck::is_valid(&P));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,8 @@ extern crate byteorder;
 pub extern crate digest;
 extern crate rand_core;
 extern crate zeroize;
+extern crate sha2;
+extern crate rand;
 
 // Used for traits related to constant-time code.
 extern crate subtle;

--- a/src/montgomery.rs
+++ b/src/montgomery.rs
@@ -161,7 +161,13 @@ impl MontgomeryPoint {
     /// # Note
     ///
     /// This method is not public because it's just used for hashing
-    /// to a point -- proper elligator support is deferred for now.
+    /// to a point (similar to the ristretto elligator) -- proper
+    /// elligator support is deferred for now.
+    /// 
+    /// Based on the paper: Elligator: Elliptic-curve points 
+    /// indistinguishable from uniform random strings.
+    /// Link: http://elligator.cr.yp.to/elligator-20130828.pdf
+    /// Section 5.5: Application of ψ to Curve25519
     pub(crate) fn elligator_montgomery_flavor(r_0: &FieldElement) -> MontgomeryPoint {
 
         let minus_a = -&MONT_A;


### PR DESCRIPTION
With an intention of having hash-to-curve methods which are applicable to `EdwardsPoint`, I wrote elligator support for Montgomery curve and using that, added methods like `EdwardsPoint::hash_from_bytes`, `EdwardsPoint::from_uniform_bytes`, `EdwardsPoint::random` for Edwards curve. 

Note that in the last step of `from_uniform_bytes`, I multiply the resulting `EdwardsPoint` with scalar `Scalar::from(8u8)` in order to make sure it lies in the prime order subgroup. Although this is exactly why Ristretto must be used to avoid such modifications which might result into vulnerabilities, but for existing systems which use Edwards' prime order subgroup, support for such functions becomes necessary. If someone wants to write a protocol for say Monero (Edwards curve) and leverage the multi-scalar multiplication and other features of `curve25519-dalek`, support of such functions for `EdwardsPoints`s becomes crucial. 

An issue was raised by @omershlo in the past for the same. #188 