### PR TITLE
Loosen zeroize semver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ serde = { version = "1.0", default-features = false, optional = true, features =
 # The original packed_simd package was orphaned, see
 # https://github.com/rust-lang/packed_simd/issues/303#issuecomment-701361161
 packed_simd = { version = "0.3.4", package = "packed_simd_2", features = ["into_bits"], optional = true }
-zeroize = { version = ">=1, <1.4", default-features = false }
+zeroize = { version = "^1", default-features = false }
 fiat-crypto = { version = "0.1.6", optional = true}
 
 [features]


### PR DESCRIPTION
Cargo does not allow conflicting versions that are semver compatible. I have a dependency that wants `zeroize ^1.5` and the hard limit on `<1.4` causes such conflict. Is there a reason why `1.4` is frowned upon? 