### PR TITLE
Remove avx2_backend feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ major series.
 * Relax the `zeroize` dependency to `^1`
 * Update the MSRV from 1.41 to 1.56.1
 * Update the edition from 2015 to 2021
+* Remove the deprecated `avx2_backend` feature.
 
 ## 3.x series
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,3 @@ fiat_u64_backend = ["fiat-crypto"]
 fiat_u32_backend = ["fiat-crypto"]
 # The SIMD backend uses parallel formulas, using either AVX2 or AVX512-IFMA.
 simd_backend = ["nightly", "u64_backend", "packed_simd"]
-# DEPRECATED: this is now an alias for `simd_backend` and may be removed
-# in some future release.
-avx2_backend = ["simd_backend"]


### PR DESCRIPTION
As mentioned in #414, this feature is deprecated and can be removed.