### PR TITLE
Fix nightly docs

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -53,7 +53,7 @@ pub mod serial;
         feature = "simd_backend",
         any(target_feature = "avx2", target_feature = "avx512ifma")
     ),
-    all(feature = "nightly", rustdoc)
+    all(feature = "nightly", doc)
 ))]
 #[cfg_attr(
     feature = "nightly",

--- a/src/backend/vector/avx2/mod.rs
+++ b/src/backend/vector/avx2/mod.rs
@@ -11,7 +11,7 @@
 
 #![cfg_attr(
     feature = "nightly",
-    doc(include = "../../../../docs/avx2-notes.md")
+    doc = include_str!("../../../../docs/avx2-notes.md")
 )]
 
 pub(crate) mod field;

--- a/src/backend/vector/ifma/mod.rs
+++ b/src/backend/vector/ifma/mod.rs
@@ -9,7 +9,7 @@
 
 #![cfg_attr(
     feature = "nightly",
-    doc(include = "../../../../docs/ifma-notes.md")
+    doc = include_str!("../../../../docs/ifma-notes.md")
 )]
 
 pub mod field;

--- a/src/backend/vector/mod.rs
+++ b/src/backend/vector/mod.rs
@@ -12,27 +12,21 @@
 // Conditionally include the notes if we're on nightly (so we can include docs at all).
 #![cfg_attr(
     feature = "nightly",
-    doc(include = "../../../docs/parallel-formulas.md")
+    doc = include_str!("../../../docs/parallel-formulas.md")
 )]
 
-#[cfg(not(any(target_feature = "avx2", target_feature = "avx512ifma", rustdoc)))]
+#[cfg(not(any(target_feature = "avx2", target_feature = "avx512ifma", doc)))]
 compile_error!("simd_backend selected without target_feature=+avx2 or +avx512ifma");
 
-#[cfg(any(
-    all(target_feature = "avx2", not(target_feature = "avx512ifma")),
-    rustdoc
-))]
+#[cfg(any(all(target_feature = "avx2", not(target_feature = "avx512ifma")), doc))]
 #[doc(cfg(all(target_feature = "avx2", not(target_feature = "avx512ifma"))))]
 pub mod avx2;
-#[cfg(any(
-    all(target_feature = "avx2", not(target_feature = "avx512ifma")),
-    rustdoc
-))]
+#[cfg(any(all(target_feature = "avx2", not(target_feature = "avx512ifma")), doc))]
 pub(crate) use self::avx2::{
     constants::BASEPOINT_ODD_LOOKUP_TABLE, edwards::CachedPoint, edwards::ExtendedPoint,
 };
 
-#[cfg(any(target_feature = "avx512ifma", rustdoc))]
+#[cfg(any(target_feature = "avx512ifma", doc))]
 #[doc(cfg(target_feature = "avx512ifma"))]
 pub mod ifma;
 #[cfg(target_feature = "avx512ifma")]


### PR DESCRIPTION
Currently [doc-internal.dalek.rs/../backend](https://doc-internal.dalek.rs/curve25519_dalek/backend/index.html) does not display the vector implementation anymore, because `cfg(rustdoc)` got changed to `cfg(doc)` [citation needed].

![image](https://user-images.githubusercontent.com/1263440/136228465-17f2a251-970b-4c56-b258-4238036869e6.png)

This patch changes that. Relately, this changes `doc(include = "path")` to `doc = include_str!("path")`, which was suggested by my compiler. Possibly, this means that soon, `#![cfg_attr(feature = "nightly", feature(doc_cfg))]` can be dropped from `lib.rs`.

![image](https://user-images.githubusercontent.com/1263440/136229123-283fb526-9c83-4888-9d8a-3d310f21afee.png)

Compiled documentation available on https://nas.rubdos.be/~rsmet/curve25519-dalek/curve25519_dalek/