### PR TITLE
curve25519: Add arbitrary integer multiplication with `MontgomeryPoint::mul_bits_be`

### DIFF
--- a/curve25519-dalek-derive/src/lib.rs
+++ b/curve25519-dalek-derive/src/lib.rs
@@ -110,8 +110,8 @@ pub fn unsafe_target_feature_specialize(
         let features: Vec<_> = attributes
             .lit()
             .value()
-            .split(",")
-            .map(|feature| feature.replace(" ", ""))
+            .split(',')
+            .map(|feature| feature.replace(' ', ""))
             .collect();
         let name = format!("{}_{}", item_mod.ident, features.join("_"));
         let ident = syn::Ident::new(&name, item_mod.ident.span());

--- a/curve25519-dalek/src/montgomery.rs
+++ b/curve25519-dalek/src/montgomery.rs
@@ -401,27 +401,27 @@ impl MontgomeryPoint {
 }
 
 /// Multiply this `MontgomeryPoint` by a `Scalar`.
-impl<'a, 'b> Mul<&'b Scalar> for &'a MontgomeryPoint {
+impl Mul<&Scalar> for &MontgomeryPoint {
     type Output = MontgomeryPoint;
 
     /// Given `self` \\( = u\_0(P) \\), and a `Scalar` \\(n\\), return \\( u\_0(\[n\]P) \\).
-    fn mul(self, scalar: &'b Scalar) -> MontgomeryPoint {
+    fn mul(self, scalar: &Scalar) -> MontgomeryPoint {
         // We multiply by the integer representation of the given Scalar. By scalar invariant #1,
         // the MSB is 0, so we can skip it.
         self._mul_bits_be(scalar.bits_le().rev().skip(1))
     }
 }
 
-impl<'b> MulAssign<&'b Scalar> for MontgomeryPoint {
-    fn mul_assign(&mut self, scalar: &'b Scalar) {
+impl MulAssign<&Scalar> for MontgomeryPoint {
+    fn mul_assign(&mut self, scalar: &Scalar) {
         *self = (self as &MontgomeryPoint) * scalar;
     }
 }
 
-impl<'a, 'b> Mul<&'b MontgomeryPoint> for &'a Scalar {
+impl Mul<&MontgomeryPoint> for &Scalar {
     type Output = MontgomeryPoint;
 
-    fn mul(self, point: &'b MontgomeryPoint) -> MontgomeryPoint {
+    fn mul(self, point: &MontgomeryPoint) -> MontgomeryPoint {
         point * self
     }
 }

--- a/curve25519-dalek/src/montgomery.rs
+++ b/curve25519-dalek/src/montgomery.rs
@@ -158,7 +158,7 @@ impl MontgomeryPoint {
     /// Curve25519 uses _clamped multiplication_, explained
     /// [here](https://neilmadden.blog/2020/05/28/whats-the-curve25519-clamping-all-about/).
     /// When in doubt, use [`Self::mul_clamped`].
-    pub fn mul_bits_be(self, bits: impl Iterator<Item = bool>) -> MontgomeryPoint {
+    pub fn mul_bits_be(&self, bits: impl Iterator<Item = bool>) -> MontgomeryPoint {
         // Algorithm 8 of Costello-Smith 2017
         let affine_u = FieldElement::from_bytes(&self.0);
         let mut x0 = ProjectivePoint::identity();

--- a/curve25519-dalek/src/montgomery.rs
+++ b/curve25519-dalek/src/montgomery.rs
@@ -529,7 +529,7 @@ mod test {
 
     /// Given a bytestring that's little-endian at the byte level, return an iterator over all the
     /// bits, in little-endian order.
-    fn bytestring_bits_le(x: &[u8]) -> impl DoubleEndedIterator<Item = bool> + '_ {
+    fn bytestring_bits_le(x: &[u8]) -> impl DoubleEndedIterator<Item = bool> + Clone + '_ {
         let bitlen = x.len() * 8;
         (0..bitlen).map(|i| {
             // As i runs from 0..256, the bottom 3 bits index the bit, while the upper bits index
@@ -601,13 +601,15 @@ mod test {
             csprng.fill_bytes(&mut bigint2[..]);
 
             // Compute b₁P and b₂P
-            let prod1 = p_montgomery._mul_bits_be(bytestring_bits_le(&bigint1).rev());
-            let prod2 = p_montgomery._mul_bits_be(bytestring_bits_le(&bigint2).rev());
+            let bigint1_bits_be = bytestring_bits_le(&bigint1).rev();
+            let bigint2_bits_be = bytestring_bits_le(&bigint2).rev();
+            let prod1 = p_montgomery._mul_bits_be(bigint1_bits_be.clone());
+            let prod2 = p_montgomery._mul_bits_be(bigint2_bits_be.clone());
 
             // Check that b₁(b₂P) == b₂(b₁P)
             assert_eq!(
-                prod1._mul_bits_be(bytestring_bits_le(&bigint2).rev()),
-                prod2._mul_bits_be(bytestring_bits_le(&bigint1).rev())
+                prod1._mul_bits_be(bigint2_bits_be),
+                prod2._mul_bits_be(bigint1_bits_be)
             );
         }
     }

--- a/curve25519-dalek/src/ristretto.rs
+++ b/curve25519-dalek/src/ristretto.rs
@@ -970,7 +970,7 @@ impl VartimeMultiscalarMul for RistrettoPoint {
         I::Item: Borrow<Scalar>,
         J: IntoIterator<Item = Option<RistrettoPoint>>,
     {
-        let extended_points = points.into_iter().map(|opt_P| opt_P.map(|P| P.borrow().0));
+        let extended_points = points.into_iter().map(|opt_P| opt_P.map(|P| P.0));
 
         EdwardsPoint::optional_multiscalar_mul(scalars, extended_points).map(RistrettoPoint)
     }


### PR DESCRIPTION
There is occasionally [a need](https://github.com/dalek-cryptography/curve25519-dalek/pull/519#issuecomment-1637770888) to multiply a non-prime-order Montgomery point by an integer. There's currently no way to do this, since our only methods are multiplication by `Scalar` (doesn't make sense in the non-prime-order case), and `MontgomeryPoint::mul_base_clamped` clamps the integer before multiplying.

So we define `MontgomeryPoint::mul_bits_be`, gated behind `hazmat`, which takes a big-endian representation of an integer and multiplies the point by that integer.

cc @elichai