### PR TITLE
Allow the fiat serial backend work with the simd backend

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,8 +34,8 @@ jobs:
           RUSTFLAGS: '--cfg curve25519_dalek_backend="fiat"'
         run: cargo test --target ${{ matrix.target }}
 
-  build-simd:
-    name: Build simd backend (nightly)
+  build-simd-default:
+    name: Build simd backend without fiat (nightly)
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -46,6 +46,20 @@ jobs:
       run: cargo build --target x86_64-unknown-linux-gnu
     - env:
         RUSTFLAGS: '--cfg curve25519_dalek_backend="simd" -C target_feature=+avx512ifma'
+      run: cargo build --target x86_64-unknown-linux-gnu
+
+  build-simd-fiat:
+    name: Build simd backend with fiat (nightly)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: dtolnay/rust-toolchain@nightly
+    # Build with AVX2 features, then with AVX512 features
+    - env:
+        RUSTFLAGS: '--cfg curve25519_dalek_backend="simd" --cfg curve25519_dalek_serial=\"fiat\" -C target_feature=+avx2'
+      run: cargo build --target x86_64-unknown-linux-gnu
+    - env:
+        RUSTFLAGS: '--cfg curve25519_dalek_backend="simd" --cfg curve25519_dalek_serial=\"fiat\" -C target_feature=+avx512ifma'
       run: cargo build --target x86_64-unknown-linux-gnu
 
   nightly:
@@ -82,7 +96,7 @@ jobs:
     - run: cargo fmt --all -- --check
 
   msrv:
-    name: Current MSRV is 1.56.1
+    name: Current non-Fiat MSRV is 1.56.1
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -95,19 +109,43 @@ jobs:
     - uses: dtolnay/rust-toolchain@1.56.1
     - run: cargo build --no-default-features --features serde
 
+  msrv-fiat:
+    name: Current Fiat MSRV is 1.57
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    # First run `cargo +nightly -Z minimal-verisons check` in order to get a
+    # Cargo.lock with the oldest possible deps
+    - uses: dtolnay/rust-toolchain@nightly
+    - run: cargo -Z minimal-versions check --no-default-features --features serde
+    # Now check that `cargo build` works with respect to the oldest possible
+    # deps and the stated MSRV
+    - uses: dtolnay/rust-toolchain@1.57
+    - env:
+        RUSTFLAGS: '--cfg curve25519_dalek_serial="fiat"'
+      run: cargo build --no-default-features --features serde
+
   bench:
     name: Check that benchmarks compile
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@stable
-    - name: Build u32 bench
+    - name: Build non-Fiat u32 bench
       env:
         RUSTFLAGS: '--cfg curve25519_dalek_bits="32"'
       run: cargo build --benches
-    - name: Build u64 bench
+    - name: Build non-Fiat u64 bench
       env:
         RUSTFLAGS: '--cfg curve25519_dalek_bits="64"'
+      run: cargo build --benches
+    - name: Build Fiat u32 bench
+      env:
+        RUSTFLAGS: '--cfg curve25519_dalek_serial="fiat" --cfg curve25519_dalek_bits="64"'
+      run: cargo build --benches
+    - name: Build Fiat u64 bench
+      env:
+        RUSTFLAGS: '--cfg curve25519_dalek_serial="fiat" --cfg curve25519_dalek_bits="64"'
       run: cargo build --benches
     - name: Build default (host native) bench
       run: cargo build --benches

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ major series.
 
 #### Other changes
 
+* Allow the fiat serial backend work with the simd backend
 * Update Maintenance Policies for SemVer
 * Migrate documentation to docs.rs hosted
 * Fix backend documentation generation

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,8 @@ subtle = { version = "^2.2.1", default-features = false }
 serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
 zeroize = { version = "1", default-features = false }
 
-[target.'cfg(curve25519_dalek_backend = "fiat")'.dependencies]
+# Cargo.toml comes before build.rs and we support selection on both _serial and _backend due ergonomics
+[target.'cfg(any(curve25519_dalek_backend = "fiat", curve25519_dalek_serial = "fiat"))'.dependencies]
 fiat-crypto = "0.1.6"
 
 # The original packed_simd package was orphaned, see

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,29 @@
 //! This selects the curve25519_dalek_bits either by default from target_pointer_width or explicitly set
 
+#[cfg_attr(
+    any(curve25519_dalek_serial = "fiat", curve25519_dalek_backend = "fiat"),
+    deny(dead_code)
+)]
+#[cfg_attr(
+    all(
+        not(curve25519_dalek_backend = "fiat"),
+        not(curve25519_dalek_serial = "fiat")
+    ),
+    allow(dead_code)
+)]
+fn fiat_backend(simd: bool) {
+    println!("cargo:rustc-cfg=curve25519_dalek_serial=\"fiat\"");
+
+    match simd {
+        false => println!("cargo:rustc-cfg=curve25519_dalek_backend=\"fiat\""),
+        true => println!("cargo:rustc-cfg=curve25519_dalek_backend=\"simd\""),
+    }
+}
+
 fn main() {
+    /***************************************************************************
+     * Allow overriding the [fiat_][u32|u64] serial arithmetric PR#454
+     ***************************************************************************/
     #[cfg(any(
         all(not(target_pointer_width = "64"), not(curve25519_dalek_bits = "64")),
         curve25519_dalek_bits = "32"
@@ -12,4 +35,19 @@ fn main() {
         curve25519_dalek_bits = "64"
     ))]
     println!("cargo:rustc-cfg=curve25519_dalek_bits=\"64\"");
+
+    /***************************************************************************
+     * Allow selection of fiat serial with simd backend Issue#437
+     ***************************************************************************/
+    #[cfg(any(
+        all(
+            curve25519_dalek_serial = "fiat",
+            not(curve25519_dalek_backend = "simd")
+        ),
+        curve25519_dalek_backend = "fiat"
+    ))]
+    fiat_backend(false);
+
+    #[cfg(all(curve25519_dalek_serial = "fiat", curve25519_dalek_backend = "simd"))]
+    fiat_backend(true);
 }

--- a/src/backend/serial/mod.rs
+++ b/src/backend/serial/mod.rs
@@ -21,7 +21,7 @@
 use cfg_if::cfg_if;
 
 cfg_if! {
-    if #[cfg(curve25519_dalek_backend = "fiat")] {
+    if #[cfg(curve25519_dalek_serial = "fiat")] {
 
         #[cfg(curve25519_dalek_bits = "32")]
         pub mod fiat_u32;

--- a/src/backend/vector/avx2/edwards.rs
+++ b/src/backend/vector/avx2/edwards.rs
@@ -331,6 +331,9 @@ mod test {
 
     #[rustfmt::skip] // keep alignment of some S* calculations
     fn serial_add(P: edwards::EdwardsPoint, Q: edwards::EdwardsPoint) -> edwards::EdwardsPoint {
+        #[cfg(curve25519_dalek_serial = "fiat")]
+        use crate::backend::serial::fiat_u64::field::FieldElement51;
+        #[cfg(not(curve25519_dalek_serial = "fiat"))]
         use crate::backend::serial::u64::field::FieldElement51;
 
         let (X1, Y1, Z1, T1) = (P.X, P.Y, P.Z, P.T);

--- a/src/backend/vector/avx2/field.rs
+++ b/src/backend/vector/avx2/field.rs
@@ -43,7 +43,11 @@ const D_LANES64: u8 = 0b11_00_00_00;
 use core::ops::{Add, Mul, Neg};
 use packed_simd::{i32x8, u32x8, u64x4, IntoBits};
 
+#[cfg(curve25519_dalek_serial = "fiat")]
+use crate::backend::serial::fiat_u64::field::FieldElement51;
+#[cfg(not(curve25519_dalek_serial = "fiat"))]
 use crate::backend::serial::u64::field::FieldElement51;
+
 use crate::backend::vector::avx2::constants::{
     P_TIMES_16_HI, P_TIMES_16_LO, P_TIMES_2_HI, P_TIMES_2_LO,
 };

--- a/src/backend/vector/ifma/field.rs
+++ b/src/backend/vector/ifma/field.rs
@@ -14,6 +14,9 @@
 use core::ops::{Add, Mul, Neg};
 use packed_simd::{u64x4, IntoBits};
 
+#[cfg(curve25519_dalek_serial = "fiat")]
+use crate::backend::serial::fiat_u64::field::FieldElement51;
+#[cfg(not(curve25519_dalek_serial = "fiat"))]
 use crate::backend::serial::u64::field::FieldElement51;
 
 /// A wrapper around `vpmadd52luq` that works on `u64x4`.

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -37,7 +37,7 @@ use crate::ristretto::RistrettoPoint;
 use crate::scalar::Scalar;
 
 cfg_if! {
-    if #[cfg(curve25519_dalek_backend = "fiat")] {
+    if #[cfg(curve25519_dalek_serial = "fiat")] {
         #[cfg(curve25519_dalek_bits = "32")]
         pub use crate::backend::serial::fiat_u32::constants::*;
         #[cfg(curve25519_dalek_bits = "64")]
@@ -149,7 +149,7 @@ mod test {
 
     /// Test that d = -121665/121666
     #[test]
-    #[cfg(all(curve25519_dalek_bits = "32", not(curve25519_dalek_backend = "fiat")))]
+    #[cfg(all(curve25519_dalek_bits = "32", not(curve25519_dalek_serial = "fiat")))]
     fn test_d_vs_ratio() {
         use crate::backend::serial::u32::field::FieldElement2625;
         let a = -&FieldElement2625([121665, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
@@ -162,7 +162,7 @@ mod test {
 
     /// Test that d = -121665/121666
     #[test]
-    #[cfg(all(curve25519_dalek_bits = "64", not(curve25519_dalek_backend = "fiat")))]
+    #[cfg(all(curve25519_dalek_bits = "64", not(curve25519_dalek_serial = "fiat")))]
     fn test_d_vs_ratio() {
         use crate::backend::serial::u64::field::FieldElement51;
         let a = -&FieldElement51([121665, 0, 0, 0, 0]);

--- a/src/field.rs
+++ b/src/field.rs
@@ -36,7 +36,7 @@ use crate::backend;
 use crate::constants;
 
 cfg_if! {
-    if #[cfg(curve25519_dalek_backend = "fiat")] {
+    if #[cfg(curve25519_dalek_serial = "fiat")] {
         #[cfg(curve25519_dalek_bits = "32")]
         pub use backend::serial::fiat_u32::field::*;
         #[cfg(curve25519_dalek_bits = "64")]

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -170,16 +170,12 @@ use crate::backend;
 use crate::constants;
 
 cfg_if! {
-    if #[cfg(curve25519_dalek_backend = "fiat")] {
+    if #[cfg(curve25519_dalek_serial = "fiat")] {
         /// An `UnpackedScalar` represents an element of the field GF(l), optimized for speed.
         ///
         /// This is a type alias for one of the scalar types in the `backend`
         /// module.
         #[cfg(curve25519_dalek_bits = "32")]
-        #[cfg_attr(
-            docsrs,
-            doc(cfg(all(feature = "fiat_backend", curve25519_dalek_bits = "32")))
-        )]
         type UnpackedScalar = backend::serial::fiat_u32::scalar::Scalar29;
 
         /// An `UnpackedScalar` represents an element of the field GF(l), optimized for speed.
@@ -187,10 +183,6 @@ cfg_if! {
         /// This is a type alias for one of the scalar types in the `backend`
         /// module.
         #[cfg(curve25519_dalek_bits = "64")]
-        #[cfg_attr(
-            docsrs,
-            doc(cfg(all(feature = "fiat_backend", curve25519_dalek_bits = "64")))
-        )]
         type UnpackedScalar = backend::serial::fiat_u64::scalar::Scalar52;
     } else if #[cfg(curve25519_dalek_bits = "64")] {
         /// An `UnpackedScalar` represents an element of the field GF(l), optimized for speed.


### PR DESCRIPTION
- Fixes #437 
 
As discussed above it is feasible to allow the fiat serial backend to work with the simd backend.

This change makes it possible to use the fiat serial backend with the simd backend.

Introduces `cfg(curve25519_dalek_serial = "fiat")` to work alongside `cfg(curve25519_dalek_backend = "simd")`.

For ergonomics `cfg(curve25519_dalek_backend = "fiat")` work as-is like `curve25519_dalek_serial` alone.

It was also noted that the fiat serial backend requires MSRV 1.57.

The backend selection logic for this is now in build.rs.