### PR TITLE
add feature for enabling/disabling inclusion of basepoint tables

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ fiat-crypto = { version = "0.1.6", optional = true}
 
 [features]
 nightly = ["subtle/nightly"]
-default = ["std", "u64_backend"]
+default = ["std", "u64_backend", "basepoint_tables"]
 std = ["alloc", "subtle/std", "rand_core/std"]
 alloc = ["zeroize/alloc"]
 
@@ -72,3 +72,5 @@ simd_backend = ["nightly", "u64_backend", "packed_simd"]
 # DEPRECATED: this is now an alias for `simd_backend` and may be removed
 # in some future release.
 avx2_backend = ["simd_backend"]
+# Enable use of basepoint tables for accelerated operations
+basepoint_tables = []

--- a/src/backend/serial/u32/constants.rs
+++ b/src/backend/serial/u32/constants.rs
@@ -231,10 +231,12 @@ pub const EIGHT_TORSION_INNER_DOC_HIDDEN: [EdwardsPoint; 8] = [
 ];
 
 /// Table containing precomputed multiples of the Ed25519 basepoint \\(B = (x, 4/5)\\).
+#[cfg(feature="basepoint_tables")]
 pub const ED25519_BASEPOINT_TABLE: EdwardsBasepointTable = ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN;
 
 /// Inner constant, used to avoid filling the docs with precomputed points.
 #[doc(hidden)]
+#[cfg(feature="basepoint_tables")]
 pub const ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable =
     EdwardsBasepointTable([
         LookupTable([

--- a/src/backend/serial/u64/constants.rs
+++ b/src/backend/serial/u64/constants.rs
@@ -321,10 +321,12 @@ pub const EIGHT_TORSION_INNER_DOC_HIDDEN: [EdwardsPoint; 8] = [
 ];
 
 /// Table containing precomputed multiples of the Ed25519 basepoint \\(B = (x, 4/5)\\).
+#[cfg(feature="basepoint_tables")]
 pub const ED25519_BASEPOINT_TABLE: EdwardsBasepointTable = ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN;
 
 /// Inner constant, used to avoid filling the docs with precomputed points.
 #[doc(hidden)]
+#[cfg(feature="basepoint_tables")]
 pub const ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable =
     EdwardsBasepointTable([
         LookupTable([

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -90,6 +90,7 @@ pub const BASEPOINT_ORDER: Scalar = Scalar{
 
 use ristretto::RistrettoBasepointTable;
 /// The Ristretto basepoint, as a `RistrettoBasepointTable` for scalar multiplication.
+#[cfg(feature="basepoint_tables")]
 pub const RISTRETTO_BASEPOINT_TABLE: RistrettoBasepointTable
     = RistrettoBasepointTable(ED25519_BASEPOINT_TABLE);
 


### PR DESCRIPTION
allows basepoint tables to be excluded to reduce flash usage on embedded devices.

this should have no impact on most users, but will require adding `features = [ "basepoint_tables" ]` for any folks with `default_features=false`.

cc. @isislovecruft 