### PR TITLE
Fix docs.rs release pre.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ name = "curve25519-dalek"
 # - update html_root_url
 # - update README if required by semver
 # - if README was updated, also update module documentation in src/lib.rs
-version = "4.0.0-pre.4"
+version = "4.0.0-pre.5"
 edition = "2021"
 rust-version = "1.56.1"
 authors = ["Isis Lovecruft <isis@patternsinthevoid.net>",
@@ -28,8 +28,8 @@ exclude = [
 rustdoc-args = [
     "--html-in-header", "docs/assets/rustdoc-include-katex-header.html",
     "--cfg", "docsrs",
-    '--cfg=curve25519_dalek_backend="simd"',
 ]
+rustc-args = ["--cfg", "curve25519_dalek_backend=\"simd\""]
 features = ["serde", "rand_core", "digest"]
 
 [badges]

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ curve25519-dalek = "3"
 To use the latest prerelease (see changes [below](#breaking-changes-in-400)),
 use the following line in your project's `Cargo.toml`:
 ```toml
-curve25519-dalek = "4.0.0-pre.4"
+curve25519-dalek = "4.0.0-pre.5"
 ```
 
 ## Feature Flags

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 #![doc(
     html_logo_url = "https://cdn.jsdelivr.net/gh/dalek-cryptography/curve25519-dalek/docs/assets/dalek-logo-clear.png"
 )]
-#![doc(html_root_url = "https://docs.rs/curve25519-dalek/4.0.0-pre.2")]
+#![doc(html_root_url = "https://docs.rs/curve25519-dalek/4.0.0-pre.5")]
 #![doc = include_str!("../README.md")]
 
 //------------------------------------------------------------------------


### PR DESCRIPTION
[Rendered](https://docs.rs/crate/test-curve25519-dalek/4.0.0-pre.16)

Just needed the separate` RUSTCFLAGS` which are `rustc-flags = []` in docs.rs meta (regular thing with `RUSTDOCFLAGS`)