### PR TITLE
fix: Use the correct exponent in the description of the `mods` operation

### DIFF
--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -877,7 +877,7 @@ impl Scalar {
     ///
     /// Here \\( \bar x = x \operatorname{mods} 2^w \\) means the
     /// \\( \bar x \\) with \\( \bar x \equiv x \pmod{2^w} \\) and
-    /// \\( -2^{w-1} \leq \bar x < 2^w \\).
+    /// \\( -2^{w-1} \leq \bar x < 2^{w-1} \\).
     ///
     /// We implement this by scanning across the bits of \\(k\\) from
     /// least-significant bit to most-significant-bit.


### PR DESCRIPTION
## Motivation

The exponent defining the upper bound of the result of the `mods` operation in the docs should be `w-1`, not `w`. See the screenshot below for reference.

![image](https://user-images.githubusercontent.com/8863307/235256405-0d56ae33-5226-4c89-bc04-73a5f16134e6.png)

The implementation is not affected by this error.

## Solution

This PR fixes the value of the exponent in the docs.