### PR TITLE
Change `Scalar::from_canonical_bytes` to return `CtOption`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ major series.
 * Deprecate `EdwardsPoint::hash_from_bytes` and rename it `EdwardsPoint::nonspec_map_to_curve`
 * Require including a new trait, `use curve25519_dalek::traits::BasepointTable`
   whenever using `EdwardsBasepointTable` or `RistrettoBasepointTable`
+* `Scalar::from_canonical_bytes` now returns `CtOption`
+* `Scalar::is_canonical` now returns `Choice`
 
 #### Other changes
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ required-features = ["rand_core"]
 cfg-if = "1"
 rand_core = { version = "0.6.4", default-features = false, optional = true }
 digest = { version = "0.10", default-features = false, optional = true }
-subtle = { version = "^2.2.1", default-features = false }
+subtle = { version = "2.3.0", default-features = false }
 serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
 zeroize = { version = "1", default-features = false }
 
@@ -65,3 +65,6 @@ packed_simd = { version = "0.3.4", package = "packed_simd_2", features = ["into_
 [features]
 default = ["alloc"]
 alloc = ["zeroize/alloc"]
+
+[profile.dev]
+opt-level = 2


### PR DESCRIPTION
~~*NOTE: includes #470 which should be merged first*~~ Merged!

This is helpful for implementing `ff::PrimeField::from_repr`.

Also changes `Scalar::is_canonical` to return `Choice`.