### PR TITLE
Relax zeroize dependency

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -105,6 +105,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    # First run `cargo +nightly -Z minimal-verisons check` in order to get a
+    # Cargo.lock with the oldest possible deps
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal
@@ -114,6 +116,8 @@ jobs:
       with:
         command: check
         args: -Z minimal-versions
+    # Now check that `cargo build` works with respect to the oldest possible
+    # deps and the stated MSRV
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal
@@ -137,4 +141,4 @@ jobs:
       with:
         command: bench
         # This filter selects no benchmarks, so we don't run any, only build them.
-        args: "DONTRUNBENCHMARKS"
+        args: "nonexistentbenchmark"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -108,6 +108,15 @@ jobs:
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal
+        toolchain: nightly
+        override: true
+    - uses: actions-rs/cargo@v1
+      with:
+        command: check
+        args: -Z minimal-versions
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
         toolchain: 1.41
         override: true
     - uses: actions-rs/cargo@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -101,7 +101,7 @@ jobs:
         args: --features "nightly"
 
   msrv:
-    name: Current MSRV is 1.41
+    name: Current MSRV is 1.56.1
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -112,20 +112,15 @@ jobs:
         profile: minimal
         toolchain: nightly
         override: true
-    - uses: actions-rs/cargo@v1
-      with:
-        command: check
-        args: -Z minimal-versions
+    - run: cargo -Z minimal-versions check --no-default-features --features "fiat_u64_backend,serde"
     # Now check that `cargo build` works with respect to the oldest possible
     # deps and the stated MSRV
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: 1.41
+        toolchain: 1.56.1
         override: true
-    - uses: actions-rs/cargo@v1
-      with:
-        command: build
+    - run: cargo build --no-default-features --features "fiat_u64_backend,serde"
 
   bench:
     name: Check that benchmarks compile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ major series.
 
 * Update the `rand_core` dependency version and the `rand` dev-dependency
   version.
+* Relax the `zeroize` dependency to `^1`
 
 ## 3.x series
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ major series.
 * Update the `rand_core` dependency version and the `rand` dev-dependency
   version.
 * Relax the `zeroize` dependency to `^1`
+* Update the MSRV from 1.41 to 1.56.1
 
 ## 3.x series
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ serde = { version = "1.0", default-features = false, optional = true, features =
 # The original packed_simd package was orphaned, see
 # https://github.com/rust-lang/packed_simd/issues/303#issuecomment-701361161
 packed_simd = { version = "0.3.4", package = "packed_simd_2", features = ["into_bits"], optional = true }
-zeroize = { version = ">=1, <1.4", default-features = false }
+zeroize = { version = "1", default-features = false }
 fiat-crypto = { version = "0.1.6", optional = true}
 
 [features]

--- a/README.md
+++ b/README.md
@@ -119,7 +119,9 @@ If no backend is selected, compilation will fail.
 
 # Minimum Supported Rust Version
 
-This crate requires Rust 1.41 at a minimum. In the future, MSRV changes will be accompanied by a minor version bump.
+This crate requires Rust 1.56.1 at a minimum. 3.x releases of this crate supported an MSRV of 1.41.
+
+In the future, MSRV changes will be accompanied by a minor version bump.
 
 # Safety
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,11 @@ builds using `--no-default-features`.  Note that this requires explicitly
 selecting an arithmetic backend using one of the `_backend` features.
 If no backend is selected, compilation will fail.
 
+
+# Minimum Supported Rust Version
+
+This crate requires Rust 1.41 at a minimum. In the future, MSRV changes will be accompanied by a minor version bump.
+
 # Safety
 
 The `curve25519-dalek` types are designed to make illegal states


### PR DESCRIPTION
This PR:
* Relaxes `zeroize` to `^1`
* Improves documentation about this crate's MSRV
* Fixes the MSRV tests. Previously they were using the newest deps. But the MSRV should be calculated with respect to the oldest possible deps.

I would like to cut a release soon. According to the MSRV test, our v4.0 will not require an MSRV bump.