### PR TITLE
CI: pin nightly version to 2022-11-01

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,7 +34,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: dtolnay/rust-toolchain@nightly
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: nightly-2022-11-01
     # Build with AVX2 features, then with AVX512 features
     - env:
         RUSTFLAGS: "-C target_feature=+avx2"
@@ -66,7 +68,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: dtolnay/rust-toolchain@nightly
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: nightly-2022-11-01
     - run: cargo test --features "nightly"
 
   msrv:


### PR DESCRIPTION
A pinned nightly may potentially work around the build failures we're experiencing due to build scripts using SIMD features:

https://github.com/dalek-cryptography/curve25519-dalek/pull/433#issuecomment-1312787275