### PR TITLE
Update Dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ serde = { version = "1.0", default-features = false, optional = true, features =
 # The original packed_simd package was orphaned, see
 # https://github.com/rust-lang/packed_simd/issues/303#issuecomment-701361161
 packed_simd = { version = "0.3.4", package = "packed_simd_2", features = ["into_bits"], optional = true }
-zeroize = { version = ">=1, <1.4", default-features = false }
+zeroize = { version = "1", default-features = false }
 fiat-crypto = { version = "0.1.6", optional = true}
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ features = ["nightly", "simd_backend"]
 travis-ci = { repository = "dalek-cryptography/curve25519-dalek", branch = "master"}
 
 [dev-dependencies]
-sha2 = { version = "0.9", default-features = false }
+sha2 = { version = "0.10.2", default-features = false }
 bincode = "1"
 criterion = { version = "0.3.0", features = ["html_reports"] }
 hex = "0.4.2"
@@ -44,7 +44,7 @@ harness = false
 [dependencies]
 rand_core = { version = "0.5", default-features = false }
 byteorder = { version = "^1.2.3", default-features = false, features = ["i128"] }
-digest = { version = "0.9", default-features = false }
+digest = { version = "0.10.3", default-features = false }
 subtle = { version = "^2.2.1", default-features = false }
 serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
 # The original packed_simd package was orphaned, see

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,14 +35,14 @@ sha2 = { version = "0.10.2", default-features = false }
 bincode = "1"
 criterion = { version = "0.3.0", features = ["html_reports"] }
 hex = "0.4.2"
-rand = "0.7"
+rand = "0.8.5"
 
 [[bench]]
 name = "dalek_benchmarks"
 harness = false
 
 [dependencies]
-rand_core = { version = "0.5", default-features = false }
+rand_core = { version = "0.6.3", default-features = false }
 byteorder = { version = "^1.2.3", default-features = false, features = ["i128"] }
 digest = { version = "0.10.3", default-features = false }
 subtle = { version = "^2.2.1", default-features = false }

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -613,6 +613,7 @@ impl Scalar {
     /// ```
     /// # extern crate curve25519_dalek;
     /// # use curve25519_dalek::scalar::Scalar;
+    /// # use curve25519_dalek::digest::Update;
     /// extern crate sha2;
     ///
     /// use sha2::Digest;


### PR DESCRIPTION
In particular, we're having problems with dependency trees in the reference implementation for the wasi-crypto specification.