### PR TITLE
Fixed-based Montgomery scalar multiplication

### DIFF
--- a/benches/dalek_benchmarks.rs
+++ b/benches/dalek_benchmarks.rs
@@ -288,6 +288,7 @@ mod ristretto_benches {
 
 mod montgomery_benches {
     use super::*;
+    use curve25519_dalek::montgomery::MontgomeryPoint;
 
     fn montgomery_ladder(c: &mut Criterion) {
         c.bench_function("Montgomery pseudomultiplication", |b| {
@@ -297,10 +298,17 @@ mod montgomery_benches {
         });
     }
 
+    fn consttime_fixed_base_scalar_mul(c: &mut Criterion) {
+        let s = Scalar::from(897987897u64).invert();
+        c.bench_function("Constant-time fixed-base scalar mul", move |b| {
+            b.iter(|| MontgomeryPoint::mul_base(&s))
+        });
+    }
+
     criterion_group! {
         name = montgomery_benches;
         config = Criterion::default();
-        targets = montgomery_ladder,
+        targets = montgomery_ladder, consttime_fixed_base_scalar_mul
     }
 }
 

--- a/src/montgomery.rs
+++ b/src/montgomery.rs
@@ -54,7 +54,7 @@ use core::{
     ops::{Mul, MulAssign},
 };
 
-use crate::constants::{APLUS2_OVER_FOUR, MONTGOMERY_A, MONTGOMERY_A_NEG, X25519_BASEPOINT};
+use crate::constants::{APLUS2_OVER_FOUR, MONTGOMERY_A, MONTGOMERY_A_NEG};
 use crate::edwards::{CompressedEdwardsY, EdwardsPoint};
 use crate::field::FieldElement;
 use crate::scalar::Scalar;
@@ -120,7 +120,7 @@ impl Zeroize for MontgomeryPoint {
 impl MontgomeryPoint {
     /// Fixed-base scalar multiplication (i.e. multiplication by the base point).
     pub fn mul_base(scalar: &Scalar) -> Self {
-        scalar * X25519_BASEPOINT
+        EdwardsPoint::mul_base(scalar).to_montgomery()
     }
 
     /// View this `MontgomeryPoint` as an array of bytes.

--- a/src/montgomery.rs
+++ b/src/montgomery.rs
@@ -54,7 +54,7 @@ use core::{
     ops::{Mul, MulAssign},
 };
 
-use crate::constants::{APLUS2_OVER_FOUR, MONTGOMERY_A, MONTGOMERY_A_NEG};
+use crate::constants::{APLUS2_OVER_FOUR, MONTGOMERY_A, MONTGOMERY_A_NEG, X25519_BASEPOINT};
 use crate::edwards::{CompressedEdwardsY, EdwardsPoint};
 use crate::field::FieldElement;
 use crate::scalar::Scalar;
@@ -118,6 +118,11 @@ impl Zeroize for MontgomeryPoint {
 }
 
 impl MontgomeryPoint {
+    /// Fixed-base scalar multiplication (i.e. multiplication by the base point).
+    pub fn mul_base(scalar: &Scalar) -> Self {
+        scalar * X25519_BASEPOINT
+    }
+
     /// View this `MontgomeryPoint` as an array of bytes.
     pub const fn as_bytes(&self) -> &[u8; 32] {
         &self.0


### PR DESCRIPTION
Adds `MontgomeryPoint::mul_base` as an API for fixed-base scalar multiplication which allows for potential future optimizations.

As a baseline implementation, it uses the variable base scalar multiplication implementation.

This follows the existing `EdwardsPoint::mul_base` and `RistrettoPoint::mul_base` APIs.