### PR TITLE
Fix `simd_backend` + `--no-default-features`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,4 +63,4 @@ alloc = ["zeroize/alloc"]
 # fiat-crypto backend with formally-verified field arithmetic
 fiat_backend = ["fiat-crypto"]
 # The SIMD backend uses parallel formulas, using either AVX2 or AVX512-IFMA.
-simd_backend = ["nightly", "packed_simd"]
+simd_backend = ["alloc", "nightly", "packed_simd"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,4 +63,4 @@ alloc = ["zeroize/alloc"]
 # fiat-crypto backend with formally-verified field arithmetic
 fiat_backend = ["fiat-crypto"]
 # The SIMD backend uses parallel formulas, using either AVX2 or AVX512-IFMA.
-simd_backend = ["alloc", "nightly", "packed_simd"]
+simd_backend = ["nightly", "packed_simd"]

--- a/src/edwards.rs
+++ b/src/edwards.rs
@@ -1389,6 +1389,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "alloc")]
     fn impl_sum() {
         // Test that sum works for non-empty iterators
         let BASE = constants::ED25519_BASEPOINT_POINT;
@@ -1487,6 +1488,7 @@ mod test {
     }
 
     // A single iteration of a consistency check for MSM.
+    #[cfg(feature = "alloc")]
     fn multiscalar_consistency_iter(n: usize) {
         use core::iter;
         let mut rng = rand::thread_rng();
@@ -1521,6 +1523,7 @@ mod test {
     // parameters.
 
     #[test]
+    #[cfg(feature = "alloc")]
     fn multiscalar_consistency_n_100() {
         let iters = 50;
         for _ in 0..iters {
@@ -1529,6 +1532,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "alloc")]
     fn multiscalar_consistency_n_250() {
         let iters = 50;
         for _ in 0..iters {
@@ -1537,6 +1541,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "alloc")]
     fn multiscalar_consistency_n_500() {
         let iters = 50;
         for _ in 0..iters {
@@ -1545,6 +1550,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "alloc")]
     fn multiscalar_consistency_n_1000() {
         let iters = 50;
         for _ in 0..iters {
@@ -1553,6 +1559,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "alloc")]
     fn vartime_precomputed_vs_nonprecomputed_multiscalar() {
         let mut rng = rand::thread_rng();
 
@@ -1609,6 +1616,7 @@ mod test {
         }
 
         #[test]
+        #[cfg(feature = "alloc")]
         fn multiscalar_mul_vs_ed25519py() {
             let A = A_TIMES_BASEPOINT.decompress().unwrap();
             let result = EdwardsPoint::vartime_multiscalar_mul(
@@ -1619,6 +1627,7 @@ mod test {
         }
 
         #[test]
+        #[cfg(feature = "alloc")]
         fn multiscalar_mul_vartime_vs_consttime() {
             let A = A_TIMES_BASEPOINT.decompress().unwrap();
             let result_vartime = EdwardsPoint::vartime_multiscalar_mul(
@@ -1663,6 +1672,7 @@ mod test {
     //     https://github.com/signalapp/libsignal-protocol-c/ //
     ////////////////////////////////////////////////////////////
 
+    #[cfg(feature = "alloc")]
     fn test_vectors() -> Vec<Vec<&'static str>> {
         vec![
             vec![
@@ -1709,6 +1719,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "alloc")]
     fn elligator_signal_test_vectors() {
         for vector in test_vectors().iter() {
             let input = hex::decode(vector[0]).unwrap();

--- a/src/field.rs
+++ b/src/field.rs
@@ -378,6 +378,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "alloc")]
     fn batch_invert_a_matches_nonbatched() {
         let a = FieldElement::from_bytes(&A_BYTES);
         let ap58 = FieldElement::from_bytes(&AP58_BYTES);
@@ -495,6 +496,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "alloc")]
     fn batch_invert_empty() {
         FieldElement::batch_invert(&mut []);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,8 @@
 // External dependencies:
 //------------------------------------------------------------------------
 
-#[cfg(all(feature = "alloc", not(feature = "std")))]
+#[cfg(feature = "alloc")]
+#[allow(unused_imports)]
 #[macro_use]
 extern crate alloc;
 

--- a/src/montgomery.rs
+++ b/src/montgomery.rs
@@ -470,9 +470,9 @@ mod test {
     ];
 
     #[test]
-    #[cfg(feature = "std")] // Vec
+    #[cfg(feature = "alloc")] // Vec
     fn montgomery_elligator_correct() {
-        let bytes: std::vec::Vec<u8> = (0u8..32u8).collect();
+        let bytes: alloc::vec::Vec<u8> = (0u8..32u8).collect();
         let bits_in: [u8; 32] = (&bytes[..]).try_into().expect("Range invariant broken");
 
         let fe = FieldElement::from_bytes(&bits_in);

--- a/src/ristretto.rs
+++ b/src/ristretto.rs
@@ -1178,6 +1178,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "alloc")]
     fn impl_sum() {
         // Test that sum works for non-empty iterators
         let BASE = constants::RISTRETTO_BASEPOINT_POINT;
@@ -1500,6 +1501,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "alloc")]
     fn double_and_compress_1024_random_points() {
         let mut rng = OsRng;
 
@@ -1516,6 +1518,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "alloc")]
     fn vartime_precomputed_vs_nonprecomputed_multiscalar() {
         let mut rng = rand::thread_rng();
 

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -1509,6 +1509,7 @@ mod test {
 
     #[allow(non_snake_case)]
     #[test]
+    #[cfg(feature = "alloc")]
     fn impl_product() {
         // Test that product works for non-empty iterators
         let X_Y_vector = vec![X, Y];
@@ -1538,6 +1539,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "alloc")]
     fn impl_sum() {
         // Test that sum works for non-empty iterators
         let two = Scalar::from(2u64);
@@ -1705,7 +1707,7 @@ mod test {
         assert_eq!(X, bincode::deserialize(X.as_bytes()).unwrap(),);
     }
 
-    #[cfg(debug_assertions)]
+    #[cfg(all(debug_assertions, feature = "alloc"))]
     #[test]
     #[should_panic]
     fn batch_invert_with_a_zero_input_panics() {
@@ -1716,11 +1718,13 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "alloc")]
     fn batch_invert_empty() {
         assert_eq!(Scalar::one(), Scalar::batch_invert(&mut []));
     }
 
     #[test]
+    #[cfg(feature = "alloc")]
     fn batch_invert_consistency() {
         let mut x = Scalar::from(1u64);
         let mut v1: Vec<_> = (0..16)
@@ -1783,6 +1787,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "alloc")]
     fn test_read_le_u64_into() {
         let cases: &[(&[u8], &[u64])] = &[
             (

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -84,6 +84,8 @@ pub trait MultiscalarMul {
     /// iterators returning either `Scalar`s or `&Scalar`s.
     ///
     /// ```
+    /// # #[cfg(feature = "alloc")]
+    /// # {
     /// use curve25519_dalek::constants;
     /// use curve25519_dalek::traits::MultiscalarMul;
     /// use curve25519_dalek::ristretto::RistrettoPoint;
@@ -110,6 +112,7 @@ pub trait MultiscalarMul {
     /// // Note: minus_abc.into_iter(): Iterator<Item=Scalar>
     ///
     /// assert_eq!(A1.compress(), (-A2).compress());
+    /// # }
     /// ```
     fn multiscalar_mul<I, J>(scalars: I, points: J) -> Self::Point
     where
@@ -136,6 +139,8 @@ pub trait VartimeMultiscalarMul {
     /// inlining point decompression into the multiscalar call,
     /// avoiding the need for temporary buffers.
     /// ```
+    /// #[cfg(feature = "alloc")]
+    /// # {
     /// use curve25519_dalek::constants;
     /// use curve25519_dalek::traits::VartimeMultiscalarMul;
     /// use curve25519_dalek::ristretto::RistrettoPoint;
@@ -175,6 +180,7 @@ pub trait VartimeMultiscalarMul {
     /// );
     ///
     /// assert_eq!(A3, Some(A1+A1));
+    /// # }
     /// ```
     fn optional_multiscalar_mul<I, J>(scalars: I, points: J) -> Option<Self::Point>
     where
@@ -199,6 +205,8 @@ pub trait VartimeMultiscalarMul {
     /// iterators returning either `Scalar`s or `&Scalar`s.
     ///
     /// ```
+    /// #[cfg(feature = "alloc")]
+    /// # {
     /// use curve25519_dalek::constants;
     /// use curve25519_dalek::traits::VartimeMultiscalarMul;
     /// use curve25519_dalek::ristretto::RistrettoPoint;
@@ -225,6 +233,7 @@ pub trait VartimeMultiscalarMul {
     /// // Note: minus_abc.into_iter(): Iterator<Item=Scalar>
     ///
     /// assert_eq!(A1.compress(), (-A2).compress());
+    /// # }
     /// ```
     fn vartime_multiscalar_mul<I, J>(scalars: I, points: J) -> Self::Point
     where


### PR DESCRIPTION
...and one other `alloc` cleanup.

`simd_backend` requires `alloc` and so this combination previously caused a compile error.

Also one additional test that works with an `alloc`-only profile wasn't enabled, causing a warning in this case.

Finally, changes CI to test this configuration.