### PR TITLE
Use `CryptoRngCore` trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ required-features = ["rand_core"]
 
 [dependencies]
 cfg-if = "1"
-rand_core = { version = "0.6", default-features = false, optional = true }
+rand_core = { version = "0.6.4", default-features = false, optional = true }
 digest = { version = "0.10", default-features = false, optional = true }
 subtle = { version = "^2.2.1", default-features = false }
 serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }

--- a/src/ristretto.rs
+++ b/src/ristretto.rs
@@ -169,7 +169,7 @@ use core::ops::{AddAssign, SubAssign};
 use core::ops::{Mul, MulAssign};
 
 #[cfg(any(test, feature = "rand_core"))]
-use rand_core::{CryptoRng, RngCore};
+use rand_core::CryptoRngCore;
 
 #[cfg(feature = "digest")]
 use digest::generic_array::typenum::U64;
@@ -675,7 +675,8 @@ impl RistrettoPoint {
     ///
     /// # Inputs
     ///
-    /// * `rng`: any RNG which implements the `RngCore + CryptoRng` interface.
+    /// * `rng`: any RNG which implements `CryptoRngCore`
+    ///   (i.e. `CryptoRng` + `RngCore`) interface.
     ///
     /// # Returns
     ///
@@ -687,7 +688,7 @@ impl RistrettoPoint {
     /// discrete log of the output point with respect to any other
     /// point should be unknown.  The map is applied twice and the
     /// results are added, to ensure a uniform distribution.
-    pub fn random<R: RngCore + CryptoRng + ?Sized>(rng: &mut R) -> Self {
+    pub fn random<R: CryptoRngCore + ?Sized>(rng: &mut R) -> Self {
         let mut uniform_bytes = [0u8; 64];
         rng.fill_bytes(&mut uniform_bytes);
 

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -153,7 +153,7 @@ use core::ops::{Sub, SubAssign};
 use cfg_if::cfg_if;
 
 #[cfg(any(test, feature = "rand_core"))]
-use rand_core::{CryptoRng, RngCore};
+use rand_core::CryptoRngCore;
 
 #[cfg(feature = "digest")]
 use digest::generic_array::typenum::U64;
@@ -574,7 +574,8 @@ impl Scalar {
     ///
     /// # Inputs
     ///
-    /// * `rng`: any RNG which implements the `RngCore + CryptoRng` interface.
+    /// * `rng`: any RNG which implements `CryptoRngCore`
+    ///   (i.e. `CryptoRng` + `RngCore`) interface.
     ///
     /// # Returns
     ///
@@ -591,7 +592,7 @@ impl Scalar {
     /// let mut csprng = OsRng;
     /// let a: Scalar = Scalar::random(&mut csprng);
     /// # }
-    pub fn random<R: RngCore + CryptoRng + ?Sized>(rng: &mut R) -> Self {
+    pub fn random<R: CryptoRngCore + ?Sized>(rng: &mut R) -> Self {
         let mut scalar_bytes = [0u8; 64];
         rng.fill_bytes(&mut scalar_bytes);
         Scalar::from_bytes_mod_order_wide(&scalar_bytes)


### PR DESCRIPTION
This is a convenience/marker trait for types which impl `CryptoRng` + `RngCore` which makes the type signatures a little more readable.

It was introduced in `rand_core` v0.6.4 (now pinned as the minimum version)