### PR TITLE
Implement num_traits::pow for Scalar

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ serde = { version = "1.0", default-features = false, optional = true, features =
 # https://github.com/rust-lang/packed_simd/issues/303#issuecomment-701361161
 packed_simd = { version = "0.3.4", package = "packed_simd_2", features = ["into_bits"], optional = true }
 zeroize = { version = "1", default-features = false }
+num-traits = { version = "0.2", default-features = false }
 
 [features]
 nightly = ["subtle/nightly"]

--- a/README.md
+++ b/README.md
@@ -197,6 +197,8 @@ optimised batch inversion was contributed by Sean Bowe and Daira Hopwood.
 
 The `no_std` and `zeroize` support was contributed by Tony Arcieri.
 
+The `num_traits` support was contributed by Cargodog.
+
 Thanks also to Ashley Hauck, Lucas Salibian, and Manish Goregaokar for their
 contributions.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@ extern crate byteorder;
 pub extern crate digest;
 extern crate rand_core;
 extern crate zeroize;
+extern crate num_traits;
 
 // Used for traits related to constant-time code.
 extern crate subtle;


### PR DESCRIPTION
## What:
This PR implements [num_traits::Pow](https://docs.rs/num-traits/0.2.8/num_traits/pow/index.html) for the `Scalar` type.

## Why:
Many cryptographic protocols, especially some more complex ZKP schemes, rely on `Scalar` exponentiation. Without this trait implementation, using this library in such protocols requires also implementing exponentiation for Scalar types. This leads to inconsistent implementations and suboptimal arithmetic (e.g. fast exponentiation).

In many cases, simple iterative exponentiation is sufficient and easy to implement. In other cases, however, iterative exponentiation is costly and slows down the system. `num_traits::Pow` provides optimized "fast math" exponentiation for us, providing users an easy and repeatable way to get the most efficient exponentiation in all scenarios.

## Implementation notes:
I copied the `pow_impl!` macro from `num_traits::Pow`, because they do not export this macro. I feel this provides the simplest/cleanest implementation, but please let me know if you would prefer to have this done some other way (or not at all).

Cheers :beers:

P.S. great work on this library! I find myself recommending it to others all the time.
