### PR TITLE
Fix error for custom targets

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -10,54 +10,6 @@ enum DalekBits {
     Dalek64,
 }
 
-// Only when the curve25519_dalek_bits is not explicitly set.
-// Error handling when the bits setting cannot be determined
-#[cfg(all(not(curve25519_dalek_bits = "64"), not(curve25519_dalek_bits = "32")))]
-fn determine_curve25519_dalek_bits_error(error_code: i32, trigger_msg: &str) -> ! {
-    eprintln!("Error: {trigger_msg}");
-    eprintln!("Please set cfg(curve25519_dalek_bits) explicitly either as 32 or 64.");
-    std::process::exit(error_code)
-}
-
-// Only when the curve25519_dalek_bits is not explicitly set.
-#[cfg(all(not(curve25519_dalek_bits = "64"), not(curve25519_dalek_bits = "32")))]
-fn determine_curve25519_dalek_bits() -> DalekBits {
-    use platforms::target::PointerWidth;
-
-    // TARGET environment is supplied by Cargo
-    // https://doc.rust-lang.org/cargo/reference/environment-variables.html
-    let target_triplet = match std::env::var("TARGET") {
-        Ok(t) => t,
-        Err(_) => determine_curve25519_dalek_bits_error(
-            10,
-            "Standard Cargo TARGET environment variable is not set",
-        ),
-    };
-
-    // platforms crate is the source of truth used to determine the platform
-    // Custom target platforms require explicit settings.
-    let platform = match platforms::Platform::find(&target_triplet) {
-        Some(p) => p,
-        None => determine_curve25519_dalek_bits_error(20, "Unrecognised Rust target"),
-    };
-
-    #[allow(clippy::match_single_binding)]
-    match platform.target_arch {
-        //Issues: 449 and 456
-        //TODO(Arm): Needs tests + benchmarks to back this up
-        //platforms::target::Arch::Arm => DalekBits::Dalek64,
-        //TODO(Wasm32): Needs tests + benchmarks to back this up
-        //platforms::target::Arch::Wasm32 => DalekBits::Dalek64,
-        _ => match platform.target_pointer_width {
-            PointerWidth::U64 => DalekBits::Dalek64,
-            PointerWidth::U32 => DalekBits::Dalek32,
-            // Intended default solely for non-32/64 target pointer widths
-            // Otherwise known target platforms only.
-            _ => DalekBits::Dalek32,
-        },
-    }
-}
-
 fn main() {
     #[cfg(curve25519_dalek_bits = "32")]
     let curve25519_dalek_bits = DalekBits::Dalek32;
@@ -66,10 +18,65 @@ fn main() {
     let curve25519_dalek_bits = DalekBits::Dalek64;
 
     #[cfg(all(not(curve25519_dalek_bits = "64"), not(curve25519_dalek_bits = "32")))]
-    let curve25519_dalek_bits = determine_curve25519_dalek_bits();
+    let curve25519_dalek_bits = deterministic::determine_curve25519_dalek_bits();
 
     match curve25519_dalek_bits {
         DalekBits::Dalek64 => println!("cargo:rustc-cfg=curve25519_dalek_bits=\"64\""),
         DalekBits::Dalek32 => println!("cargo:rustc-cfg=curve25519_dalek_bits=\"32\""),
+    }
+}
+
+// Deterministic cfg(curve25519_dalek_bits) when this is not explicitly set.
+#[cfg(all(not(curve25519_dalek_bits = "64"), not(curve25519_dalek_bits = "32")))]
+mod deterministic {
+
+    use super::*;
+
+    // Standard Cargo TARGET environment variable of triplet is required
+    static ERR_MSG_NO_TARGET: &'static str =
+        "Standard Cargo TARGET environment variable is not set.";
+
+    // Custom Non-Rust standard target platforms require explicit settings.
+    static ERR_MSG_NO_PLATFORM: &'static str = "Unrecognised Rust target platform.";
+
+    // Error handling when the bits setting cannot be determined
+    fn determine_curve25519_dalek_bits_error(cause: &str) -> ! {
+        eprintln!("Error: {cause}");
+        eprintln!("Please set cfg(curve25519_dalek_bits) explicitly either as 32 or 64.");
+        std::process::exit(1)
+    }
+
+    // Determine the curve25519_dalek_bits based on Rust standard TARGET triplet
+    pub(crate) fn determine_curve25519_dalek_bits() -> DalekBits {
+        use platforms::target::PointerWidth;
+
+        // TARGET environment is supplied by Cargo
+        // https://doc.rust-lang.org/cargo/reference/environment-variables.html
+        let target_triplet = match std::env::var("TARGET") {
+            Ok(t) => t,
+            Err(_) => determine_curve25519_dalek_bits_error(ERR_MSG_NO_TARGET),
+        };
+
+        // platforms crate is the source of truth used to determine the platform
+        let platform = match platforms::Platform::find(&target_triplet) {
+            Some(p) => p,
+            None => determine_curve25519_dalek_bits_error(ERR_MSG_NO_PLATFORM),
+        };
+
+        #[allow(clippy::match_single_binding)]
+        match platform.target_arch {
+            //Issues: 449 and 456
+            //TODO(Arm): Needs tests + benchmarks to back this up
+            //platforms::target::Arch::Arm => DalekBits::Dalek64,
+            //TODO(Wasm32): Needs tests + benchmarks to back this up
+            //platforms::target::Arch::Wasm32 => DalekBits::Dalek64,
+            _ => match platform.target_pointer_width {
+                PointerWidth::U64 => DalekBits::Dalek64,
+                PointerWidth::U32 => DalekBits::Dalek32,
+                // Intended default solely for non-32/64 target pointer widths
+                // Otherwise known target platforms only.
+                _ => DalekBits::Dalek32,
+            },
+        }
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -47,7 +47,7 @@ mod deterministic {
     }
 
     // Determine the curve25519_dalek_bits based on Rust standard TARGET triplet
-    pub(crate) fn determine_curve25519_dalek_bits() -> DalekBits {
+    pub(super) fn determine_curve25519_dalek_bits() -> DalekBits {
         use platforms::target::PointerWidth;
 
         // TARGET environment is supplied by Cargo

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,7 @@
 //! This selects the curve25519_dalek_bits either by default from target_pointer_width or explicitly set
 
+#![deny(clippy::unwrap_used, dead_code)]
+
 #[allow(non_camel_case_types)]
 enum DalekBits {
     #[cfg_attr(curve25519_dalek_bits = "64", allow(dead_code))]
@@ -8,13 +10,36 @@ enum DalekBits {
     Dalek64,
 }
 
+// Only when the curve25519_dalek_bits is not explicitly set.
+// Error handling when the bits setting cannot be determined
 #[cfg(all(not(curve25519_dalek_bits = "64"), not(curve25519_dalek_bits = "32")))]
-#[deny(dead_code)]
-fn lotto_curve25519_dalek_bits() -> DalekBits {
+fn determine_curve25519_dalek_bits_error(error_code: i32, trigger_msg: &str) -> ! {
+    eprintln!("Error: {trigger_msg}");
+    eprintln!("Please set cfg(curve25519_dalek_bits) explicitly either as 32 or 64.");
+    std::process::exit(error_code)
+}
+
+// Only when the curve25519_dalek_bits is not explicitly set.
+#[cfg(all(not(curve25519_dalek_bits = "64"), not(curve25519_dalek_bits = "32")))]
+fn determine_curve25519_dalek_bits() -> DalekBits {
     use platforms::target::PointerWidth;
 
-    let target_triplet = std::env::var("TARGET").unwrap();
-    let platform = platforms::Platform::find(&target_triplet).unwrap();
+    // TARGET environment is supplied by Cargo
+    // https://doc.rust-lang.org/cargo/reference/environment-variables.html
+    let target_triplet = match std::env::var("TARGET") {
+        Ok(t) => t,
+        Err(_) => determine_curve25519_dalek_bits_error(
+            10,
+            "Standard Cargo TARGET environment variable is not set",
+        ),
+    };
+
+    // platforms crate is the source of truth used to determine the platform
+    // Custom target platforms require explicit settings.
+    let platform = match platforms::Platform::find(&target_triplet) {
+        Some(p) => p,
+        None => determine_curve25519_dalek_bits_error(20, "Unrecognised Rust target"),
+    };
 
     #[allow(clippy::match_single_binding)]
     match platform.target_arch {
@@ -26,6 +51,8 @@ fn lotto_curve25519_dalek_bits() -> DalekBits {
         _ => match platform.target_pointer_width {
             PointerWidth::U64 => DalekBits::Dalek64,
             PointerWidth::U32 => DalekBits::Dalek32,
+            // Intended default solely for non-32/64 target pointer widths
+            // Otherwise known target platforms only.
             _ => DalekBits::Dalek32,
         },
     }
@@ -39,7 +66,7 @@ fn main() {
     let curve25519_dalek_bits = DalekBits::Dalek64;
 
     #[cfg(all(not(curve25519_dalek_bits = "64"), not(curve25519_dalek_bits = "32")))]
-    let curve25519_dalek_bits = lotto_curve25519_dalek_bits();
+    let curve25519_dalek_bits = determine_curve25519_dalek_bits();
 
     match curve25519_dalek_bits {
         DalekBits::Dalek64 => println!("cargo:rustc-cfg=curve25519_dalek_bits=\"64\""),

--- a/build.rs
+++ b/build.rs
@@ -33,11 +33,10 @@ mod deterministic {
     use super::*;
 
     // Standard Cargo TARGET environment variable of triplet is required
-    static ERR_MSG_NO_TARGET: &'static str =
-        "Standard Cargo TARGET environment variable is not set.";
+    static ERR_MSG_NO_TARGET: &str = "Standard Cargo TARGET environment variable is not set.";
 
     // Custom Non-Rust standard target platforms require explicit settings.
-    static ERR_MSG_NO_PLATFORM: &'static str = "Unknown Rust target platform.";
+    static ERR_MSG_NO_PLATFORM: &str = "Unknown Rust target platform.";
 
     // Error handling when the bits setting cannot be determined
     fn determine_curve25519_dalek_bits_error(cause: &str) -> ! {

--- a/build.rs
+++ b/build.rs
@@ -37,7 +37,7 @@ mod deterministic {
         "Standard Cargo TARGET environment variable is not set.";
 
     // Custom Non-Rust standard target platforms require explicit settings.
-    static ERR_MSG_NO_PLATFORM: &'static str = "Unrecognised Rust target platform.";
+    static ERR_MSG_NO_PLATFORM: &'static str = "Unknown Rust target platform.";
 
     // Error handling when the bits setting cannot be determined
     fn determine_curve25519_dalek_bits_error(cause: &str) -> ! {


### PR DESCRIPTION
Fixes #508 
Supercedes #509 

Desired behaviour is to require explicit setting in case of custom targets and give our helpful error message.

Also clears out the unwrap for missing standard TARGET in case of being used in non-Cargo build system.