### PR TITLE
Update zeroize and MSRV accordingly

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -101,14 +101,14 @@ jobs:
         args: --features "nightly"
 
   msrv:
-    name: Current MSRV is 1.41
+    name: Current MSRV is 1.51
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: 1.41
+        toolchain: 1.51
         override: true
     - uses: actions-rs/cargo@v1
       with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ name = "curve25519-dalek"
 # - update html_root_url
 # - update README if required by semver
 # - if README was updated, also update module documentation in src/lib.rs
-version = "4.0.0-pre.2"
+version = "4.0.0-pre.3"
 authors = ["Isis Lovecruft <isis@patternsinthevoid.net>",
            "Henry de Valence <hdevalence@hdevalence.ca>"]
 readme = "README.md"
@@ -50,7 +50,7 @@ serde = { version = "1.0", default-features = false, optional = true, features =
 # The original packed_simd package was orphaned, see
 # https://github.com/rust-lang/packed_simd/issues/303#issuecomment-701361161
 packed_simd = { version = "0.3.4", package = "packed_simd_2", features = ["into_bits"], optional = true }
-zeroize = { version = ">=1, <1.4", default-features = false }
+zeroize = { version = "1", default-features = false }
 fiat-crypto = { version = "0.1.6", optional = true}
 
 [features]


### PR DESCRIPTION
Turns out similar to #386, but updates other relevant things.

I need this because it causes issues deep in the dependencies, my chain looks like this:
```
my-crate -> substrate -> libp2p -> snow -> curve25519-dalek
```

So this crate deep in dependency tree causes too many issues. I think bumping it in pre-release will not cause any issues for anyone in the ecosystem.

Closes #386, fixes #387