### PR TITLE
Make crate feature alloc work with stable Rust

### DIFF
--- a/src/backend/serial/u64/scalar.rs
+++ b/src/backend/serial/u64/scalar.rs
@@ -443,7 +443,6 @@ mod test {
     fn from_bytes_wide() {
         let bignum = [255u8; 64]; // 2^512 - 1
         let reduced = Scalar52::from_bytes_wide(&bignum);
-        println!("{:?}", reduced);
         for i in 0..5 {
             assert!(reduced[i] == C[i]);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@
 
 #![no_std]
 #![cfg_attr(feature = "nightly", feature(test))]
-#![cfg_attr(all(feature = "alloc", not(feature = "std")), feature(alloc))]
 #![cfg_attr(feature = "nightly", feature(external_doc))]
 #![cfg_attr(feature = "nightly", feature(doc_cfg))]
 #![cfg_attr(feature = "simd_backend", feature(stdsimd))]


### PR DESCRIPTION
`feature(alloc)` is not needed and removing it allows to compile with stable Rust when the crate `alloc` feature is on.

`println!` was removed in the test as the corresponding test for `u32` does not have it.