### PR TITLE
Use ok_or_else instead of ok_or in serde decoding

### DIFF
--- a/src/edwards.rs
+++ b/src/edwards.rs
@@ -274,11 +274,11 @@ impl<'de> Deserialize<'de> for EdwardsPoint {
                 for i in 0..32 {
                     bytes[i] = seq
                         .next_element()?
-                        .ok_or(serde::de::Error::invalid_length(i, &"expected 32 bytes"))?;
+                        .ok_or_else(|| serde::de::Error::invalid_length(i, &"expected 32 bytes"))?;
                 }
                 CompressedEdwardsY(bytes)
                     .decompress()
-                    .ok_or(serde::de::Error::custom("decompression failed"))
+                    .ok_or_else(|| serde::de::Error::custom("decompression failed"))
             }
         }
 
@@ -309,7 +309,7 @@ impl<'de> Deserialize<'de> for CompressedEdwardsY {
                 for i in 0..32 {
                     bytes[i] = seq
                         .next_element()?
-                        .ok_or(serde::de::Error::invalid_length(i, &"expected 32 bytes"))?;
+                        .ok_or_else(|| serde::de::Error::invalid_length(i, &"expected 32 bytes"))?;
                 }
                 Ok(CompressedEdwardsY(bytes))
             }

--- a/src/ristretto.rs
+++ b/src/ristretto.rs
@@ -400,11 +400,11 @@ impl<'de> Deserialize<'de> for RistrettoPoint {
                 for i in 0..32 {
                     bytes[i] = seq
                         .next_element()?
-                        .ok_or(serde::de::Error::invalid_length(i, &"expected 32 bytes"))?;
+                        .ok_or_else(|| serde::de::Error::invalid_length(i, &"expected 32 bytes"))?;
                 }
                 CompressedRistretto(bytes)
                     .decompress()
-                    .ok_or(serde::de::Error::custom("decompression failed"))
+                    .ok_or_else(|| serde::de::Error::custom("decompression failed"))
             }
         }
 
@@ -435,7 +435,7 @@ impl<'de> Deserialize<'de> for CompressedRistretto {
                 for i in 0..32 {
                     bytes[i] = seq
                         .next_element()?
-                        .ok_or(serde::de::Error::invalid_length(i, &"expected 32 bytes"))?;
+                        .ok_or_else(|| serde::de::Error::invalid_length(i, &"expected 32 bytes"))?;
                 }
                 Ok(CompressedRistretto(bytes))
             }

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -448,7 +448,7 @@ impl<'de> Deserialize<'de> for Scalar {
                 for i in 0..32 {
                     bytes[i] = seq
                         .next_element()?
-                        .ok_or(serde::de::Error::invalid_length(i, &"expected 32 bytes"))?;
+                        .ok_or_else(|| serde::de::Error::invalid_length(i, &"expected 32 bytes"))?;
                 }
                 Option::from(Scalar::from_canonical_bytes(bytes))
                     .ok_or_else(|| serde::de::Error::custom(&"scalar was not canonically encoded"))


### PR DESCRIPTION
Serde errors are not simple enums; they format a full error string from their arguments. It's worth not doing that up front.