### PR TITLE
CI: fix `build-simd` job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,10 +38,10 @@ jobs:
     # Build with AVX2 features, then with AVX512 features
     - env:
         RUSTFLAGS: "-C target_feature=+avx2"
-      run: cargo build --no-default-features --features "std simd_backend"
+      run: cargo build --target x86_64-unknown-linux-gnu --features simd_backend
     - env:
         RUSTFLAGS: "-C target_feature=+avx512ifma"
-      run: cargo build --no-default-features --features "std simd_backend"
+      run: cargo build --target x86_64-unknown-linux-gnu --features simd_backend
 
   test-defaults-serde:
     name: Test default feature selection and serde


### PR DESCRIPTION
The `RUSTFLAGS` were getting applied to build scripts, which caused them to crash with SIGILL.

According to this issue, RUSTFLAGS won't be applied to build scripts when cross-compiling by passing the `--target` attribute:

https://github.com/rust-lang/cargo/issues/4423

This attempts to work around the problem by explicitly passing:

    --target x86_64-unknown-linux-gnu