### PR TITLE
Updated deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,25 +33,25 @@ travis-ci = { repository = "dalek-cryptography/curve25519-dalek", branch = "mast
 [dev-dependencies]
 sha2 = { version = "0.9", default-features = false }
 bincode = "1"
-criterion = { version = "0.3.0", features = ["html_reports"] }
-hex = "0.4.2"
-rand = "0.7"
+criterion = { version = "0.3", features = ["html_reports"] }
+hex = "0.4"
+rand = "0.8"
 
 [[bench]]
 name = "dalek_benchmarks"
 harness = false
 
 [dependencies]
-rand_core = { version = "0.5", default-features = false }
-byteorder = { version = "^1.2.3", default-features = false, features = ["i128"] }
+rand_core = { version = "0.6", default-features = false }
+byteorder = { version = "1", default-features = false, features = ["i128"] }
 digest = { version = "0.9", default-features = false }
-subtle = { version = "^2.2.1", default-features = false }
+subtle = { version = "2", default-features = false }
 serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
 # The original packed_simd package was orphaned, see
 # https://github.com/rust-lang/packed_simd/issues/303#issuecomment-701361161
 packed_simd = { version = "0.3.4", package = "packed_simd_2", features = ["into_bits"], optional = true }
 zeroize = { version = "1", default-features = false }
-fiat-crypto = { version = "0.1.6", optional = true}
+fiat-crypto = { version = "0.1.8", optional = true}
 
 [features]
 nightly = ["subtle/nightly"]


### PR DESCRIPTION
**This requires a major version bump**, as it is a breaking change. Because `curve25519-dalek` exposes its `rand` dependency, if another crate previously used an `OsRng` from v0.7 to generate a scalar (which e.g. `ed25519-dalek` does), it would not compile anymore. This seemed awkward to me but it looks like `merlin` [does this too](https://github.com/zkcrypto/merlin/blob/main/CHANGELOG.md).

Notes on dependency updates:
* `byteorder = "1"` is the line that's used in byteorder's own [README](https://github.com/BurntSushi/byteorder/blob/master/README.md)
* `subtle` is semantic-versioned (check me on this)
* I didn't switch `fiat_crypto` to `0.1` because I have no idea how it's versioned. Thankfully it's bug-free by definition, so that's not an issue >.>
