### PR TITLE
CI: use RustCrypto/actions/cross-install

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -87,7 +87,7 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
-      - run: cargo install cross
+      - uses: RustCrypto/actions/cross-install@master
       - run: cross test --release --target ${{ matrix.target }}
 
   nightly:


### PR DESCRIPTION
This action is located at:

https://github.com/RustCrypto/actions/blob/master/cross-install/action.yml

It's used across the RustCrypto project for installing `cross` in CI.

Installation is performed by fetching a pinned binary release from:

https://github.com/cross-rs/cross/releases/

This eliminates problems that might occur when using `cargo install` such as:

https://github.com/dalek-cryptography/curve25519-dalek/actions/runs/3786735408/jobs/6437902657

It's also marginally faster.