### PR TITLE
Update rand_core to 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ travis-ci = { repository = "dalek-cryptography/curve25519-dalek", branch = "mast
 sha2 = { version = "0.9", default-features = false }
 bincode = "1"
 criterion = "0.3.0"
-rand = "0.7"
+rand = "0.8"
 
 [[bench]]
 name = "dalek_benchmarks"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ name = "dalek_benchmarks"
 harness = false
 
 [dependencies]
-rand_core = { version = "0.5", default-features = false }
+rand_core = { version = "0.6", default-features = false }
 byteorder = { version = "^1.2.3", default-features = false, features = ["i128"] }
 digest = { version = "0.9", default-features = false }
 subtle = { version = "^2.2.1", default-features = false }


### PR DESCRIPTION
https://github.com/rust-random/rand/blob/master/rand_core/CHANGELOG.md
This new version makes using rand_core on wasm seamless (thanks to the update of getrandom to v0.2)
The crate compiles well with this PR, but since some `rand_core` traits are publicly exposed in this crate's API, this is strictly speaking a breaking change.