### PR TITLE
Weakly activate `zeroize?/alloc`; MSRV 1.60

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,6 +28,7 @@ jobs:
       - run: rustup target add ${{ matrix.target }}
       - run: ${{ matrix.deps }}
       - run: cargo test --target ${{ matrix.target }} --no-default-features
+      - run: cargo test --target ${{ matrix.target }} --no-default-features --features alloc
       - run: cargo test --target ${{ matrix.target }} --no-default-features --features zeroize
       - run: cargo test --target ${{ matrix.target }}
       - run: cargo test --target ${{ matrix.target }} --features serde
@@ -110,7 +111,7 @@ jobs:
     - run: cargo fmt --all -- --check
 
   msrv:
-    name: Current MSRV is 1.56.1
+    name: Current MSRV is 1.60.0
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -120,7 +121,7 @@ jobs:
     - run: cargo -Z minimal-versions check --no-default-features --features serde
     # Now check that `cargo build` works with respect to the oldest possible
     # deps and the stated MSRV
-    - uses: dtolnay/rust-toolchain@1.56.1
+    - uses: dtolnay/rust-toolchain@1.60.0
     - run: cargo build --no-default-features --features serde
 
   bench:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ major series.
 
 #### Breaking changes
 
-* Update the MSRV from 1.41 to 1.56.1
+* Update the MSRV from 1.41 to 1.60
 * Make `digest` an optional feature
 * Make `rand_core` an optional feature
 * Add target u32/u64 backend overrides

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ name = "curve25519-dalek"
 # - if README was updated, also update module documentation in src/lib.rs
 version = "4.0.0-pre.5"
 edition = "2021"
-rust-version = "1.56.1"
+rust-version = "1.60.0"
 authors = ["Isis Lovecruft <isis@patternsinthevoid.net>",
            "Henry de Valence <hdevalence@hdevalence.ca>"]
 readme = "README.md"
@@ -69,7 +69,7 @@ packed_simd = { version = "0.3.4", package = "packed_simd_2", features = ["into_
 
 [features]
 default = ["alloc", "zeroize"]
-alloc = ["zeroize/alloc"] # TODO: use weak feature activation
+alloc = ["zeroize?/alloc"]
 
 [profile.dev]
 opt-level = 2

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ latest breaking changes are below:
 
 ### Breaking changes in 4.0.0
 
-* Update the MSRV from 1.41 to 1.56.1
+* Update the MSRV from 1.41 to 1.60
 * Update backend selection to be more automatic. See [backends](#backends)
 * Remove `std` feature flag
 * Remove `nightly` feature flag
@@ -185,8 +185,8 @@ for MSRV and public API.
 ## Minimum Supported Rust Version
 
 | Releases | MSRV   |
-| :---     | :---   |
-| 4.x      | 1.56.1 |
+| :---     |:-------|
+| 4.x      | 1.60.0 |
 | 3.x      | 1.41.0 |
 
 From 4.x and on, MSRV changes will be accompanied by a minor version bump.

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -793,15 +793,10 @@ impl Scalar {
         // externally, but there's no corresponding distinction for
         // field elements.
 
-        use zeroize::Zeroizing;
-
         let n = inputs.len();
         let one: UnpackedScalar = Scalar::ONE.unpack().as_montgomery();
 
-        // Place scratch storage in a Zeroizing wrapper to wipe it when
-        // we pass out of scope.
-        let scratch_vec = vec![one; n];
-        let mut scratch = Zeroizing::new(scratch_vec);
+        let mut scratch = vec![one; n];
 
         // Keep an accumulator of all of the previous products
         let mut acc = Scalar::ONE.unpack().as_montgomery();
@@ -834,6 +829,9 @@ impl Scalar {
             *input = UnpackedScalar::montgomery_mul(&acc, scratch).pack();
             acc = tmp;
         }
+
+        #[cfg(feature = "zeroize")]
+        zeroize::Zeroize::zeroize(&mut scratch);
 
         ret
     }


### PR DESCRIPTION
Previously `alloc` implicitly activated `zeroize` via `zeroize/alloc`.

This commit switches to weak feature activation as added in Rust 1.60, only activating `zeroize/alloc` if the `zeroize` dependency is explicitly activated (which it is by default).