### PR TITLE
Implement Identity for MontgomeryPoint.

### DIFF
--- a/src/montgomery.rs
+++ b/src/montgomery.rs
@@ -94,6 +94,13 @@ impl PartialEq for MontgomeryPoint {
 
 impl Eq for MontgomeryPoint {}
 
+impl Identity for MontgomeryPoint {
+    /// Return the group identity element, which has order 4.
+    fn identity() -> MontgomeryPoint {
+        MontgomeryPoint([0u8; 32])
+    }
+}
+
 impl Zeroize for MontgomeryPoint {
     fn zeroize(&mut self) {
         self.0.zeroize();
@@ -350,6 +357,14 @@ mod test {
     use core::convert::TryInto;
 
     use rand_core::OsRng;
+
+    #[test]
+    fn identity_in_different_coordinates() {
+        let id_projective = ProjectivePoint::identity();
+        let id_montgomery = id_projective.to_affine();
+
+        assert!(id_montgomery == MontgomeryPoint::identity());
+    }
 
     #[test]
     #[cfg(feature = "serde")]

--- a/src/montgomery.rs
+++ b/src/montgomery.rs
@@ -367,6 +367,11 @@ mod test {
     }
 
     #[test]
+    fn identity_in_different_models() {
+        assert!(EdwardsPoint::identity().to_montgomery() == MontgomeryPoint::identity());
+    }
+
+    #[test]
     #[cfg(feature = "serde")]
     fn serde_bincode_basepoint_roundtrip() {
         use bincode;


### PR DESCRIPTION
This can be used in checks for non-contributory behaviour in protocols
where that is a concern.