### PR TITLE
Stabilize x25519-dalek version 2

### DIFF
--- a/x25519-dalek/Cargo.toml
+++ b/x25519-dalek/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # - update html_root_url
 # - update CHANGELOG
 # - if any changes were made to README.md, mirror them in src/lib.rs docs
-version = "2.0.0-rc.3"
+version = "2.0.0"
 authors = [
     "Isis Lovecruft <isis@patternsinthevoid.net>",
     "DebugSteven <debugsteven@gmail.com>",
@@ -45,7 +45,7 @@ zeroize = { version = "1", default-features = false, optional = true, features =
 
 [dev-dependencies]
 bincode = "1"
-criterion = "0.4.0"
+criterion = "0.5"
 rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
 
 [[bench]]

--- a/x25519-dalek/README.md
+++ b/x25519-dalek/README.md
@@ -53,9 +53,9 @@ shared secret with Bob by doing:
 ```rust
 # use rand_core::OsRng;
 # use x25519_dalek::{EphemeralSecret, PublicKey};
-# let alice_secret = EphemeralSecret::new(OsRng);
+# let alice_secret = EphemeralSecret::random_from_rng(OsRng);
 # let alice_public = PublicKey::from(&alice_secret);
-# let bob_secret = EphemeralSecret::new(OsRng);
+# let bob_secret = EphemeralSecret::random_from_rng(OsRng);
 # let bob_public = PublicKey::from(&bob_secret);
 let alice_shared_secret = alice_secret.diffie_hellman(&bob_public);
 ```
@@ -65,9 +65,9 @@ Similarly, Bob computes a shared secret by doing:
 ```rust
 # use rand_core::OsRng;
 # use x25519_dalek::{EphemeralSecret, PublicKey};
-# let alice_secret = EphemeralSecret::new(OsRng);
+# let alice_secret = EphemeralSecret::random_from_rng(OsRng);
 # let alice_public = PublicKey::from(&alice_secret);
-# let bob_secret = EphemeralSecret::new(OsRng);
+# let bob_secret = EphemeralSecret::random_from_rng(OsRng);
 # let bob_public = PublicKey::from(&bob_secret);
 let bob_shared_secret = bob_secret.diffie_hellman(&alice_public);
 ```
@@ -77,9 +77,9 @@ These secrets are the same:
 ```rust
 # use rand_core::OsRng;
 # use x25519_dalek::{EphemeralSecret, PublicKey};
-# let alice_secret = EphemeralSecret::new(OsRng);
+# let alice_secret = EphemeralSecret::random_from_rng(OsRng);
 # let alice_public = PublicKey::from(&alice_secret);
-# let bob_secret = EphemeralSecret::new(OsRng);
+# let bob_secret = EphemeralSecret::random_from_rng(OsRng);
 # let bob_public = PublicKey::from(&bob_secret);
 # let alice_shared_secret = alice_secret.diffie_hellman(&bob_public);
 # let bob_shared_secret = bob_secret.diffie_hellman(&alice_public);
@@ -100,7 +100,7 @@ To install, add the following to your project's `Cargo.toml`:
 
 ```toml
 [dependencies]
-x25519-dalek = "2.0.0-rc.3"
+x25519-dalek = "2"
 ```
 
 # MSRV

--- a/x25519-dalek/src/x25519.rs
+++ b/x25519-dalek/src/x25519.rs
@@ -101,7 +101,7 @@ impl EphemeralSecret {
     /// Generate a new [`EphemeralSecret`].
     #[cfg(feature = "getrandom")]
     pub fn random() -> Self {
-        Self::random_from_rng(&mut rand_core::OsRng)
+        Self::random_from_rng(rand_core::OsRng)
     }
 }
 


### PR DESCRIPTION
Now that `curve25519-dalek` version 4 has been released and I couldn't find any outstanding PRs/Issues can version 2 of `x25519-dalek` be released?

Also, can https://github.com/dalek-cryptography/x25519-dalek redirect to here? It's pretty confusing