### PR TITLE
Make `from_slice` methods fallible; add `TryFrom<&[u8]>`

### DIFF
--- a/src/edwards.rs
+++ b/src/edwards.rs
@@ -93,6 +93,7 @@
 // affine and projective cakes and eat both of them too.
 #![allow(non_snake_case)]
 
+use core::array::TryFromSliceError;
 use core::borrow::Borrow;
 use core::fmt::Debug;
 use core::iter::Iterator;
@@ -206,6 +207,14 @@ impl CompressedEdwardsY {
         X.conditional_negate(compressed_sign_bit);
 
         Some(EdwardsPoint{ X, Y, Z, T: &X * &Y })
+    }
+}
+
+impl TryFrom<&[u8]> for CompressedEdwardsY {
+    type Error = TryFromSliceError;
+
+    fn try_from(slice: &[u8]) -> Result<CompressedEdwardsY, TryFromSliceError> {
+        Self::from_slice(slice)
     }
 }
 
@@ -356,15 +365,12 @@ impl Default for CompressedEdwardsY {
 impl CompressedEdwardsY {
     /// Construct a `CompressedEdwardsY` from a slice of bytes.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// If the input `bytes` slice does not have a length of 32.
-    pub fn from_slice(bytes: &[u8]) -> CompressedEdwardsY {
-        let mut tmp = [0u8; 32];
-
-        tmp.copy_from_slice(bytes);
-
-        CompressedEdwardsY(tmp)
+    /// Returns [`TryFromSliceError`] if the input `bytes` slice does not have
+    /// a length of 32.
+    pub fn from_slice(bytes: &[u8]) -> Result<CompressedEdwardsY, TryFromSliceError> {
+        bytes.try_into().map(CompressedEdwardsY)
     }
 }
 

--- a/src/ristretto.rs
+++ b/src/ristretto.rs
@@ -161,6 +161,7 @@
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
+use core::array::TryFromSliceError;
 use core::borrow::Borrow;
 use core::fmt::Debug;
 use core::iter::Sum;
@@ -242,15 +243,12 @@ impl CompressedRistretto {
 
     /// Construct a `CompressedRistretto` from a slice of bytes.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// If the input `bytes` slice does not have a length of 32.
-    pub fn from_slice(bytes: &[u8]) -> CompressedRistretto {
-        let mut tmp = [0u8; 32];
-
-        tmp.copy_from_slice(bytes);
-
-        CompressedRistretto(tmp)
+    /// Returns [`TryFromSliceError`] if the input `bytes` slice does not have
+    /// a length of 32.
+    pub fn from_slice(bytes: &[u8]) -> Result<CompressedRistretto, TryFromSliceError> {
+        bytes.try_into().map(CompressedRistretto)
     }
 
     /// Attempt to decompress to an `RistrettoPoint`.
@@ -332,6 +330,14 @@ impl Identity for CompressedRistretto {
 impl Default for CompressedRistretto {
     fn default() -> CompressedRistretto {
         CompressedRistretto::identity()
+    }
+}
+
+impl TryFrom<&[u8]> for CompressedRistretto {
+    type Error = TryFromSliceError;
+
+    fn try_from(slice: &[u8]) -> Result<CompressedRistretto, TryFromSliceError> {
+        Self::from_slice(slice)
     }
 }
 


### PR DESCRIPTION
The `from_slice` methods on `CompressedEdwardsY` and `CompressedRistretto` both previously panicked if the slice was the wrong length.

This changes them to be fallible, returning `TryFromSliceError` in the event the slice is the wrong length.

It also adds a `TryFrom<&[u8]>` impl for each of these types which calls the corresponding `from_slice` method.