### PR TITLE
ed25519-dalek: remove `ExpandedSecretKey::to_bytes`

### DIFF
--- a/ed25519-dalek/src/signing.rs
+++ b/ed25519-dalek/src/signing.rs
@@ -488,8 +488,8 @@ impl SigningKey {
     /// For more information on the security of systems which use the same keys for both signing
     /// and Diffie-Hellman, see the paper
     /// [On using the same key pair for Ed25519 and an X25519 based KEM](https://eprint.iacr.org/2021/509).
-    pub fn to_scalar_bytes(&self) -> [u8; 32] {
-        ExpandedSecretKey::from(&self.secret_key).scalar_bytes
+    pub fn to_scalar(&self) -> Scalar {
+        ExpandedSecretKey::from(&self.secret_key).scalar
     }
 }
 

--- a/ed25519-dalek/src/verifying.rs
+++ b/ed25519-dalek/src/verifying.rs
@@ -91,7 +91,7 @@ impl PartialEq<VerifyingKey> for VerifyingKey {
 impl From<&ExpandedSecretKey> for VerifyingKey {
     /// Derive this public key from its corresponding `ExpandedSecretKey`.
     fn from(expanded_secret_key: &ExpandedSecretKey) -> VerifyingKey {
-        VerifyingKey::clamp_and_mul_base(expanded_secret_key.scalar_bytes)
+        VerifyingKey::from(EdwardsPoint::mul_base(&expanded_secret_key.scalar))
     }
 }
 
@@ -185,16 +185,6 @@ impl VerifyingKey {
     /// property before verification, then use this method.
     pub fn is_weak(&self) -> bool {
         self.point.is_small_order()
-    }
-
-    /// Internal utility function for clamping a scalar representation and multiplying by the
-    /// basepont to produce a public key.
-    fn clamp_and_mul_base(bits: [u8; 32]) -> VerifyingKey {
-        let point = EdwardsPoint::mul_base_clamped(bits);
-        let compressed = point.compress();
-
-        // Invariant: VerifyingKey.1 is always the decompression of VerifyingKey.0
-        VerifyingKey { compressed, point }
     }
 
     // A helper function that computes `H(R || A || M)` where `H` is the 512-bit hash function

--- a/ed25519-dalek/tests/x25519.rs
+++ b/ed25519-dalek/tests/x25519.rs
@@ -16,17 +16,8 @@ fn ed25519_to_x25519_dh() {
     let ed25519_signing_key_a = SigningKey::from_bytes(&ed25519_secret_key_a);
     let ed25519_signing_key_b = SigningKey::from_bytes(&ed25519_secret_key_b);
 
-    let scalar_a_bytes = ed25519_signing_key_a.to_scalar_bytes();
-    let scalar_b_bytes = ed25519_signing_key_b.to_scalar_bytes();
-
-    assert_eq!(
-        scalar_a_bytes,
-        hex!("357c83864f2833cb427a2ef1c00a013cfdff2768d980c0a3a520f006904de90f")
-    );
-    assert_eq!(
-        scalar_b_bytes,
-        hex!("6ebd9ed75882d52815a97585caf4790a7f6c6b3b7f821c5e259a24b02e502e11")
-    );
+    let scalar_a = ed25519_signing_key_a.to_scalar();
+    let scalar_b = ed25519_signing_key_b.to_scalar();
 
     let x25519_public_key_a = ed25519_signing_key_a.verifying_key().to_montgomery();
     let x25519_public_key_b = ed25519_signing_key_b.verifying_key().to_montgomery();
@@ -44,11 +35,11 @@ fn ed25519_to_x25519_dh() {
         hex!("5166f24a6918368e2af831a4affadd97af0ac326bdf143596c045967cc00230e");
 
     assert_eq!(
-        x25519_public_key_a.mul_clamped(scalar_b_bytes).to_bytes(),
+        (x25519_public_key_a * scalar_b).to_bytes(),
         expected_shared_secret
     );
     assert_eq!(
-        x25519_public_key_b.mul_clamped(scalar_a_bytes).to_bytes(),
+        (x25519_public_key_b * scalar_a).to_bytes(),
         expected_shared_secret
     );
 }


### PR DESCRIPTION
The reason `ExpandedSecretKey` needs a private `scalar_bytes` field is to retain the canonical scalar bytes as output by SHA-512 during key expansion so they can be serialized by the `to_bytes` method.

However, `ExpandedSecretKey`s should not be serialized to the wire.

Removing this method allows the private field to be removed, which allows `ExpandedSecretKey` to be constructed entirely from public fields. This provides an alternative to #544 for use cases like Ed25519-BIP32 where the private scalar is derived rather than clamped from bytes.

One other change is needed: `to_scalar_bytes` was changed to `to_scalar` as the canonical scalar bytes are no longer retained, however this has no impact on its main use case, X25519 Diffie-Hellman exchanges, where the `Scalar` should NOT be written to the wire anyway.