### PR TITLE
chore: Release 4.0.0-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,14 @@ major series.
 #### Breaking changes
 
 * Update the MSRV from 1.41 to 1.60
+* Provide SemVer policy
 * Make `digest` an optional feature
 * Make `rand_core` an optional feature
-* Add target u32/u64 backend overrides
-* Update backend selection to be more automatic
 * Remove `std` feature flag
 * Remove `nightly` feature flag
+* Automatic serial backend selection between `u32` and `u64` over the default `u32`
+* Backend selection is now via cfg(curve25519_dalek_backend) over additive features.
+* Provide override to select `u32` or `u64` backend via cfg(curve25519_dalek_bits)
 * Replace methods `Scalar::{zero, one}` with constants `Scalar::{ZERO, ONE}`
 * Deprecate `EdwardsPoint::hash_from_bytes` and rename it `EdwardsPoint::nonspec_map_to_curve`
 * Require including a new trait, `use curve25519_dalek::traits::BasepointTable`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "curve25519-dalek"
 # - update CHANGELOG
 # - update README if required by semver
 # - if README was updated, also update module documentation in src/lib.rs
-version = "4.0.0-rc.1"
+version = "4.0.0-rc.2"
 edition = "2021"
 rust-version = "1.60.0"
 authors = ["Isis Lovecruft <isis@patternsinthevoid.net>",
@@ -55,12 +55,12 @@ serde = { version = "1.0", default-features = false, optional = true, features =
 zeroize = { version = "1", default-features = false, optional = true }
 
 [target.'cfg(curve25519_dalek_backend = "fiat")'.dependencies]
-fiat-crypto = "0.1.6"
+fiat-crypto = "0.1.19"
 
 # The original packed_simd package was orphaned, see
 # https://github.com/rust-lang/packed_simd/issues/303#issuecomment-701361161
 [target.'cfg(curve25519_dalek_backend = "simd")'.dependencies]
-packed_simd = { version = "0.3.4", package = "packed_simd_2", features = ["into_bits"] }
+packed_simd = { version = "0.3.8", package = "packed_simd_2", features = ["into_bits"] }
 
 [features]
 default = ["alloc", "precomputed-tables", "zeroize"]

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ curve25519-dalek = "3"
 To use the latest prerelease (see changes [below](#breaking-changes-in-400)),
 use the following line in your project's `Cargo.toml`:
 ```toml
-curve25519-dalek = "4.0.0-rc.1"
+curve25519-dalek = "4.0.0-rc.2"
 ```
 
 ## Feature Flags
@@ -65,16 +65,15 @@ disable it when running `cargo`, add the `--no-default-features` CLI flag.
 
 Breaking changes for each major version release can be found in
 [`CHANGELOG.md`](CHANGELOG.md), under the "Breaking changes" subheader. The
-latest breaking changes are below:
+latest breaking changes in high level are below:
 
 ### Breaking changes in 4.0.0
 
 * Update the MSRV from 1.41 to 1.60
-* Update backend selection to be more automatic. See [backends](#backends)
-* Remove `std` feature flag
-* Remove `nightly` feature flag
-* Make `digest` an optional feature
-* Make `rand_core` an optional feature
+* Provide SemVer policy
+* Make `digest` and `rand_core` optional features
+* Remove `std` and `nightly` features
+* Replace backend selection - See [CHANGELOG.md](CHANGELOG.md) and [backends](#backends)
 * Replace methods `Scalar::{zero, one}` with constants `Scalar::{ZERO, ONE}`
 * `Scalar::from_canonical_bytes` now returns `CtOption`
 * `Scalar::is_canonical` now returns `Choice`
@@ -84,6 +83,10 @@ latest breaking changes are below:
   whenever using `EdwardsBasepointTable` or `RistrettoBasepointTable`
 
 This release also does a lot of dependency updates and relaxations to unblock upstream build issues.
+
+### 4.0.0 - Open Breaking Changes
+
+See tracking issue: [curve25519-dalek/issues/521](https://github.com/dalek-cryptography/curve25519-dalek/issues/521)
 
 # Backends
 
@@ -272,9 +275,6 @@ that primitive.
 # Contributing
 
 Please see [CONTRIBUTING.md][contributing].
-
-Patches and pull requests should be make against the `develop`
-branch, **not** `main`.
 
 # About
 


### PR DESCRIPTION
- Update manifest
- Update CHANGELOG - [Rendered](https://github.com/pinkforest/curve25519-dalek/blob/chore-release-400-rc2/CHANGELOG.md)
- Update README - [Rendered](https://github.com/pinkforest/curve25519-dalek/tree/chore-release-400-rc2)
- Minor dep bump (these get selected anyways just reflects the reality)
- Adds tracking issue mention about remaining pending potential API breaking change/s for 4.0.0:
- https://github.com/dalek-cryptography/curve25519-dalek/issues/521

x25519 and ed25519 would have reflctive rc.2 releases so this would be across-the-crates sync release easy to :anchor: on.

Current use of release candidates is at ~10% and it is safe to do across-all-the-crates rc.2 release to increase use/migration.