### PR TITLE
Rename `basepoint-tables` to `precomputed-tables`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,7 +30,7 @@ jobs:
       - run: cargo test --target ${{ matrix.target }} --no-default-features
       - run: cargo test --target ${{ matrix.target }} --no-default-features --features alloc
       - run: cargo test --target ${{ matrix.target }} --no-default-features --features digest
-      - run: cargo test --target ${{ matrix.target }} --no-default-features --features basepoint-tables
+      - run: cargo test --target ${{ matrix.target }} --no-default-features --features precomputed-tables
       - run: cargo test --target ${{ matrix.target }} --no-default-features --features rand_core
       - run: cargo test --target ${{ matrix.target }} --no-default-features --features serde
       - run: cargo test --target ${{ matrix.target }} --no-default-features --features zeroize

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ major series.
 
 #### Other changes
 
-* Add `basepoint-tables` feature
+* Add `precomputed-tables` feature
 * Update Maintenance Policies for SemVer
 * Migrate documentation to docs.rs hosted
 * Fix backend documentation generation

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,9 +63,9 @@ fiat-crypto = "0.1.6"
 packed_simd = { version = "0.3.4", package = "packed_simd_2", features = ["into_bits"] }
 
 [features]
-default = ["alloc", "basepoint-tables", "zeroize"]
+default = ["alloc", "precomputed-tables", "zeroize"]
 alloc = ["zeroize?/alloc"]
-basepoint-tables = []
+precomputed-tables = []
 
 [profile.dev]
 opt-level = 2

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ curve25519-dalek = "4.0.0-pre.5"
 | :---               |  :---:   | :---        |
 | `alloc`            |    ✓     | Enables Edwards and Ristretto multiscalar multiplication, batch scalar inversion, and batch Ristretto double-and-compress. Also enables `zeroize`. |
 | `zeroize`          |    ✓     | Enables [`Zeroize`][zeroize-trait] for all scalar and curve point types. |
-| `basepoint-tables` |    ✓     | Includes precomputed basepoint multiplication tables. This speeds up `EdwardsPoint::mul_base` and `RistrettoPoint::mul_base` by ~4x, at the cost of ~30KB added to the code size. |
+| `precomputed-tables` |    ✓     | Includes precomputed basepoint multiplication tables. This speeds up `EdwardsPoint::mul_base` and `RistrettoPoint::mul_base` by ~4x, at the cost of ~30KB added to the code size. |
 | `rand_core`        |          | Enables `Scalar::random` and `RistrettoPoint::random`. This is an optional dependency whose version is not subject to SemVer. See [below](#public-api-semver-exemptions) for more details. |
 | `digest`           |          | Enables `RistrettoPoint::{from_hash, hash_from_bytes}` and `Scalar::{from_hash, hash_from_bytes}`. This is an optional dependency whose version is not subject to SemVer. See [below](#public-api-semver-exemptions) for more details. |
 | `serde`            |          | Enables `serde` serialization/deserialization for all the point and scalar types. |

--- a/src/backend/serial/u32/constants.rs
+++ b/src/backend/serial/u32/constants.rs
@@ -19,7 +19,7 @@ use crate::backend::serial::curve_models::AffineNielsPoint;
 use crate::edwards::EdwardsPoint;
 use crate::window::NafLookupTable8;
 
-#[cfg(feature = "basepoint-tables")]
+#[cfg(feature = "precomputed-tables")]
 use crate::{edwards::EdwardsBasepointTable, window::LookupTable};
 
 /// The value of minus one, equal to `-&FieldElement::ONE`
@@ -237,13 +237,13 @@ pub const EIGHT_TORSION_INNER_DOC_HIDDEN: [EdwardsPoint; 8] = [
 ];
 
 /// Table containing precomputed multiples of the Ed25519 basepoint \\(B = (x, 4/5)\\).
-#[cfg(feature = "basepoint-tables")]
+#[cfg(feature = "precomputed-tables")]
 pub static ED25519_BASEPOINT_TABLE: &'static EdwardsBasepointTable =
     &ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN;
 
 /// Inner constant, used to avoid filling the docs with precomputed points.
 #[doc(hidden)]
-#[cfg(feature = "basepoint-tables")]
+#[cfg(feature = "precomputed-tables")]
 static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = EdwardsBasepointTable([
     LookupTable([
         AffineNielsPoint {

--- a/src/backend/serial/u64/constants.rs
+++ b/src/backend/serial/u64/constants.rs
@@ -17,7 +17,7 @@ use crate::backend::serial::curve_models::AffineNielsPoint;
 use crate::edwards::EdwardsPoint;
 use crate::window::NafLookupTable8;
 
-#[cfg(feature = "basepoint-tables")]
+#[cfg(feature = "precomputed-tables")]
 use crate::{edwards::EdwardsBasepointTable, window::LookupTable};
 
 /// The value of minus one, equal to `-&FieldElement::ONE`
@@ -324,13 +324,13 @@ pub const EIGHT_TORSION_INNER_DOC_HIDDEN: [EdwardsPoint; 8] = [
 ];
 
 /// Table containing precomputed multiples of the Ed25519 basepoint \\(B = (x, 4/5)\\).
-#[cfg(feature = "basepoint-tables")]
+#[cfg(feature = "precomputed-tables")]
 pub static ED25519_BASEPOINT_TABLE: &'static EdwardsBasepointTable =
     &ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN;
 
 /// Inner constant, used to avoid filling the docs with precomputed points.
 #[doc(hidden)]
-#[cfg(feature = "basepoint-tables")]
+#[cfg(feature = "precomputed-tables")]
 static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = EdwardsBasepointTable([
     LookupTable([
         AffineNielsPoint {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -15,8 +15,8 @@
 //! `LONG_DESCRIPTIVE_UPPER_CASE_NAMES`, but they can be brought into
 //! scope using a `let` binding:
 //!
-#![cfg_attr(feature = "basepoint-tables", doc = "```")]
-#![cfg_attr(not(feature = "basepoint-tables"), doc = "```ignore")]
+#![cfg_attr(feature = "precomputed-tables", doc = "```")]
+#![cfg_attr(not(feature = "precomputed-tables"), doc = "```ignore")]
 //! use curve25519_dalek::constants;
 //! use curve25519_dalek::traits::IsIdentity;
 //!
@@ -36,7 +36,7 @@ use crate::montgomery::MontgomeryPoint;
 use crate::ristretto::{CompressedRistretto, RistrettoPoint};
 use crate::scalar::Scalar;
 
-#[cfg(feature = "basepoint-tables")]
+#[cfg(feature = "precomputed-tables")]
 use crate::edwards::EdwardsBasepointTable;
 
 cfg_if! {
@@ -94,11 +94,11 @@ pub const BASEPOINT_ORDER: Scalar = Scalar {
     ],
 };
 
-#[cfg(feature = "basepoint-tables")]
+#[cfg(feature = "precomputed-tables")]
 use crate::ristretto::RistrettoBasepointTable;
 
 /// The Ristretto basepoint, as a `RistrettoBasepointTable` for scalar multiplication.
-#[cfg(feature = "basepoint-tables")]
+#[cfg(feature = "precomputed-tables")]
 pub static RISTRETTO_BASEPOINT_TABLE: &'static RistrettoBasepointTable = unsafe {
     // SAFETY: `RistrettoBasepointTable` is a `#[repr(transparent)]` newtype of
     // `EdwardsBasepointTable`

--- a/src/edwards.rs
+++ b/src/edwards.rs
@@ -126,13 +126,13 @@ use crate::backend::serial::curve_models::CompletedPoint;
 use crate::backend::serial::curve_models::ProjectiveNielsPoint;
 use crate::backend::serial::curve_models::ProjectivePoint;
 
-#[cfg(feature = "basepoint-tables")]
+#[cfg(feature = "precomputed-tables")]
 use crate::window::{
     LookupTableRadix128, LookupTableRadix16, LookupTableRadix256, LookupTableRadix32,
     LookupTableRadix64,
 };
 
-#[cfg(feature = "basepoint-tables")]
+#[cfg(feature = "precomputed-tables")]
 use crate::traits::BasepointTable;
 
 use crate::traits::ValidityCheck;
@@ -709,15 +709,15 @@ impl<'a, 'b> Mul<&'b EdwardsPoint> for &'a Scalar {
 impl EdwardsPoint {
     /// Fixed-base scalar multiplication by the Ed25519 base point.
     ///
-    /// Uses precomputed basepoint tables when the `basepoint-tables` feature
+    /// Uses precomputed basepoint tables when the `precomputed-tables` feature
     /// is enabled, trading off increased code size for ~4x better performance.
     pub fn mul_base(scalar: &Scalar) -> Self {
-        #[cfg(not(feature = "basepoint-tables"))]
+        #[cfg(not(feature = "precomputed-tables"))]
         {
             scalar * constants::ED25519_BASEPOINT_POINT
         }
 
-        #[cfg(feature = "basepoint-tables")]
+        #[cfg(feature = "precomputed-tables")]
         {
             scalar * constants::ED25519_BASEPOINT_TABLE
         }
@@ -846,7 +846,7 @@ impl EdwardsPoint {
     }
 }
 
-#[cfg(feature = "basepoint-tables")]
+#[cfg(feature = "precomputed-tables")]
 macro_rules! impl_basepoint_table {
     (Name = $name:ident, LookupTable = $table:ident, Point = $point:ty, Radix = $radix:expr, Additions = $adds:expr) => {
         /// A precomputed table of multiples of a basepoint, for accelerating
@@ -1004,7 +1004,7 @@ macro_rules! impl_basepoint_table {
 
 // The number of additions required is ceil(256/w) where w is the radix representation.
 cfg_if! {
-    if #[cfg(feature = "basepoint-tables")] {
+    if #[cfg(feature = "precomputed-tables")] {
         impl_basepoint_table! {
             Name = EdwardsBasepointTable,
             LookupTable = LookupTableRadix16,
@@ -1051,7 +1051,7 @@ cfg_if! {
     }
 }
 
-#[cfg(feature = "basepoint-tables")]
+#[cfg(feature = "precomputed-tables")]
 macro_rules! impl_basepoint_table_conversions {
     (LHS = $lhs:ty, RHS = $rhs:ty) => {
         impl<'a> From<&'a $lhs> for $rhs {
@@ -1069,7 +1069,7 @@ macro_rules! impl_basepoint_table_conversions {
 }
 
 cfg_if! {
-    if #[cfg(feature = "basepoint-tables")] {
+    if #[cfg(feature = "precomputed-tables")] {
         // Conversions from radix 16
         impl_basepoint_table_conversions! {
             LHS = EdwardsBasepointTableRadix16,
@@ -1225,7 +1225,7 @@ mod test {
     #[cfg(feature = "alloc")]
     use alloc::vec::Vec;
 
-    #[cfg(feature = "basepoint-tables")]
+    #[cfg(feature = "precomputed-tables")]
     use crate::constants::ED25519_BASEPOINT_TABLE;
 
     /// X coordinate of the basepoint.
@@ -1314,7 +1314,7 @@ mod test {
     }
 
     /// Test that computing 1*basepoint gives the correct basepoint.
-    #[cfg(feature = "basepoint-tables")]
+    #[cfg(feature = "precomputed-tables")]
     #[test]
     fn basepoint_mult_one_vs_basepoint() {
         let bp = ED25519_BASEPOINT_TABLE * &Scalar::ONE;
@@ -1323,7 +1323,7 @@ mod test {
     }
 
     /// Test that `EdwardsBasepointTable::basepoint()` gives the correct basepoint.
-    #[cfg(feature = "basepoint-tables")]
+    #[cfg(feature = "precomputed-tables")]
     #[test]
     fn basepoint_table_basepoint_function_correct() {
         let bp = ED25519_BASEPOINT_TABLE.basepoint();
@@ -1375,7 +1375,7 @@ mod test {
     }
 
     /// Sanity check for conversion to precomputed points
-    #[cfg(feature = "basepoint-tables")]
+    #[cfg(feature = "precomputed-tables")]
     #[test]
     fn to_affine_niels_clears_denominators() {
         // construct a point as aB so it has denominators (ie. Z != 1)
@@ -1400,7 +1400,7 @@ mod test {
     }
 
     /// Test precomputed basepoint mult
-    #[cfg(feature = "basepoint-tables")]
+    #[cfg(feature = "precomputed-tables")]
     #[test]
     fn test_precomputed_basepoint_mult() {
         let aB_1 = ED25519_BASEPOINT_TABLE * &A_SCALAR;
@@ -1433,7 +1433,7 @@ mod test {
     }
 
     /// Test that all the basepoint table types compute the same results.
-    #[cfg(feature = "basepoint-tables")]
+    #[cfg(feature = "precomputed-tables")]
     #[test]
     fn basepoint_tables() {
         let P = &constants::ED25519_BASEPOINT_POINT;
@@ -1460,7 +1460,7 @@ mod test {
     }
 
     /// Check a unreduced scalar multiplication by the basepoint tables.
-    #[cfg(feature = "basepoint-tables")]
+    #[cfg(feature = "precomputed-tables")]
     #[test]
     fn basepoint_tables_unreduced_scalar() {
         let P = &constants::ED25519_BASEPOINT_POINT;

--- a/src/ristretto.rs
+++ b/src/ristretto.rs
@@ -190,13 +190,13 @@ use subtle::ConstantTimeEq;
 #[cfg(feature = "zeroize")]
 use zeroize::Zeroize;
 
-#[cfg(feature = "basepoint-tables")]
+#[cfg(feature = "precomputed-tables")]
 use crate::edwards::EdwardsBasepointTable;
 use crate::edwards::EdwardsPoint;
 
 use crate::scalar::Scalar;
 
-#[cfg(feature = "basepoint-tables")]
+#[cfg(feature = "precomputed-tables")]
 use crate::traits::BasepointTable;
 use crate::traits::Identity;
 #[cfg(feature = "alloc")]
@@ -929,15 +929,15 @@ impl<'a, 'b> Mul<&'b RistrettoPoint> for &'a Scalar {
 impl RistrettoPoint {
     /// Fixed-base scalar multiplication by the Ristretto base point.
     ///
-    /// Uses precomputed basepoint tables when the `basepoint-tables` feature
+    /// Uses precomputed basepoint tables when the `precomputed-tables` feature
     /// is enabled, trading off increased code size for ~4x better performance.
     pub fn mul_base(scalar: &Scalar) -> Self {
-        #[cfg(not(feature = "basepoint-tables"))]
+        #[cfg(not(feature = "precomputed-tables"))]
         {
             scalar * constants::RISTRETTO_BASEPOINT_POINT
         }
 
-        #[cfg(feature = "basepoint-tables")]
+        #[cfg(feature = "precomputed-tables")]
         {
             scalar * constants::RISTRETTO_BASEPOINT_TABLE
         }
@@ -1060,12 +1060,12 @@ impl RistrettoPoint {
 /// let a = Scalar::from(87329482u64);
 /// let P = &a * RISTRETTO_BASEPOINT_TABLE;
 /// ```
-#[cfg(feature = "basepoint-tables")]
+#[cfg(feature = "precomputed-tables")]
 #[derive(Clone)]
 #[repr(transparent)]
 pub struct RistrettoBasepointTable(pub(crate) EdwardsBasepointTable);
 
-#[cfg(feature = "basepoint-tables")]
+#[cfg(feature = "precomputed-tables")]
 impl<'a, 'b> Mul<&'b Scalar> for &'a RistrettoBasepointTable {
     type Output = RistrettoPoint;
 
@@ -1074,7 +1074,7 @@ impl<'a, 'b> Mul<&'b Scalar> for &'a RistrettoBasepointTable {
     }
 }
 
-#[cfg(feature = "basepoint-tables")]
+#[cfg(feature = "precomputed-tables")]
 impl<'a, 'b> Mul<&'a RistrettoBasepointTable> for &'b Scalar {
     type Output = RistrettoPoint;
 
@@ -1083,7 +1083,7 @@ impl<'a, 'b> Mul<&'a RistrettoBasepointTable> for &'b Scalar {
     }
 }
 
-#[cfg(feature = "basepoint-tables")]
+#[cfg(feature = "precomputed-tables")]
 impl RistrettoBasepointTable {
     /// Create a precomputed table of multiples of the given `basepoint`.
     pub fn create(basepoint: &RistrettoPoint) -> RistrettoBasepointTable {

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -1043,7 +1043,7 @@ impl Scalar {
 
     /// Returns a size hint indicating how many entries of the return
     /// value of `to_radix_2w` are nonzero.
-    #[cfg(any(feature = "alloc", all(test, feature = "basepoint-tables")))]
+    #[cfg(any(feature = "alloc", all(test, feature = "precomputed-tables")))]
     pub(crate) fn to_radix_2w_size_hint(w: usize) -> usize {
         debug_assert!(w >= 4);
         debug_assert!(w <= 8);
@@ -1079,7 +1079,7 @@ impl Scalar {
     /// $$
     /// with \\(-2\^w/2 \leq a_i < 2\^w/2\\) for \\(0 \leq i < (n-1)\\) and \\(-2\^w/2 \leq a_{n-1} \leq 2\^w/2\\).
     ///
-    #[cfg(any(feature = "alloc", feature = "basepoint-tables"))]
+    #[cfg(any(feature = "alloc", feature = "precomputed-tables"))]
     pub(crate) fn as_radix_2w(&self, w: usize) -> [i8; 64] {
         debug_assert!(w >= 4);
         debug_assert!(w <= 8);
@@ -1793,7 +1793,7 @@ mod test {
         }
     }
 
-    #[cfg(feature = "basepoint-tables")]
+    #[cfg(feature = "precomputed-tables")]
     fn test_pippenger_radix_iter(scalar: Scalar, w: usize) {
         let digits_count = Scalar::to_radix_2w_size_hint(w);
         let digits = scalar.as_radix_2w(w);
@@ -1818,7 +1818,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "basepoint-tables")]
+    #[cfg(feature = "precomputed-tables")]
     fn test_pippenger_radix() {
         use core::iter;
         // For each valid radix it tests that 1000 random-ish scalars can be restored

--- a/src/window.rs
+++ b/src/window.rs
@@ -139,7 +139,7 @@ impl_lookup_table! {
 
 // The rest only get used to make basepoint tables
 cfg_if! {
-    if #[cfg(feature = "basepoint-tables")] {
+    if #[cfg(feature = "precomputed-tables")] {
         // radix-32
         impl_lookup_table! {
             Name = LookupTableRadix32,


### PR DESCRIPTION
This is the name we adopted for a similar feature in @RustCrypto.

It's a bit less jargony and also leaves the door open in the future to other types of precomputed tables.