### PR TITLE
Don't set `html_root_url`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,6 @@
 name = "curve25519-dalek"
 # Before incrementing:
 # - update CHANGELOG
-# - update html_root_url
 # - update README if required by semver
 # - if README was updated, also update module documentation in src/lib.rs
 version = "4.0.0-pre.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,6 @@
 #![doc(
     html_logo_url = "https://cdn.jsdelivr.net/gh/dalek-cryptography/curve25519-dalek/docs/assets/dalek-logo-clear.png"
 )]
-#![doc(html_root_url = "https://docs.rs/curve25519-dalek/4.0.0-pre.5")]
 #![doc = include_str!("../README.md")]
 
 //------------------------------------------------------------------------


### PR DESCRIPTION
The recommendation to set this has been removed from the Rust API guidelines:

https://github.com/rust-lang/api-guidelines/pull/230

It used to be used by docs.rs, but docs.rs now unconditionally sets the `--extern-html-root-url` parameter of rustdoc which overrides it, making it no longer needed and superfluous.