### PR TITLE
Add to_raw/from_raw for objects to allow external use with FFI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,3 +72,6 @@ simd_backend = ["nightly", "u64_backend", "packed_simd"]
 # DEPRECATED: this is now an alias for `simd_backend` and may be removed
 # in some future release.
 avx2_backend = ["simd_backend"]
+
+# Expose unstable internals, may be required for FFI use
+yolo_crypto = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ fiat-crypto = { version = "0.1.6", optional = true}
 
 [features]
 nightly = ["subtle/nightly"]
-default = ["std", "u64_backend"]
+default = ["std", "u64_backend", "basepoint_tables"]
 std = ["alloc", "subtle/std", "rand_core/std"]
 alloc = ["zeroize/alloc"]
 
@@ -75,3 +75,5 @@ avx2_backend = ["simd_backend"]
 
 # Expose unstable internals, may be required for FFI use
 yolo_crypto = []
+
+basepoint_tables = []

--- a/src/backend/serial/u32/constants.rs
+++ b/src/backend/serial/u32/constants.rs
@@ -231,10 +231,12 @@ pub const EIGHT_TORSION_INNER_DOC_HIDDEN: [EdwardsPoint; 8] = [
 ];
 
 /// Table containing precomputed multiples of the Ed25519 basepoint \\(B = (x, 4/5)\\).
+#[cfg(feature="basepoint_tables")]
 pub const ED25519_BASEPOINT_TABLE: EdwardsBasepointTable = ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN;
 
 /// Inner constant, used to avoid filling the docs with precomputed points.
 #[doc(hidden)]
+#[cfg(feature="basepoint_tables")]
 pub const ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable =
     EdwardsBasepointTable([
         LookupTable([

--- a/src/backend/serial/u64/constants.rs
+++ b/src/backend/serial/u64/constants.rs
@@ -321,10 +321,12 @@ pub const EIGHT_TORSION_INNER_DOC_HIDDEN: [EdwardsPoint; 8] = [
 ];
 
 /// Table containing precomputed multiples of the Ed25519 basepoint \\(B = (x, 4/5)\\).
+#[cfg(feature="basepoint_tables")]
 pub const ED25519_BASEPOINT_TABLE: EdwardsBasepointTable = ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN;
 
 /// Inner constant, used to avoid filling the docs with precomputed points.
 #[doc(hidden)]
+#[cfg(feature="basepoint_tables")]
 pub const ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable =
     EdwardsBasepointTable([
         LookupTable([

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -90,6 +90,7 @@ pub const BASEPOINT_ORDER: Scalar = Scalar{
 
 use ristretto::RistrettoBasepointTable;
 /// The Ristretto basepoint, as a `RistrettoBasepointTable` for scalar multiplication.
+#[cfg(feature="basepoint_tables")]
 pub const RISTRETTO_BASEPOINT_TABLE: RistrettoBasepointTable
     = RistrettoBasepointTable(ED25519_BASEPOINT_TABLE);
 

--- a/src/edwards.rs
+++ b/src/edwards.rs
@@ -326,6 +326,41 @@ pub struct EdwardsPoint {
     pub(crate) T: FieldElement,
 }
 
+#[cfg(feature = "yolo_crypto")]
+impl EdwardsPoint {
+
+    #[cfg(feature = "u32_backend")]
+    /// Construct an [`EdwardsPoint`] from raw (X, Y, Z, T) [u32; 10] parts, 
+    /// provided for FFI object compatibility
+    /// 
+    /// NOTE THAT BIT REPRESENTATIONS ARE NOT STABLE 
+    /// AND SHOULD NOT BE USED OUTSIDE THIS LIBRARY
+    pub unsafe fn try_from_raw_u32(x: [u32; 10], y: [u32; 10], z: [u32; 10], t: [u32; 10]) -> Result<Self, ()> {
+        let s = Self{
+            X: FieldElement{ 0: x },
+            Y: FieldElement{ 0: y },
+            Z: FieldElement{ 0: z },
+            T: FieldElement{ 0: t },
+        };
+        
+        // TODO(@isislovecruft): could we have useful safety checks here?
+        // TODO: also there's probably room to refactor the backends to be consty now?
+        let _ = &s;
+        
+        Ok(s)
+    }
+
+    #[cfg(feature = "u32_backend")]
+    /// Copy raw (X, Y, Z, T) [u32; 10] parts from edwards point, 
+    /// provided for FFI object compatibility
+    /// 
+    /// NOTE THAT BIT REPRESENTATIONS ARE NOT STABLE 
+    /// AND SHOULD NOT BE USED OUTSIDE THIS LIBRARY
+    pub unsafe fn to_raw_u32(&self) -> ([u32; 10], [u32; 10], [u32; 10], [u32; 10]) {
+        (self.X.0, self.Y.0, self.Z.0, self.T.0)
+    }
+}
+
 // ------------------------------------------------------------------------
 // Constructors
 // ------------------------------------------------------------------------

--- a/src/field.rs
+++ b/src/field.rs
@@ -44,9 +44,9 @@ pub use backend::serial::fiat_u64::field::*;
 /// implementations.
 /// Using formally-verified field arithmetic from fiat-crypto
 #[cfg(feature = "fiat_u32_backend")]
-pub type FieldElement = backend::serial::fiat_u32::field::FieldElement2625;
+pub use backend::serial::fiat_u32::field::{FieldElement2625 as FieldElement};
 #[cfg(feature = "fiat_u64_backend")]
-pub type FieldElement = backend::serial::fiat_u64::field::FieldElement51;
+pub use backend::serial::fiat_u64::field::{FieldElement51 as FieldElement};
 
 #[cfg(feature = "u64_backend")]
 pub use backend::serial::u64::field::*;
@@ -56,7 +56,7 @@ pub use backend::serial::u64::field::*;
 /// The `FieldElement` type is an alias for one of the platform-specific
 /// implementations.
 #[cfg(feature = "u64_backend")]
-pub type FieldElement = backend::serial::u64::field::FieldElement51;
+pub use backend::serial::u64::field::{FieldElement51 as FieldElement};
 
 #[cfg(feature = "u32_backend")]
 pub use backend::serial::u32::field::*;
@@ -66,7 +66,7 @@ pub use backend::serial::u32::field::*;
 /// The `FieldElement` type is an alias for one of the platform-specific
 /// implementations.
 #[cfg(feature = "u32_backend")]
-pub type FieldElement = backend::serial::u32::field::FieldElement2625;
+pub use backend::serial::u32::field::{FieldElement2625 as FieldElement};
 
 impl Eq for FieldElement {}
 
@@ -82,6 +82,27 @@ impl ConstantTimeEq for FieldElement {
     /// are normalized to wire format before comparison.
     fn ct_eq(&self, other: &FieldElement) -> Choice {
         self.to_bytes().ct_eq(&other.to_bytes())
+    }
+}
+
+#[cfg(feature = "yolo_crypto")]
+impl FieldElement {
+    /// Create a FieldElement from a raw u32 limb.
+    /// 
+    /// NOTE THAT BIT REPRESENTATIONS ARE NOT STABLE 
+    /// AND SHOULD NOT BE USED OUTSIDE THIS LIBRARY
+    #[cfg(feature = "u32_backend")]
+    pub const fn from_raw_u32(raw: [u32; 10]) -> Self {
+        Self(raw)
+    }
+
+    /// Create a FieldElement from a raw u32 limb
+    /// 
+    /// NOTE THAT BIT REPRESENTATIONS ARE NOT STABLE 
+    /// AND SHOULD NOT BE USED OUTSIDE THIS LIBRARY
+    #[cfg(feature = "u32_backend")]
+    pub const fn to_raw_u32(&self) -> [u32; 10] {
+        self.0
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -303,12 +303,17 @@ pub mod constants;
 // External (and internal) traits.
 pub mod traits;
 
+// Finite field arithmetic mod p = 2^255 - 19
+#[cfg(feature = "yolo_crypto")]
+pub mod field;
+
+#[cfg(not(feature = "yolo_crypto"))]
+mod field;
+
+
 //------------------------------------------------------------------------
 // curve25519-dalek internal modules
 //------------------------------------------------------------------------
-
-// Finite field arithmetic mod p = 2^255 - 19
-pub(crate) mod field;
 
 // Arithmetic backends (using u32, u64, etc) live here
 pub(crate) mod backend;

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -262,6 +262,30 @@ impl Scalar {
     }
 }
 
+#[cfg(feature="yolo_crypto")]
+impl Scalar {
+    /// Construct a `Scalar` from an unpacked [u32; 9] array, 
+    /// provided for FFI object compatibility
+    /// 
+    /// NOTE THAT BIT REPRESENTATIONS ARE NOT STABLE 
+    /// AND SHOULD NOT BE USED OUTSIDE THIS LIBRARY
+    #[cfg(feature = "u32_backend")]
+    pub unsafe fn from_unpacked_u32(unpacked: [u32; 9]) -> Scalar {
+        use backend::serial::u32::scalar::Scalar29;
+        Scalar29(unpacked).pack()
+    }
+
+    /// Export unpacked [u32; 9] array from a `Scalar`, 
+    /// provided for FFI object compatibility
+    /// 
+    /// NOTE THAT BIT REPRESENTATIONS ARE NOT STABLE 
+    /// AND SHOULD NOT BE USED OUTSIDE THIS LIBRARY
+    #[cfg(feature = "u32_backend")]
+    pub unsafe fn to_unpacked_u32(&self) -> [u32; 9] {
+        self.unpack().0
+    }
+}
+
 impl Debug for Scalar {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         write!(f, "Scalar{{\n\tbytes: {:?},\n}}", &self.bytes)


### PR DESCRIPTION
hi folks, thanks for all your effort in building / maintaining such excellent cryptographic libraries ^_^

i'm working on replacing a bunch of c cryptography APIs with dalek via FFI, implemented as a third party crate (as suggested in the [readme](https://github.com/dalek-cryptography/curve25519-dalek#ffi)), however, **to actually use this with FFI one requires byte and word oriented methods for constructing and destructing dalek objects so these can be passed around in C between calls to the dalek libraries.**

this PR adds methods to convert to basic FFI compatible types (mostly arrays) for the `u32_backend`, as well as exporting a couple of previously internal methods and swapping the backends from type aliases to re-exports to allow access to constructors etc., all behind the `yolo_crypto` feature.

cc. @isislovecruft 