### PR TITLE
Add target u32/u64 backend overrides

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -115,4 +115,9 @@ jobs:
     - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@stable
     # This filter selects no benchmarks, so we don't run any, only build them.
-    - run: cargo bench "nonexistentbenchmark"
+    - name: Build u32 bench
+      run: env RUSTFLAGS="--cfg curve25519_dalek_bits=\"32\"" cargo bench "nonexistentbenchmark"
+    - name: Build u64 bench
+      run: env RUSTFLAGS="--cfg curve25519_dalek_bits=\"64\"" cargo bench "nonexistentbenchmark"
+    - name: Build default (host native) bench
+      run: cargo bench "nonexistentbenchmark"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ major series.
 
 ## 4.x series
 
+* Add target u32/u64 backend overrides
 * Migrate documentation to docs.rs hosted
 * Fix backend documentation generation
 * Deprecate `EdwardsPoint::hash_from_bytes` and rename it `EdwardsPoint::nonspect_map_to_curve`

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,15 @@
+//! This selects the curve25519_dalek_bits either by default from target_pointer_width or explicitly set
+
+fn main() {
+    #[cfg(any(
+        all(not(target_pointer_width = "64"), not(curve25519_dalek_bits = "64")),
+        curve25519_dalek_bits = "32"
+    ))]
+    println!("cargo:rustc-cfg=curve25519_dalek_bits=\"32\"");
+
+    #[cfg(any(
+        all(target_pointer_width = "64", not(curve25519_dalek_bits = "32")),
+        curve25519_dalek_bits = "64"
+    ))]
+    println!("cargo:rustc-cfg=curve25519_dalek_bits=\"64\"");
+}

--- a/src/backend/serial/mod.rs
+++ b/src/backend/serial/mod.rs
@@ -21,18 +21,23 @@
 use cfg_if::cfg_if;
 
 cfg_if! {
+
     if #[cfg(feature = "fiat_backend")] {
-        #[cfg(not(target_pointer_width = "64"))]
+
+        #[cfg(curve25519_dalek_bits = "32")]
         pub mod fiat_u32;
 
-        #[cfg(target_pointer_width = "64")]
+        #[cfg(curve25519_dalek_bits = "64")]
         pub mod fiat_u64;
+
     } else {
-        #[cfg(not(target_pointer_width = "64"))]
+
+        #[cfg(curve25519_dalek_bits = "32")]
         pub mod u32;
 
-        #[cfg(target_pointer_width = "64")]
+        #[cfg(curve25519_dalek_bits = "64")]
         pub mod u64;
+
     }
 }
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -38,14 +38,14 @@ use crate::scalar::Scalar;
 
 cfg_if! {
     if #[cfg(feature = "fiat_backend")] {
-        #[cfg(not(target_pointer_width = "64"))]
+        #[cfg(curve25519_dalek_bits = "32")]
         pub use crate::backend::serial::fiat_u32::constants::*;
-        #[cfg(target_pointer_width = "64")]
+        #[cfg(curve25519_dalek_bits = "64")]
         pub use crate::backend::serial::fiat_u64::constants::*;
     } else {
-        #[cfg(not(target_pointer_width = "64"))]
+        #[cfg(curve25519_dalek_bits = "32")]
         pub use crate::backend::serial::u32::constants::*;
-        #[cfg(target_pointer_width = "64")]
+        #[cfg(curve25519_dalek_bits = "64")]
         pub use crate::backend::serial::u64::constants::*;
     }
 }
@@ -149,7 +149,7 @@ mod test {
 
     /// Test that d = -121665/121666
     #[test]
-    #[cfg(all(not(target_pointer_width = "64"), not(feature = "fiat_backend")))]
+    #[cfg(all(curve25519_dalek_bits = "32", not(feature = "fiat_backend")))]
     fn test_d_vs_ratio() {
         use crate::backend::serial::u32::field::FieldElement2625;
         let a = -&FieldElement2625([121665, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
@@ -162,7 +162,7 @@ mod test {
 
     /// Test that d = -121665/121666
     #[test]
-    #[cfg(all(target_pointer_width = "64", not(feature = "fiat_backend")))]
+    #[cfg(all(curve25519_dalek_bits = "64", not(feature = "fiat_backend")))]
     fn test_d_vs_ratio() {
         use crate::backend::serial::u64::field::FieldElement51;
         let a = -&FieldElement51([121665, 0, 0, 0, 0]);

--- a/src/field.rs
+++ b/src/field.rs
@@ -37,9 +37,9 @@ use crate::constants;
 
 cfg_if! {
     if #[cfg(feature = "fiat_backend")] {
-        #[cfg(not(target_pointer_width = "64"))]
+        #[cfg(curve25519_dalek_bits = "32")]
         pub use backend::serial::fiat_u32::field::*;
-        #[cfg(target_pointer_width = "64")]
+        #[cfg(curve25519_dalek_bits = "64")]
         pub use backend::serial::fiat_u64::field::*;
 
         /// A `FieldElement` represents an element of the field
@@ -49,7 +49,7 @@ cfg_if! {
         /// implementations.
         ///
         /// Using formally-verified field arithmetic from fiat-crypto.
-        #[cfg(not(target_pointer_width = "64"))]
+        #[cfg(curve25519_dalek_bits = "32")]
         pub type FieldElement = backend::serial::fiat_u32::field::FieldElement2625;
 
         /// A `FieldElement` represents an element of the field
@@ -59,9 +59,9 @@ cfg_if! {
         /// implementations.
         ///
         /// Using formally-verified field arithmetic from fiat-crypto.
-        #[cfg(target_pointer_width = "64")]
+        #[cfg(curve25519_dalek_bits = "64")]
         pub type FieldElement = backend::serial::fiat_u64::field::FieldElement51;
-    } else if #[cfg(target_pointer_width = "64")] {
+    } else if #[cfg(curve25519_dalek_bits = "64")] {
         pub use crate::backend::serial::u64::field::*;
 
         /// A `FieldElement` represents an element of the field

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -172,10 +172,10 @@ cfg_if! {
         ///
         /// This is a type alias for one of the scalar types in the `backend`
         /// module.
-        #[cfg(not(target_pointer_width = "64"))]
+        #[cfg(curve25519_dalek_bits = "32")]
         #[cfg_attr(
             docsrs,
-            doc(cfg(all(feature = "fiat_backend", not(target_pointer_width = "64"))))
+            doc(cfg(all(feature = "fiat_backend", curve25519_dalek_bits = "32")))
         )]
         type UnpackedScalar = backend::serial::fiat_u32::scalar::Scalar29;
 
@@ -183,25 +183,25 @@ cfg_if! {
         ///
         /// This is a type alias for one of the scalar types in the `backend`
         /// module.
-        #[cfg(target_pointer_width = "64")]
+        #[cfg(curve25519_dalek_bits = "64")]
         #[cfg_attr(
             docsrs,
-            doc(cfg(all(feature = "fiat_backend", target_pointer_width = "64")))
+            doc(cfg(all(feature = "fiat_backend", curve25519_dalek_bits = "64")))
         )]
         type UnpackedScalar = backend::serial::fiat_u64::scalar::Scalar52;
-    } else if #[cfg(target_pointer_width = "64")] {
+    } else if #[cfg(curve25519_dalek_bits = "64")] {
         /// An `UnpackedScalar` represents an element of the field GF(l), optimized for speed.
         ///
         /// This is a type alias for one of the scalar types in the `backend`
         /// module.
-        #[cfg_attr(docsrs, doc(cfg(target_pointer_width = "64")))]
+        #[cfg_attr(docsrs, doc(cfg(curve25519_dalek_bits = "64")))]
         type UnpackedScalar = backend::serial::u64::scalar::Scalar52;
     } else {
         /// An `UnpackedScalar` represents an element of the field GF(l), optimized for speed.
         ///
         /// This is a type alias for one of the scalar types in the `backend`
         /// module.
-        #[cfg_attr(docsrs, doc(cfg(not(target_pointer_width = "64"))))]
+        #[cfg_attr(docsrs, doc(cfg(curve25519_dalek_bits = "64")))]
         type UnpackedScalar = backend::serial::u32::scalar::Scalar29;
     }
 }


### PR DESCRIPTION
Related before-PR-doc (rendered): https://github.com/dalek-cryptography/curve25519-dalek/pull/453#discussion_r1042294155

Thou shall ask: https://github.com/dalek-cryptography/curve25519-dalek/issues/449#issuecomment-1340670829

Thou shall be giveth:

# cfg
Test cfg matrix / expectation

All selected backends are mutually exclusive.

## fiat_backend 
Auto select `fiat_u32` / `fiat_u64` based on `cfg(target_pointer_width)` - default `fiat_u32` on non-32/64 bits

## serial (default)
Auto select `u32` / `u64` based on `cfg(target_pointer_width)` - default `u32` on non-32/64 bits

## fiat_backend w/ `cfg(curve25519_dalek_bits = "32")`
Selects `fiat_u32` regardless of target_pointer on fiat_backend

## fiat_backend w/ `cfg(curve25519_dalek_bits = "64")`
Selects `fiat_u64` regardless of target_pointer

## serial (default) w/ `cfg(curve25519_dalek_bits = "32")`
Selects `u32` (serial) regardless of target_pointer

## serial (default) w/ `cfg(curve25519_dalek_bits = "64")`
Selects `u64` (serial) regardless of target_pointer