### PR TITLE
Feature-gated more precomputed tables

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ platforms = "3.0.2"
 [[bench]]
 name = "dalek_benchmarks"
 harness = false
-required-features = ["rand_core"]
+required-features = ["alloc", "rand_core"]
 
 [dependencies]
 cfg-if = "1"

--- a/benches/dalek_benchmarks.rs
+++ b/benches/dalek_benchmarks.rs
@@ -32,10 +32,9 @@ mod edwards_benches {
     }
 
     fn consttime_fixed_base_scalar_mul(c: &mut Criterion) {
-        let B = constants::ED25519_BASEPOINT_TABLE;
         let s = Scalar::from(897987897u64).invert();
         c.bench_function("Constant-time fixed-base scalar mul", move |b| {
-            b.iter(|| B * &s)
+            b.iter(|| EdwardsPoint::mul_base(&s))
         });
     }
 
@@ -50,7 +49,7 @@ mod edwards_benches {
     fn vartime_double_base_scalar_mul(c: &mut Criterion) {
         c.bench_function("Variable-time aA+bB, A variable, B fixed", |bench| {
             let mut rng = thread_rng();
-            let A = &Scalar::random(&mut rng) * constants::ED25519_BASEPOINT_TABLE;
+            let A = EdwardsPoint::mul_base(&Scalar::random(&mut rng));
             bench.iter_batched(
                 || (Scalar::random(&mut rng), Scalar::random(&mut rng)),
                 |(a, b)| EdwardsPoint::vartime_double_scalar_mul_basepoint(&a, &A, &b),
@@ -88,7 +87,7 @@ mod multiscalar_benches {
     fn construct_points(n: usize) -> Vec<EdwardsPoint> {
         let mut rng = thread_rng();
         (0..n)
-            .map(|_| &Scalar::random(&mut rng) * constants::ED25519_BASEPOINT_TABLE)
+            .map(|_| EdwardsPoint::mul_base(&Scalar::random(&mut rng)))
             .collect()
     }
 

--- a/src/backend/serial/scalar_mul/vartime_double_base.rs
+++ b/src/backend/serial/scalar_mul/vartime_double_base.rs
@@ -22,7 +22,11 @@ use crate::window::NafLookupTable5;
 /// Compute \\(aA + bB\\) in variable time, where \\(B\\) is the Ed25519 basepoint.
 pub fn mul(a: &Scalar, A: &EdwardsPoint, b: &Scalar) -> EdwardsPoint {
     let a_naf = a.non_adjacent_form(5);
+
+    #[cfg(feature = "precomputed-tables")]
     let b_naf = b.non_adjacent_form(8);
+    #[cfg(not(feature = "precomputed-tables"))]
+    let b_naf = b.non_adjacent_form(5);
 
     // Find starting index
     let mut i: usize = 255;
@@ -34,7 +38,11 @@ pub fn mul(a: &Scalar, A: &EdwardsPoint, b: &Scalar) -> EdwardsPoint {
     }
 
     let table_A = NafLookupTable5::<ProjectiveNielsPoint>::from(A);
+    #[cfg(feature = "precomputed-tables")]
     let table_B = &constants::AFFINE_ODD_MULTIPLES_OF_BASEPOINT;
+    #[cfg(not(feature = "precomputed-tables"))]
+    let table_B =
+        &NafLookupTable5::<ProjectiveNielsPoint>::from(&constants::ED25519_BASEPOINT_POINT);
 
     let mut r = ProjectivePoint::identity();
     loop {

--- a/src/backend/serial/u32/constants.rs
+++ b/src/backend/serial/u32/constants.rs
@@ -15,12 +15,14 @@
 
 use super::field::FieldElement2625;
 use super::scalar::Scalar29;
-use crate::backend::serial::curve_models::AffineNielsPoint;
 use crate::edwards::EdwardsPoint;
-use crate::window::NafLookupTable8;
 
 #[cfg(feature = "precomputed-tables")]
-use crate::{edwards::EdwardsBasepointTable, window::LookupTable};
+use crate::{
+    backend::serial::curve_models::AffineNielsPoint,
+    edwards::EdwardsBasepointTable,
+    window::{LookupTable, NafLookupTable8},
+};
 
 /// The value of minus one, equal to `-&FieldElement::ONE`
 pub(crate) const MINUS_ONE: FieldElement2625 = FieldElement2625([
@@ -3896,6 +3898,7 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
 ]);
 
 /// Odd multiples of the basepoint `[B, 3B, 5B, 7B, 9B, 11B, 13B, 15B, ..., 127B]`.
+#[cfg(feature = "precomputed-tables")]
 #[allow(dead_code)]
 pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsPoint> =
     NafLookupTable8([

--- a/src/backend/serial/u64/constants.rs
+++ b/src/backend/serial/u64/constants.rs
@@ -13,12 +13,14 @@
 
 use super::field::FieldElement51;
 use super::scalar::Scalar52;
-use crate::backend::serial::curve_models::AffineNielsPoint;
 use crate::edwards::EdwardsPoint;
-use crate::window::NafLookupTable8;
 
 #[cfg(feature = "precomputed-tables")]
-use crate::{edwards::EdwardsBasepointTable, window::LookupTable};
+use crate::{
+    backend::serial::curve_models::AffineNielsPoint,
+    edwards::EdwardsBasepointTable,
+    window::{LookupTable, NafLookupTable8},
+};
 
 /// The value of minus one, equal to `-&FieldElement::ONE`
 pub(crate) const MINUS_ONE: FieldElement51 = FieldElement51([
@@ -6287,6 +6289,7 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
 ]);
 
 /// Odd multiples of the basepoint `[B, 3B, 5B, 7B, 9B, 11B, 13B, 15B, ..., 127B]`.
+#[cfg(feature = "precomputed-tables")]
 #[allow(dead_code)]
 pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsPoint> =
     NafLookupTable8([

--- a/src/backend/vector/avx2/constants.rs
+++ b/src/backend/vector/avx2/constants.rs
@@ -15,6 +15,8 @@ use packed_simd::u32x8;
 
 use crate::backend::vector::avx2::edwards::{CachedPoint, ExtendedPoint};
 use crate::backend::vector::avx2::field::FieldElement2625x4;
+
+#[cfg(feature = "precomputed-tables")]
 use crate::window::NafLookupTable8;
 
 /// The identity element as an `ExtendedPoint`.
@@ -96,6 +98,7 @@ pub(crate) static P_TIMES_16_HI: u32x8 = u32x8::new(
 );
 
 /// Odd multiples of the Ed25519 basepoint:
+#[cfg(feature = "precomputed-tables")]
 pub(crate) static BASEPOINT_ODD_LOOKUP_TABLE: NafLookupTable8<CachedPoint> = NafLookupTable8([
     CachedPoint(FieldElement2625x4([
         u32x8::new(

--- a/src/backend/vector/ifma/constants.rs
+++ b/src/backend/vector/ifma/constants.rs
@@ -11,6 +11,7 @@
 
 use packed_simd::u64x4;
 
+#[cfg(feature = "precomputed-tables")]
 use crate::window::NafLookupTable8;
 
 use super::edwards::{CachedPoint, ExtendedPoint};
@@ -35,6 +36,7 @@ pub(crate) static CACHEDPOINT_IDENTITY: CachedPoint = CachedPoint(F51x4Reduced([
 ]));
 
 /// Odd multiples of the Ed25519 basepoint:
+#[cfg(feature = "precomputed-tables")]
 pub(crate) static BASEPOINT_ODD_LOOKUP_TABLE: NafLookupTable8<CachedPoint> = NafLookupTable8([
     CachedPoint(F51x4Reduced([
         u64x4::new(1277522120965857, 73557767439946, 243332, 1943719795065404),

--- a/src/backend/vector/mod.rs
+++ b/src/backend/vector/mod.rs
@@ -28,9 +28,7 @@ pub(crate) use self::avx2::{edwards::CachedPoint, edwards::ExtendedPoint};
 #[cfg(any(target_feature = "avx512ifma", all(docsrs, target_arch = "x86_64")))]
 pub mod ifma;
 #[cfg(target_feature = "avx512ifma")]
-pub(crate) use self::ifma::{
-    constants::BASEPOINT_ODD_LOOKUP_TABLE, edwards::CachedPoint, edwards::ExtendedPoint,
-};
+pub(crate) use self::ifma::{edwards::CachedPoint, edwards::ExtendedPoint};
 
 #[cfg(any(
     target_feature = "avx2",
@@ -39,3 +37,21 @@ pub(crate) use self::ifma::{
 ))]
 #[allow(missing_docs)]
 pub mod scalar_mul;
+
+// Precomputed table re-exports
+
+#[cfg(any(
+    all(
+        target_feature = "avx2",
+        not(target_feature = "avx512ifma"),
+        feature = "precomputed-tables"
+    ),
+    all(docsrs, target_arch = "x86_64")
+))]
+pub(crate) use self::avx2::constants::BASEPOINT_ODD_LOOKUP_TABLE;
+
+#[cfg(any(
+    all(target_feature = "avx512ifma", feature = "precomputed-tables"),
+    all(docsrs, target_arch = "x86_64")
+))]
+pub(crate) use self::ifma::constants::BASEPOINT_ODD_LOOKUP_TABLE;

--- a/src/backend/vector/mod.rs
+++ b/src/backend/vector/mod.rs
@@ -23,9 +23,7 @@ pub mod avx2;
     all(target_feature = "avx2", not(target_feature = "avx512ifma")),
     all(docsrs, target_arch = "x86_64")
 ))]
-pub(crate) use self::avx2::{
-    constants::BASEPOINT_ODD_LOOKUP_TABLE, edwards::CachedPoint, edwards::ExtendedPoint,
-};
+pub(crate) use self::avx2::{edwards::CachedPoint, edwards::ExtendedPoint};
 
 #[cfg(any(target_feature = "avx512ifma", all(docsrs, target_arch = "x86_64")))]
 pub mod ifma;

--- a/src/backend/vector/scalar_mul/vartime_double_base.rs
+++ b/src/backend/vector/scalar_mul/vartime_double_base.rs
@@ -13,7 +13,6 @@
 
 use core::cmp::Ordering;
 
-use crate::backend::vector::BASEPOINT_ODD_LOOKUP_TABLE;
 use crate::backend::vector::{CachedPoint, ExtendedPoint};
 use crate::edwards::EdwardsPoint;
 use crate::scalar::Scalar;
@@ -23,7 +22,11 @@ use crate::window::NafLookupTable5;
 /// Compute \\(aA + bB\\) in variable time, where \\(B\\) is the Ed25519 basepoint.
 pub fn mul(a: &Scalar, A: &EdwardsPoint, b: &Scalar) -> EdwardsPoint {
     let a_naf = a.non_adjacent_form(5);
+
+    #[cfg(feature = "precomputed-tables")]
     let b_naf = b.non_adjacent_form(8);
+    #[cfg(not(feature = "precomputed-tables"))]
+    let b_naf = b.non_adjacent_form(5);
 
     // Find starting index
     let mut i: usize = 255;
@@ -35,7 +38,11 @@ pub fn mul(a: &Scalar, A: &EdwardsPoint, b: &Scalar) -> EdwardsPoint {
     }
 
     let table_A = NafLookupTable5::<CachedPoint>::from(A);
-    let table_B = &BASEPOINT_ODD_LOOKUP_TABLE;
+
+    #[cfg(feature = "precomputed-tables")]
+    let table_B = &crate::backend::vector::BASEPOINT_ODD_LOOKUP_TABLE;
+    #[cfg(not(feature = "precomputed-tables"))]
+    let table_B = &NafLookupTable5::<CachedPoint>::from(&crate::constants::ED25519_BASEPOINT_POINT);
 
     let mut Q = ExtendedPoint::identity();
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -222,12 +222,13 @@ impl<'a> From<&'a EdwardsPoint> for NafLookupTable5<AffineNielsPoint> {
     }
 }
 
-/// Holds stuff up to 8. Only our precomputed tables get this big
-#[cfg(feature = "precomputed-tables")]
+/// Holds stuff up to 8. The only time we use tables this big is for precomputed basepoint tables
+/// and multiscalar multiplication (which requires alloc).
+#[cfg(any(feature = "precomputed-tables", feature = "alloc"))]
 #[derive(Copy, Clone)]
 pub(crate) struct NafLookupTable8<T>(pub(crate) [T; 64]);
 
-#[cfg(feature = "precomputed-tables")]
+#[cfg(any(feature = "precomputed-tables", feature = "alloc"))]
 impl<T: Copy> NafLookupTable8<T> {
     pub fn select(&self, x: usize) -> T {
         debug_assert_eq!(x & 1, 1);
@@ -237,7 +238,7 @@ impl<T: Copy> NafLookupTable8<T> {
     }
 }
 
-#[cfg(feature = "precomputed-tables")]
+#[cfg(any(feature = "precomputed-tables", feature = "alloc"))]
 impl<T: Debug> Debug for NafLookupTable8<T> {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         writeln!(f, "NafLookupTable8([")?;
@@ -248,7 +249,7 @@ impl<T: Debug> Debug for NafLookupTable8<T> {
     }
 }
 
-#[cfg(feature = "precomputed-tables")]
+#[cfg(any(feature = "precomputed-tables", feature = "alloc"))]
 impl<'a> From<&'a EdwardsPoint> for NafLookupTable8<ProjectiveNielsPoint> {
     fn from(A: &'a EdwardsPoint) -> Self {
         let mut Ai = [A.as_projective_niels(); 64];
@@ -261,7 +262,7 @@ impl<'a> From<&'a EdwardsPoint> for NafLookupTable8<ProjectiveNielsPoint> {
     }
 }
 
-#[cfg(feature = "precomputed-tables")]
+#[cfg(any(feature = "precomputed-tables", feature = "alloc"))]
 impl<'a> From<&'a EdwardsPoint> for NafLookupTable8<AffineNielsPoint> {
     fn from(A: &'a EdwardsPoint) -> Self {
         let mut Ai = [A.as_affine_niels(); 64];

--- a/src/window.rs
+++ b/src/window.rs
@@ -222,10 +222,12 @@ impl<'a> From<&'a EdwardsPoint> for NafLookupTable5<AffineNielsPoint> {
     }
 }
 
-/// Holds stuff up to 8.
+/// Holds stuff up to 8. Only our precomputed tables get this big
+#[cfg(feature = "precomputed-tables")]
 #[derive(Copy, Clone)]
 pub(crate) struct NafLookupTable8<T>(pub(crate) [T; 64]);
 
+#[cfg(feature = "precomputed-tables")]
 impl<T: Copy> NafLookupTable8<T> {
     pub fn select(&self, x: usize) -> T {
         debug_assert_eq!(x & 1, 1);
@@ -235,6 +237,7 @@ impl<T: Copy> NafLookupTable8<T> {
     }
 }
 
+#[cfg(feature = "precomputed-tables")]
 impl<T: Debug> Debug for NafLookupTable8<T> {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         writeln!(f, "NafLookupTable8([")?;
@@ -245,6 +248,7 @@ impl<T: Debug> Debug for NafLookupTable8<T> {
     }
 }
 
+#[cfg(feature = "precomputed-tables")]
 impl<'a> From<&'a EdwardsPoint> for NafLookupTable8<ProjectiveNielsPoint> {
     fn from(A: &'a EdwardsPoint) -> Self {
         let mut Ai = [A.as_projective_niels(); 64];
@@ -257,6 +261,7 @@ impl<'a> From<&'a EdwardsPoint> for NafLookupTable8<ProjectiveNielsPoint> {
     }
 }
 
+#[cfg(feature = "precomputed-tables")]
 impl<'a> From<&'a EdwardsPoint> for NafLookupTable8<AffineNielsPoint> {
     fn from(A: &'a EdwardsPoint) -> Self {
         let mut Ai = [A.as_affine_niels(); 64];


### PR DESCRIPTION
We still had some size-8 NAF tables lying around for the `aA + bB` vartime procedure. This puts those tables behind the `precomputed-tables` feature gate.

New bench results for `precomputed-tables` on my M1 machine, using u64 serial backend:
65% speedup on fixed-base mul, 9% speedup on `aA + bB` vartime mul. And the `.rlib` file went from 1.4MB to 758KB (54% of original).

Weirdly, there was a 9% _slowdown_ on vartime fixed-based multiscalar mul over 512 elems, but a 6% speedup on the same thing over 1024 elements. Go figure.