### PR TITLE
Re-export commonly used types from toplevel

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,3 +80,7 @@ pub(crate) mod backend;
 
 // Generic code for window lookups
 pub(crate) mod window;
+
+pub use crate::{
+    edwards::EdwardsPoint, montgomery::MontgomeryPoint, ristretto::RistrettoPoint, scalar::Scalar,
+};


### PR DESCRIPTION
Re-exports the following commonly used types from their respective modules to the toplevel of the crate, which makes them easier to access:

- `EdwardsPoint`
- `MontgomeryPoint`
- `RistrettoPoint`
- `Scalar`