### PR TITLE
Expose function for directly encoding bytes to curve, without hashing.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ serde = { version = "1.0", default-features = false, optional = true, features =
 # The original packed_simd package was orphaned, see
 # https://github.com/rust-lang/packed_simd/issues/303#issuecomment-701361161
 packed_simd = { version = "0.3.4", package = "packed_simd_2", features = ["into_bits"], optional = true }
-zeroize = { version = ">=1, <1.4", default-features = false }
+zeroize = { version = ">=1, <=1.5.5", default-features = false }
 fiat-crypto = { version = "0.1.6", optional = true}
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
-name = "curve25519-dalek"
+name = "curve25519-entropic"
 # Before incrementing:
 # - update CHANGELOG
 # - update html_root_url
 # - update README if required by semver
 # - if README was updated, also update module documentation in src/lib.rs
-version = "3.2.0"
+version = "3.2.1"
 authors = ["Isis Lovecruft <isis@patternsinthevoid.net>",
-           "Henry de Valence <hdevalence@hdevalence.ca>"]
+           "Henry de Valence <hdevalence@hdevalence.ca>",
+           "Amit Prasad <mail@amitprasad.dev>"]
 readme = "README.md"
 license = "BSD-3-Clause"
 repository = "https://github.com/dalek-cryptography/curve25519-dalek"
@@ -27,8 +28,8 @@ exclude = [
 # rustdoc-args = ["--html-in-header", ".cargo/registry/src/github.com-1ecc6299db9ec823/curve25519-dalek-0.13.2/rustdoc-include-katex-header.html"]
 features = ["nightly", "simd_backend"]
 
-[badges]
-travis-ci = { repository = "dalek-cryptography/curve25519-dalek", branch = "master"}
+# [badges]
+# travis-ci = { repository = "dalek-cryptography/curve25519-dalek", branch = "master"}
 
 [dev-dependencies]
 sha2 = { version = "0.9", default-features = false }

--- a/src/edwards.rs
+++ b/src/edwards.rs
@@ -175,6 +175,12 @@ impl Debug for CompressedEdwardsY {
     }
 }
 
+impl AsRef<[u8]> for CompressedEdwardsY {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
 impl CompressedEdwardsY {
     /// View this `CompressedEdwardsY` as an array of bytes.
     pub fn as_bytes(&self) -> &[u8; 32] {
@@ -551,12 +557,12 @@ impl EdwardsPoint {
             .mul_by_cofactor()
     }
 
-    /// Expose elligator encoding bytes to the group
+    /// Directly encode bytes to the curve. Same as [`hash_from_bytes`], without hashing.
     pub fn bytes_to_curve(bytes: &[u8; 32]) -> EdwardsPoint
     {
         let sign_bit = (bytes[31] & 0x80) >> 7;
 
-        let fe = FieldElement::from_bytes(&bytes);
+        let fe = FieldElement::from_bytes(bytes);
 
         let M1 = crate::montgomery::elligator_encode(&fe);
         let E1_opt = M1.to_edwards(sign_bit);

--- a/src/edwards.rs
+++ b/src/edwards.rs
@@ -550,6 +550,21 @@ impl EdwardsPoint {
             .expect("Montgomery conversion to Edwards point in Elligator failed")
             .mul_by_cofactor()
     }
+
+    /// Expose elligator encoding bytes to the group
+    pub fn bytes_to_curve(bytes: &[u8; 32]) -> EdwardsPoint
+    {
+        let sign_bit = (bytes[31] & 0x80) >> 7;
+
+        let fe = FieldElement::from_bytes(&bytes);
+
+        let M1 = crate::montgomery::elligator_encode(&fe);
+        let E1_opt = M1.to_edwards(sign_bit);
+
+        E1_opt
+            .expect("Montgomery conversion to Edwards point in Elligator failed")
+            .mul_by_cofactor()
+    }
 }
 
 // ------------------------------------------------------------------------


### PR DESCRIPTION
This PR:
* Adds a `bytes_to_curve` method that allows one to encode arbitrary bytes to the Edwards curve. This function is identical to `hash_from_bytes`, without the hashing.
* For convinience, exposes an `AsRef<[u8]>` implementation for `CompressedEdwardsY`.
* Relaxes `zeroize` dependency to allow newer versions, as the existing version was outdated & incompatible with some newer libraries, for some reason.