### PR TITLE
Fix docsrs build

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -69,6 +69,15 @@ jobs:
         RUSTFLAGS: '--cfg curve25519_dalek_backend="simd" -C target_feature=+avx512ifma'
       run: cargo build --target x86_64-unknown-linux-gnu
 
+  build-docs:
+    name: Build docs
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: dtolnay/rust-toolchain@nightly
+    - run: make doc
+    - run: make doc-internal
+
   cross:
     strategy:
       matrix:

--- a/src/backend/vector/mod.rs
+++ b/src/backend/vector/mod.rs
@@ -50,8 +50,5 @@ pub mod scalar_mul;
 ))]
 pub(crate) use self::avx2::constants::BASEPOINT_ODD_LOOKUP_TABLE;
 
-#[cfg(any(
-    all(target_feature = "avx512ifma", feature = "precomputed-tables"),
-    all(docsrs, target_arch = "x86_64")
-))]
+#[cfg(all(target_feature = "avx512ifma", feature = "precomputed-tables"))]
 pub(crate) use self::ifma::constants::BASEPOINT_ODD_LOOKUP_TABLE;


### PR DESCRIPTION
This adds docs build to the CI, and fixes the [recently failed](https://docs.rs/crate/curve25519-dalek/4.0.0-rc.0/builds/731542) rc.0 build on docsrs.

I fixed the rc.0 error, but I'm now getting an error about `packed_simd` I can't quite diagnose. @tarcieri would you be able to take a look?