### PR TITLE
Relax Rng trait bounds to allow `?Sized` Rngs

### DIFF
--- a/src/ristretto.rs
+++ b/src/ristretto.rs
@@ -651,7 +651,7 @@ impl RistrettoPoint {
     /// discrete log of the output point with respect to any other
     /// point should be unknown.  The map is applied twice and the
     /// results are added, to ensure a uniform distribution.
-    pub fn random<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
+    pub fn random<R: RngCore + CryptoRng + ?Sized>(rng: &mut R) -> Self {
         let mut uniform_bytes = [0u8; 64];
         rng.fill_bytes(&mut uniform_bytes);
 

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -565,7 +565,7 @@ impl Scalar {
     /// let mut csprng = OsRng;
     /// let a: Scalar = Scalar::random(&mut csprng);
     /// # }
-    pub fn random<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
+    pub fn random<R: RngCore + CryptoRng + ?Sized>(rng: &mut R) -> Self {
         let mut scalar_bytes = [0u8; 64];
         rng.fill_bytes(&mut scalar_bytes);
         Scalar::from_bytes_mod_order_wide(&scalar_bytes)


### PR DESCRIPTION
This allows the code to compile if you pass it `&mut dyn RngType`,
since trait objects are unsized.

See here for an example of caller code that is simplified by this
change:

https://github.com/mobilecoinfoundation/mobilecoin/pull/1977#discussion_r872906913