### PR TITLE
Use `include_str!` for `.md` inclusion in rustdoc

### DIFF
--- a/src/backend/vector/avx2/mod.rs
+++ b/src/backend/vector/avx2/mod.rs
@@ -9,7 +9,7 @@
 // - isis agora lovecruft <isis@patternsinthevoid.net>
 // - Henry de Valence <hdevalence@hdevalence.ca>
 
-#![cfg_attr(feature = "nightly", doc(include = "../../../../docs/avx2-notes.md"))]
+#![doc = include_str!("../../../../docs/avx2-notes.md")]
 
 pub(crate) mod field;
 

--- a/src/backend/vector/ifma/mod.rs
+++ b/src/backend/vector/ifma/mod.rs
@@ -7,7 +7,7 @@
 // Authors:
 // - Henry de Valence <hdevalence@hdevalence.ca>
 
-#![cfg_attr(feature = "nightly", doc(include = "../../../../docs/ifma-notes.md"))]
+#![doc = include_str!("../../../../docs/ifma-notes.md")]
 
 pub mod field;
 

--- a/src/backend/vector/mod.rs
+++ b/src/backend/vector/mod.rs
@@ -9,11 +9,7 @@
 // - isis agora lovecruft <isis@patternsinthevoid.net>
 // - Henry de Valence <hdevalence@hdevalence.ca>
 
-// Conditionally include the notes if we're on nightly (so we can include docs at all).
-#![cfg_attr(
-    feature = "nightly",
-    doc(include = "../../../docs/parallel-formulas.md")
-)]
+#![doc = include_str!("../../../docs/parallel-formulas.md")]
 
 #[cfg(not(any(target_feature = "avx2", target_feature = "avx512ifma", rustdoc)))]
 compile_error!("simd_backend selected without target_feature=+avx2 or +avx512ifma");


### PR DESCRIPTION
Previously a now-removed nightly-only feature was used, but now that it's stable, `include_str!` can be used for all of these cases.