### PR TITLE
Fixed docsrs flags in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,12 @@ exclude = [
 ]
 
 [package.metadata.docs.rs]
-rustdoc-args = ["--html-in-header", "docs/assets/rustdoc-include-katex-header.html", "--cfg", "docsrs"]
-features = ["serde", "simd_backend", "rand_core", "digest"]
+rustdoc-args = [
+    "--html-in-header", "docs/assets/rustdoc-include-katex-header.html",
+    "--cfg", "docsrs",
+    '--cfg=curve25519_dalek_backend="simd"',
+]
+features = ["serde", "rand_core", "digest"]
 
 [badges]
 travis-ci = { repository = "dalek-cryptography/curve25519-dalek", branch = "master"}


### PR DESCRIPTION
Current build [fails](https://docs.rs/crate/curve25519-dalek/4.0.0-pre.3/builds/700411) because `simd_backend` was accidentally listed as a feature. This should fix it, but I haven't tested it myself.