### PR TITLE
proposed work-around for https://github.com/rust-lang/rust/issues/86693

### DIFF
--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -914,8 +914,14 @@ impl Scalar {
 
         let mut naf = [0i8; 256];
 
-        let mut x_u64 = [0u64; 5];
-        LittleEndian::read_u64_into(&self.bytes, &mut x_u64[0..4]);
+        // work-around for https://github.com/rust-lang/rust/issues/86693
+        // riscv32i targets mis-align u64 types, leading to the lower 32 bits being aliased to the upper 32 bits
+        // the AlignedU64Slice wrapper forces the enclosed structure to be aligned, thus avoiding this problem.
+        #[repr(align(32))]
+        struct AlignedU64Slice([u64; 5]);
+
+        let mut x_u64 = AlignedU64Slice([0u64; 5]);
+        LittleEndian::read_u64_into(&self.bytes, &mut x_u64.0[0..4]);
 
         let width = 1 << w;
         let window_mask = width - 1;
@@ -929,10 +935,10 @@ impl Scalar {
             let bit_buf: u64;
             if bit_idx < 64 - w {
                 // This window's bits are contained in a single u64
-                bit_buf = x_u64[u64_idx] >> bit_idx;
+                bit_buf = x_u64.0[u64_idx] >> bit_idx;
             } else {
                 // Combine the current u64's bits with the bits from the next u64
-                bit_buf = (x_u64[u64_idx] >> bit_idx) | (x_u64[1+u64_idx] << (64 - bit_idx));
+                bit_buf = (x_u64.0[u64_idx] >> bit_idx) | (x_u64.0[1+u64_idx] << (64 - bit_idx));
             }
 
             // Add the carry into the current window


### PR DESCRIPTION
For 32-bit targets on RISC-V, we have encountered a problem in the
`non_adjacent_form()` routine inside `Scalar`. To the best we can tell,
there is a compiler bug which is causing 64-bit types on 32-bit platforms
to not be properly aligned (see issue https://github.com/rust-lang/rust/issues/86693).
This bug results in the lower 32 bits of a 64-bit number being replicated
into the top 32 bits, as a result of pointer arithmetic optimizations that
rely on correct alignment of the data types.

So far, we have only seen this problem inside one function that affects
ed25519 verifications, but it could be in other libraries we haven't
used yet.

Thanks to @xobs we have a work-around, which is to wrap the `[u64; 5]`
type inside an `AlignedU64Slice` `newtype` which is annotated with
a `#[repr(align(32))]`. In our tests this causes the ed25519 signatures
tests to pass on our platform.

Unfortunately, we are unable to get the bug to express on x86 using a u32
backend; the bug seems to be specific to RISC-V. However, I think this
patch is light-fingered enough that it might be worth considering
absorbing into the upstream crate. Based on the age of similar bugs filed against
the Rust project, it may take some months or years even before this issue
gets properly addressed...