### PR TITLE
Add `clamp` function to `Scalar` struct (#497)

### DIFF
--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -144,7 +144,7 @@ use core::cmp::{Eq, PartialEq};
 use core::convert::TryInto;
 use core::fmt::Debug;
 use core::iter::{Product, Sum};
-use core::ops::{Index};
+use core::ops::Index;
 use core::ops::Neg;
 use core::ops::{Add, AddAssign};
 use core::ops::{Mul, MulAssign};


### PR DESCRIPTION
* test added
* Little change to `Scalar::from_bytes` to remove `mut Scalar` variable (I think this way it's a bit more clear)