### PR TITLE
Implement missing traits to allow Scalar to be used as generic type for polynomial::Polynomial

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,6 @@ packed_simd = { version = "0.3.4", package = "packed_simd_2", features = ["into_
 zeroize = { version = ">=1, <1.4", default-features = false }
 fiat-crypto = { version = "0.1.6", optional = true}
 num-traits = "0.2"
-bitvec = "1.0.1"
 
 [features]
 nightly = ["subtle/nightly"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ serde = { version = "1.0", default-features = false, optional = true, features =
 packed_simd = { version = "0.3.4", package = "packed_simd_2", features = ["into_bits"], optional = true }
 zeroize = { version = ">=1, <1.4", default-features = false }
 fiat-crypto = { version = "0.1.6", optional = true}
+num-traits = "0.2"
 
 [features]
 nightly = ["subtle/nightly"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ packed_simd = { version = "0.3.4", package = "packed_simd_2", features = ["into_
 zeroize = { version = ">=1, <1.4", default-features = false }
 fiat-crypto = { version = "0.1.6", optional = true}
 num-traits = "0.2"
+hex = "0.4.3"
 
 [features]
 nightly = ["subtle/nightly"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ packed_simd = { version = "0.3.4", package = "packed_simd_2", features = ["into_
 zeroize = { version = ">=1, <1.4", default-features = false }
 fiat-crypto = { version = "0.1.6", optional = true}
 num-traits = "0.2"
+bitvec = "1.0.1"
 
 [features]
 nightly = ["subtle/nightly"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,6 +264,7 @@ extern crate packed_simd;
 extern crate byteorder;
 pub extern crate digest;
 extern crate rand_core;
+extern crate num_traits;
 extern crate zeroize;
 
 #[cfg(any(feature = "fiat_u64_backend", feature = "fiat_u32_backend"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,7 +265,6 @@ extern crate byteorder;
 pub extern crate digest;
 extern crate rand_core;
 extern crate num_traits;
-extern crate bitvec;
 extern crate zeroize;
 
 #[cfg(any(feature = "fiat_u64_backend", feature = "fiat_u32_backend"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,6 +265,7 @@ extern crate byteorder;
 pub extern crate digest;
 extern crate rand_core;
 extern crate num_traits;
+extern crate bitvec;
 extern crate zeroize;
 
 #[cfg(any(feature = "fiat_u64_backend", feature = "fiat_u32_backend"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,7 +274,8 @@ extern crate fiat_crypto;
 // Used for traits related to constant-time code.
 extern crate subtle;
 
-#[cfg(all(test, feature = "serde"))]extern crate bincode;
+#[cfg(all(test, feature = "serde"))]
+extern crate bincode;
 #[cfg(feature = "serde")]
 extern crate serde;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,6 +266,7 @@ pub extern crate digest;
 extern crate rand_core;
 extern crate num_traits;
 extern crate zeroize;
+extern crate hex;
 
 #[cfg(any(feature = "fiat_u64_backend", feature = "fiat_u32_backend"))]
 extern crate fiat_crypto;
@@ -273,8 +274,7 @@ extern crate fiat_crypto;
 // Used for traits related to constant-time code.
 extern crate subtle;
 
-#[cfg(all(test, feature = "serde"))]
-extern crate bincode;
+#[cfg(all(test, feature = "serde"))]extern crate bincode;
 #[cfg(feature = "serde")]
 extern crate serde;
 

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -311,9 +311,9 @@ impl One for Scalar {
     }
 }
 
-impl<'b> Div<&'b Scalar> for Scalar {
+impl Div<Scalar> for Scalar {
     type Output = Scalar;
-    fn div(self, q: &Scalar) -> Self::Output {
+    fn div(self, q: Scalar) -> Self::Output {
 	Scalar::one()
     }
 }

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -272,9 +272,8 @@ impl Debug for Scalar {
 
 impl Display for Scalar {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-	for byte in self.as_bytes() {
-            write!(f, "{:#02x}", byte)?;
-	}
+	let data = hex::encode(self.bytes);
+        write!(f, "{}", data)?;
 	Ok(())
     }
 }

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -138,7 +138,6 @@
 //!
 //! The resulting `Scalar` has exactly the specified bit pattern,
 //! **except for the highest bit, which will be set to 0**.
-
 use core::borrow::Borrow;
 use core::cmp::{Eq, PartialEq};
 use core::fmt::Debug;
@@ -151,6 +150,7 @@ use core::ops::{Sub, SubAssign};
 use core::ops::{Div, DivAssign};
 
 use::num_traits::{Zero, One};
+use bitvec::prelude::*;
 
 #[allow(unused_imports)]
 use prelude::*;
@@ -311,10 +311,39 @@ impl One for Scalar {
     }
 }
 
+fn square_and_multiply(x: Scalar, n: Scalar) -> Scalar {
+    let mut ret = Scalar::zero();
+
+    let mut bitvec: Vec<bool> = Vec::new();
+    for byte in n.as_bytes() {
+        let bits = byte.view_bits::<Lsb0>();
+        for bit in bits {
+            bitvec.push(*bit);
+        }
+    }
+    //println!("{:?}", bitvec);
+    let mut square = x;
+    //for (i,bit) in bitvec.iter().enumerate() {
+    for bit in bitvec {
+        //println!("bit {} square is {:?}", i, square);                                                                  
+        if bit {
+            //println!("bit {} is {}", i, *bit);                                                                         
+            //let old = ret;
+            ret += square;
+            //println!("{:?} +\n{:?} =\n{:?}", old.as_bytes(), square.as_bytes(), ret.as_bytes());                       
+        }
+        square *= square;
+    }
+    //println!("{:?}", square);                                                                                          
+    ret
+}
+
 impl Div<Scalar> for Scalar {
     type Output = Scalar;
     fn div(self, q: Scalar) -> Self::Output {
-	Scalar::one()
+	let q1 = square_and_multiply(q, constants::BASEPOINT_ORDER - Scalar::from(2 as u8));
+	println!("inverse of {:?} is {:?}", q, q1);
+	self * q1
     }
 }
 

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -148,6 +148,7 @@ use core::ops::Neg;
 use core::ops::{Add, AddAssign};
 use core::ops::{Mul, MulAssign};
 use core::ops::{Sub, SubAssign};
+use core::ops::{Div, DivAssign};
 
 use::num_traits::{Zero, One};
 
@@ -307,6 +308,13 @@ impl One for Scalar {
     }
     fn is_one(&self) -> bool {
 	self == &Scalar::one()
+    }
+}
+
+impl<'b> Div<&'b Scalar> for Scalar {
+    type Output = Scalar;
+    fn div(self, q: &Scalar) -> Self::Output {
+	Scalar::one()
     }
 }
 

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -150,7 +150,7 @@ use core::ops::{Sub, SubAssign};
 use core::ops::{Div, DivAssign};
 
 use::num_traits::{Zero, One};
-use bitvec::prelude::*;
+//use bitvec::prelude::*;
 
 #[allow(unused_imports)]
 use prelude::*;
@@ -263,12 +263,6 @@ impl Scalar {
 
         s
     }
-
-    /// Find the inverse module the group order of the passed scalar
-    pub fn inverse(&self) -> Self {
-	let exp = constants::BASEPOINT_ORDER - Scalar::from(2 as u8);
-	square_and_multiply(self, &exp)
-    }
 }
 
 impl Debug for Scalar {
@@ -317,37 +311,10 @@ impl One for Scalar {
     }
 }
 
-fn square_and_multiply(x: &Scalar, n: &Scalar) -> Scalar {
-    let mut ret = Scalar::zero();
-
-    let mut bitvec: Vec<bool> = Vec::new();
-    for byte in n.as_bytes() {
-        let bits = byte.view_bits::<Lsb0>();
-        for bit in bits {
-            bitvec.push(*bit);
-        }
-    }
-    //println!("{:?}", bitvec);
-    let mut square = *x;
-    //for (i,bit) in bitvec.iter().enumerate() {
-    for bit in bitvec {
-        //println!("bit {} square is {:?}", i, square);                                                                  
-        if bit {
-            //println!("bit {} is {}", i, *bit);                                                                         
-            //let old = ret;
-            ret += square;
-            //println!("{:?} +\n{:?} =\n{:?}", old.as_bytes(), square.as_bytes(), ret.as_bytes());                       
-        }
-        square *= square;
-    }
-    //println!("{:?}", square);                                                                                          
-    ret
-}
-
 impl Div<Scalar> for Scalar {
     type Output = Scalar;
     fn div(self, q: Scalar) -> Self::Output {
-	let q1 = q.inverse();
+	let q1 = q.invert();
 	println!("inverse of {:?} is {:?}", q, q1);
 	self * q1
     }
@@ -355,7 +322,7 @@ impl Div<Scalar> for Scalar {
 
 impl DivAssign<Scalar> for Scalar {
     fn div_assign(&mut self, q: Scalar) {
-	let q1 = q.inverse();
+	let q1 = q.invert();
 	println!("inverse of {:?} is {:?}", q, q1);
 	*self = *self * q1;
     }

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -150,7 +150,6 @@ use core::ops::{Sub, SubAssign};
 use core::ops::{Div, DivAssign};
 
 use::num_traits::{Zero, One};
-//use bitvec::prelude::*;
 
 #[allow(unused_imports)]
 use prelude::*;
@@ -315,7 +314,6 @@ impl Div<Scalar> for Scalar {
     type Output = Scalar;
     fn div(self, q: Scalar) -> Self::Output {
 	let q1 = q.invert();
-	println!("inverse of {:?} is {:?}", q, q1);
 	self * q1
     }
 }
@@ -323,7 +321,6 @@ impl Div<Scalar> for Scalar {
 impl DivAssign<Scalar> for Scalar {
     fn div_assign(&mut self, q: Scalar) {
 	let q1 = q.invert();
-	println!("inverse of {:?} is {:?}", q, q1);
 	*self = *self * q1;
     }
 }

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -263,6 +263,12 @@ impl Scalar {
 
         s
     }
+
+    /// Find the inverse module the group order of the passed scalar
+    pub fn inverse(&self) -> Self {
+	let exp = constants::BASEPOINT_ORDER - Scalar::from(2 as u8);
+	square_and_multiply(self, &exp)
+    }
 }
 
 impl Debug for Scalar {
@@ -311,7 +317,7 @@ impl One for Scalar {
     }
 }
 
-fn square_and_multiply(x: Scalar, n: Scalar) -> Scalar {
+fn square_and_multiply(x: &Scalar, n: &Scalar) -> Scalar {
     let mut ret = Scalar::zero();
 
     let mut bitvec: Vec<bool> = Vec::new();
@@ -322,7 +328,7 @@ fn square_and_multiply(x: Scalar, n: Scalar) -> Scalar {
         }
     }
     //println!("{:?}", bitvec);
-    let mut square = x;
+    let mut square = *x;
     //for (i,bit) in bitvec.iter().enumerate() {
     for bit in bitvec {
         //println!("bit {} square is {:?}", i, square);                                                                  
@@ -341,9 +347,17 @@ fn square_and_multiply(x: Scalar, n: Scalar) -> Scalar {
 impl Div<Scalar> for Scalar {
     type Output = Scalar;
     fn div(self, q: Scalar) -> Self::Output {
-	let q1 = square_and_multiply(q, constants::BASEPOINT_ORDER - Scalar::from(2 as u8));
+	let q1 = q.inverse();
 	println!("inverse of {:?} is {:?}", q, q1);
 	self * q1
+    }
+}
+
+impl DivAssign<Scalar> for Scalar {
+    fn div_assign(&mut self, q: Scalar) {
+	let q1 = q.inverse();
+	println!("inverse of {:?} is {:?}", q, q1);
+	*self = *self * q1;
     }
 }
 

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -149,6 +149,8 @@ use core::ops::{Add, AddAssign};
 use core::ops::{Mul, MulAssign};
 use core::ops::{Sub, SubAssign};
 
+use::num_traits::{Zero, One};
+
 #[allow(unused_imports)]
 use prelude::*;
 
@@ -287,6 +289,24 @@ impl Index<usize> for Scalar {
     /// Index the bytes of the representative for this `Scalar`.  Mutation is not permitted.
     fn index(&self, _index: usize) -> &u8 {
         &(self.bytes[_index])
+    }
+}
+
+impl Zero for Scalar {
+    fn zero() -> Self {
+	Scalar::zero()
+    }
+    fn is_zero(&self) -> bool {
+	self == &Scalar::zero()
+    }
+}
+
+impl One for Scalar {
+    fn one() -> Self {
+	Scalar::one()
+    }
+    fn is_one(&self) -> bool {
+	self == &Scalar::one()
     }
 }
 

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -139,8 +139,8 @@
 //! The resulting `Scalar` has exactly the specified bit pattern,
 //! **except for the highest bit, which will be set to 0**.
 use core::borrow::Borrow;
-use core::cmp::{Eq, PartialEq};
-use core::fmt::Debug;
+use core::cmp::{Eq, Ord, PartialEq};
+use core::fmt::{Debug, Display};
 use core::iter::{Product, Sum};
 use core::ops::Index;
 use core::ops::Neg;
@@ -194,7 +194,7 @@ type UnpackedScalar = backend::serial::u32::scalar::Scalar29;
 
 /// The `Scalar` struct holds an integer \\(s < 2\^{255} \\) which
 /// represents an element of \\(\mathbb Z / \ell\\).
-#[derive(Copy, Clone, Hash)]
+#[derive(Copy, Clone, Hash, Ord, PartialOrd)]
 pub struct Scalar {
     /// `bytes` is a little-endian byte encoding of an integer representing a scalar modulo the
     /// group order.
@@ -267,6 +267,15 @@ impl Scalar {
 impl Debug for Scalar {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         write!(f, "Scalar{{\n\tbytes: {:?},\n}}", &self.bytes)
+    }
+}
+
+impl Display for Scalar {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+	for byte in self.as_bytes() {
+            write!(f, "{:#02x}", byte)?;
+	}
+	Ok(())
     }
 }
 


### PR DESCRIPTION
While implementing FROST signatures, I tried to use polynomial::Polynomial with Scalar.  Unfortunately, Scalar was missing several traits.  This PR implements those traits.

The Display trait should prove useful to anyone debugging code which uses Scalar.