### PR TITLE
CI: add `build-nostd` job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,6 +34,19 @@ jobs:
           RUSTFLAGS: '--cfg curve25519_dalek_backend="fiat"'
         run: cargo test --target ${{ matrix.target }}
 
+  build-nostd:
+    name: Build on no_std target (thumbv7em-none-eabi)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          targets: thumbv7em-none-eabi
+      - run: cargo build --target thumbv7em-none-eabi --release --no-default-features
+      - run: cargo build --target thumbv7em-none-eabi --release
+      - run: cargo build --target thumbv7em-none-eabi --release --features serde
+
   build-simd:
     name: Build simd backend (nightly)
     runs-on: ubuntu-latest


### PR DESCRIPTION
We currently don't have any checks that this crate builds on a `no_std` target.

While `curve25519-dalek` itself doesn't link `std`, it uses dependencies which could potentially link `std`, so it's important to have a job to check that the crate builds on a `no_std` target to ensure feature activation doesn't accidentally flip on the `std` feature of one of those dependencies unintentionally.

This adds a job which checks the crate builds on a `thumbv7em-none-eabi` target which has no `std` implementation.