### PR TITLE
elliptic-curve trait implementations for `Scalar` and `RistrettoPoint`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -114,6 +114,21 @@ jobs:
       with:
         command: build
 
+  test-elliptic-curve:
+    name: Test default feature selection and elliptic-curve
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+    - uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --features "elliptic-curve"
+
   bench:
     name: Check that benchmarks compile
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ serde = { version = "1.0", default-features = false, optional = true, features =
 # The original packed_simd package was orphaned, see
 # https://github.com/rust-lang/packed_simd/issues/303#issuecomment-701361161
 packed_simd = { version = "0.3.4", package = "packed_simd_2", features = ["into_bits"], optional = true }
-zeroize = { version = "1", default-features = false }
+zeroize = { version = "=1.3.0", default-features = false }
 fiat-crypto = { version = "0.1.6", optional = true}
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,14 +35,14 @@ sha2 = { version = "0.9", default-features = false }
 bincode = "1"
 criterion = { version = "0.3.0", features = ["html_reports"] }
 hex = "0.4.2"
-rand = "0.7"
+rand = "0.8"
 
 [[bench]]
 name = "dalek_benchmarks"
 harness = false
 
 [dependencies]
-rand_core = { version = "0.5", default-features = false }
+rand_core = { version = "0.6", default-features = false }
 byteorder = { version = "^1.2.3", default-features = false, features = ["i128"] }
 digest = { version = "0.9", default-features = false }
 subtle = { version = "^2.2.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,12 +52,14 @@ serde = { version = "1.0", default-features = false, optional = true, features =
 packed_simd = { version = "0.3.4", package = "packed_simd_2", features = ["into_bits"], optional = true }
 zeroize = { version = "=1.3.0", default-features = false }
 fiat-crypto = { version = "0.1.6", optional = true}
+group = { version = "0.11", default-features = false, optional = true }
 
 [features]
 nightly = ["subtle/nightly"]
 default = ["std", "u64_backend"]
 std = ["alloc", "subtle/std", "rand_core/std"]
 alloc = ["zeroize/alloc"]
+elliptic-curve = ["group"]
 
 # The u32 backend uses u32s with u64 products.
 u32_backend = []

--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ builds using `--no-default-features`.  Note that this requires explicitly
 selecting an arithmetic backend using one of the `_backend` features.
 If no backend is selected, compilation will fail.
 
+The `elliptic-curve` feature can be enabled to implement traits from the
+[elliptic-curve][elliptic-curve_doc] for some types. Specifically `Field` and
+`PrimeField` for `Scalar` and `Group` and `GroupEncoding` for `RistrettoPoint`.
+
 # Safety
 
 The `curve25519-dalek` types are designed to make illegal states
@@ -224,3 +228,4 @@ contributions.
 [criterion]: https://github.com/japaric/criterion.rs
 [parallel_doc]: https://doc-internal.dalek.rs/curve25519_dalek/backend/vector/avx2/index.html
 [subtle_doc]: https://doc.dalek.rs/subtle/
+[elliptic-curve_doc]: https://docs.rs/elliptic-curve/

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,6 +123,13 @@
 //! builds using `--no-default-features`.  Note that this requires explicitly
 //! selecting an arithmetic backend using one of the `_backend` features.
 //! If no backend is selected, compilation will fail.
+//! 
+//! The `elliptic-curve` feature can be enabled to implement traits from the
+//! [elliptic-curve][elliptic-curve_doc] for some types. Specifically
+//! [`Field`](group::ff::Field) and [`PrimeField`](group::ff::PrimeField) for
+//! [`Scalar`](scalar::Scalar) and [`Group`](group::Group) and
+//! [`GroupEncoding`](group::GroupEncoding) for
+//! [`RistrettoPoint`](ristretto::RistrettoPoint).
 //!
 //! # Safety
 //!
@@ -245,6 +252,7 @@
 //! [criterion]: https://github.com/japaric/criterion.rs
 //! [parallel_doc]: https://doc-internal.dalek.rs/curve25519_dalek/backend/vector/avx2/index.html
 //! [subtle_doc]: https://doc.dalek.rs/subtle/
+//! [elliptic-curve_doc]: https://docs.rs/elliptic-curve/
 
 //------------------------------------------------------------------------
 // External dependencies:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -276,6 +276,8 @@ extern crate subtle;
 extern crate bincode;
 #[cfg(feature = "serde")]
 extern crate serde;
+#[cfg(feature = "elliptic-curve")]
+extern crate group;
 
 // Internal macros. Must come first!
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,13 +123,11 @@
 //! builds using `--no-default-features`.  Note that this requires explicitly
 //! selecting an arithmetic backend using one of the `_backend` features.
 //! If no backend is selected, compilation will fail.
-//! 
+//!
 //! The `elliptic-curve` feature can be enabled to implement traits from the
-//! [elliptic-curve][elliptic-curve_doc] for some types. Specifically
-//! [`Field`](group::ff::Field) and [`PrimeField`](group::ff::PrimeField) for
-//! [`Scalar`](scalar::Scalar) and [`Group`](group::Group) and
-//! [`GroupEncoding`](group::GroupEncoding) for
-//! [`RistrettoPoint`](ristretto::RistrettoPoint).
+//! [elliptic-curve][elliptic-curve_doc] for some types. Specifically `Field`
+//! and `PrimeField` for `Scalar` and `Group` and `GroupEncoding` for
+//! `RistrettoPoint`.
 //!
 //! # Safety
 //!

--- a/src/ristretto.rs
+++ b/src/ristretto.rs
@@ -1438,4 +1438,23 @@ mod test {
         assert_eq!(P.compress(), R.compress());
         assert_eq!(Q.compress(), R.compress());
     }
+
+    #[cfg(feature = "elliptic-curve")]
+    #[test]
+    fn test_group_encoding_invalid() {
+        use group::GroupEncoding;
+
+        assert!(bool::from(RistrettoPoint::from_bytes(&constants::EDWARDS_D.to_bytes().into()).is_none()));
+    }
+
+    #[cfg(feature = "elliptic-curve")]
+    #[test]
+    fn test_group_encoding_round_trip() {
+        use group::GroupEncoding;
+
+        let mut rng = rand::thread_rng();
+        let point = RistrettoPoint::random(&mut rng);
+
+        assert_eq!(RistrettoPoint::from_bytes(&point.to_bytes()).unwrap(), point);
+    }
 }

--- a/src/ristretto.rs
+++ b/src/ristretto.rs
@@ -1136,9 +1136,6 @@ impl group::GroupEncoding for RistrettoPoint {
     type Repr = GenericArray<u8, U32>;
 
     /// Attempts to deserialize a group element from its encoding.
-    /// 
-    /// # Warning
-    /// Despite the return type this isn't constant-time.
     fn from_bytes(bytes: &Self::Repr) -> subtle::CtOption<Self> {
         let result = CompressedRistretto::from_slice(bytes).decompress();
         let choice = (result.is_some() as u8).into();

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -1828,4 +1828,37 @@ mod test {
             test_pippenger_radix_iter(scalar, 8);
         }
     }
+
+    #[cfg(feature = "elliptic-curve")]
+    #[test]
+    fn test_prime_field_valid() {
+        use group::ff::PrimeField;
+
+        assert!(bool::from(Scalar::from_repr([0xff; 32].into()).is_none()));
+        assert!(bool::from(Scalar::from_repr([0x7f; 32].into()).is_none()));
+        assert!(bool::from(Scalar::from_repr([0x7e; 32].into()).is_some()));
+    }
+
+    #[cfg(feature = "elliptic-curve")]
+    #[test]
+    fn test_prime_field_repr_round_trip() {
+        use group::ff::PrimeField;
+
+        let mut rng = rand::thread_rng();
+        let scalar = Scalar::random(&mut rng);
+
+        assert_eq!(Scalar::from_repr(scalar.to_repr()).unwrap(), scalar);
+    }
+
+    #[cfg(feature = "elliptic-curve")]
+    #[test]
+    fn test_field_invert() {
+        use group::ff::Field;
+
+        let mut rng = rand::thread_rng();
+        let scalar = Scalar::random(&mut rng);
+
+        assert!(bool::from(Field::invert(&scalar).is_some()));
+        assert!(bool::from(Field::invert(&Scalar::zero()).is_none()));
+    }
 }

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -597,9 +597,9 @@ impl group::ff::PrimeField for Scalar {
         self.bytes[0].ct_eq(&1)
     }
 
-    const NUM_BITS: u32 = 256;
+    const NUM_BITS: u32 = 253;
 
-    const CAPACITY: u32 = 255;
+    const CAPACITY: u32 = Self::NUM_BITS - 1;
 
     fn multiplicative_generator() -> Self {
         7_u8.into()


### PR DESCRIPTION
This implements `Field` and `PrimeField` for `Scalar` and `Group` and `GroupEncoding` for `RistrettoPoint`.
I'm no cryptographer, so additional attention is appreciated when reviewing this.

To support the latest version of elliptic-curve, an update to rand 0.8 was necessary, I'm unsure what the dependency update policy is for this crate.

Fixes #373.