### PR TITLE
Remove activation of `rand_core/std`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ bincode = "1"
 criterion = { version = "0.4.0", features = ["html_reports"] }
 hex = "0.4.2"
 rand = "0.8"
+rand_core = { version = "0.6", features = ["getrandom"] }
 
 [[bench]]
 name = "dalek_benchmarks"
@@ -56,7 +57,7 @@ fiat-crypto = { version = "0.1.6", optional = true}
 [features]
 nightly = ["subtle/nightly"]
 default = ["std"]
-std = ["alloc", "subtle/std", "rand_core/std"]
+std = ["alloc", "subtle/std"]
 alloc = ["zeroize/alloc"]
 
 # fiat-crypto backend with formally-verified field arithmetic


### PR DESCRIPTION
This feature provides two things:

1. Transitive activation of the `rand_core/getrandom` feature
2. Impl of `std::error::Error` for `rand_core::Error`

`rand_core::Error` is not part of `curve25519-dalek`'s public API and is irrelevant.

The `rand_core/getrandom` feature provides `OsRng` which is used in tests only, so we can activate it in `dev-dependencies`.