### PR TITLE
Fixes cfg with target from env

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,8 +2,7 @@
 
 #![deny(clippy::unwrap_used, dead_code)]
 
-#[allow(non_camel_case_types, dead_code)]
-#[derive(Debug)]
+#[allow(non_camel_case_types)]
 enum DalekBits {
     Dalek32,
     Dalek64,


### PR DESCRIPTION
Fixes #515 by @ryankurte fix
Fixes #511 thanks @jcape for pointing out the warning message

We fix the cross build with override which was broken due to rustc not relaying curve cfg's.

Given it is difficult to use we also default to `cfg(curve_25519_dalek_bits="32")` with a warning instead of a hard error.

Slightly vary of using `CARGO_CFG_` given rustc removes them in build.rs for `#[cfg()]` beyond target `cfg` set.

Cc/ @jrose-signal

Test matrix on x86_64-unknown-linux-gnu native host:

$ rustup default 1.60 ; cargo clean
$ rustup default stable ; cargo clean
$ rustup default nightly ; cargo clean

## Dalek64
$ cargo build
$ env RUSTFLAGS='--cfg curve25519_dalek_bits="64"' cargo build
$ env RUSTFLAGS='--cfg curve25519_dalek_bits="64"' cargo build --target wasm32-unknown-unknown
$ env RUSTFLAGS='--cfg curve25519_dalek_bits="64"' cargo build --target aarch64-unknown-linux-gnu
$ env RUSTFLAGS='--cfg curve25519_dalek_bits="64"' cargo build --target i686-unknown-linux-gnu
$ env RUSTFLAGS='--cfg curve25519_dalek_bits="64"' cargo build --no-default-features --target thumbv7em-none-eabi


## Dalek32
$ env RUSTFLAGS='--cfg curve25519_dalek_bits="32"' cargo build
$ env RUSTFLAGS='--cfg curve25519_dalek_bits="32"' cargo build --target wasm32-unknown-unknown
$ cargo build --target wasm32-unknown-unknown
$ env RUSTFLAGS='--cfg curve25519_dalek_bits="32"' cargo build --target aarch64-unknown-linux-gnu
$ cargo build --target i686-unknown-linux-gnu
$ env RUSTFLAGS='--cfg curve25519_dalek_bits="32"' cargo build --target i686-unknown-linux-gnu
$ cargo build --no-default-features --target thumbv7em-none-eabi
$ env RUSTFLAGS='--cfg curve25519_dalek_bits="32"' cargo build --no-default-features --target thumbv7em-none-eabi