### PR TITLE
Fixes `curve25519_dalek_bits` defaults for cross and wasm

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,6 +48,33 @@ jobs:
         RUSTFLAGS: '--cfg curve25519_dalek_backend="simd" -C target_feature=+avx512ifma'
       run: cargo build --target x86_64-unknown-linux-gnu
 
+  cross:
+    strategy:
+      matrix:
+        include:
+          # ARM32
+          - target: armv7-unknown-linux-gnueabihf
+            rust: stable
+
+          # ARM64
+          - target: aarch64-unknown-linux-gnu
+            rust: stable
+
+          # PPC32
+          - target: powerpc-unknown-linux-gnu
+            rust: stable
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: ${{ matrix.deps }}
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+          targets: ${{ matrix.target }}
+      - run: cargo install cross
+      - run: cross test --release --target ${{ matrix.target }}
+
   nightly:
     name: Test nightly compiler
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ major series.
 
 #### Other changes
 
+* Set well known defaults for wasm and arm
 * Update Maintenance Policies for SemVer
 * Migrate documentation to docs.rs hosted
 * Fix backend documentation generation

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,9 @@ hex = "0.4.2"
 rand = "0.8"
 rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
 
+[build-dependencies]
+platforms = "3.0.2"
+
 [[bench]]
 name = "dalek_benchmarks"
 harness = false

--- a/build.rs
+++ b/build.rs
@@ -1,15 +1,47 @@
 //! This selects the curve25519_dalek_bits either by default from target_pointer_width or explicitly set
 
-fn main() {
-    #[cfg(any(
-        all(not(target_pointer_width = "64"), not(curve25519_dalek_bits = "64")),
-        curve25519_dalek_bits = "32"
-    ))]
-    println!("cargo:rustc-cfg=curve25519_dalek_bits=\"32\"");
+#[allow(non_camel_case_types)]
+enum DalekBits {
+    #[cfg_attr(curve25519_dalek_bits = "64", allow(dead_code))]
+    Dalek32,
+    #[cfg_attr(curve25519_dalek_bits = "32", allow(dead_code))]
+    Dalek64,
+}
 
-    #[cfg(any(
-        all(target_pointer_width = "64", not(curve25519_dalek_bits = "32")),
-        curve25519_dalek_bits = "64"
-    ))]
-    println!("cargo:rustc-cfg=curve25519_dalek_bits=\"64\"");
+#[cfg(all(not(curve25519_dalek_bits = "64"), not(curve25519_dalek_bits = "32")))]
+#[deny(dead_code)]
+fn lotto_curve25519_dalek_bits() -> DalekBits {
+    use platforms::target::PointerWidth;
+
+    let target_triplet = std::env::var("TARGET").unwrap();
+    let platform = platforms::Platform::find(&target_triplet).unwrap();
+
+    match platform.target_arch {
+        //Issues: 449 and 456
+        //TODO(Arm): Needs tests + benchmarks to back this up
+        //platforms::target::Arch::Arm => DalekBits::Dalek64,
+        //TODO(Wasm32): Needs tests + benchmarks to back this up
+        //platforms::target::Arch::Wasm32 => DalekBits::Dalek64,
+        _ => match platform.target_pointer_width {
+            PointerWidth::U64 => DalekBits::Dalek64,
+            PointerWidth::U32 => DalekBits::Dalek32,
+            _ => DalekBits::Dalek32,
+        },
+    }
+}
+
+fn main() {
+    #[cfg(curve25519_dalek_bits = "32")]
+    let curve25519_dalek_bits = DalekBits::Dalek32;
+
+    #[cfg(curve25519_dalek_bits = "64")]
+    let curve25519_dalek_bits = DalekBits::Dalek64;
+
+    #[cfg(all(not(curve25519_dalek_bits = "64"), not(curve25519_dalek_bits = "32")))]
+    let curve25519_dalek_bits = lotto_curve25519_dalek_bits();
+
+    match curve25519_dalek_bits {
+        DalekBits::Dalek64 => println!("cargo:rustc-cfg=curve25519_dalek_bits=\"64\""),
+        DalekBits::Dalek32 => println!("cargo:rustc-cfg=curve25519_dalek_bits=\"32\""),
+    }
 }


### PR DESCRIPTION
As discussed in #456 ~~this sets well known defaults for:~~
 ~~`cfg(target_family = "wasm")`~~ and ~~`cfg(target_arch = "arm")`~~

~~By setting the 64 bit serial arithmetric via `cfg(curve25519_dalek_bits = "64")`~~

EDIT: I've used platforms crate via env TARGET to determine the actual cross target and this now fixes build.rs only.