### PR TITLE
 Sign/verify by digest update, StreamVerifier refactoring

### DIFF
--- a/ed25519-dalek/CHANGELOG.md
+++ b/ed25519-dalek/CHANGELOG.md
@@ -34,6 +34,7 @@ Entries are listed in reverse chronological order per undeprecated major series.
 * Add `pkcs` feature to support PKCS #8 (de)serialization of `SigningKey` and `VerifyingKey`
 * Add `fast` feature to include basepoint tables
 * Add tests for validation criteria
+* Add `SigningKey::verify_stream()`, and `VerifyingKey::verify_stream()`
 * Impl `DigestSigner`/`DigestVerifier` for `SigningKey`/`VerifyingKey`, respectively
 * Impl `Hash` for `VerifyingKey`
 * Impl `Clone`, `Drop`, and `ZeroizeOnDrop` for `SigningKey`

--- a/ed25519-dalek/src/signing.rs
+++ b/ed25519-dalek/src/signing.rs
@@ -41,7 +41,7 @@ use crate::{
     errors::{InternalError, SignatureError},
     hazmat::ExpandedSecretKey,
     signature::InternalSignature,
-    verifying::VerifyingKey,
+    verifying::{StreamVerifier, VerifyingKey},
     Signature,
 };
 
@@ -471,6 +471,16 @@ impl SigningKey {
         signature: &Signature,
     ) -> Result<(), SignatureError> {
         self.verifying_key.verify_strict(message, signature)
+    }
+
+    /// Constructs stream verifier with candidate `signature`.
+    ///
+    /// See [`VerifyingKey::verify_stream()`] for more details.
+    pub fn verify_stream(
+        &self,
+        signature: &ed25519::Signature,
+    ) -> Result<StreamVerifier, SignatureError> {
+        self.verifying_key.verify_stream(signature)
     }
 
     /// Convert this signing key into a byte representation of a(n) (unreduced) Curve25519 scalar.

--- a/ed25519-dalek/src/verifying.rs
+++ b/ed25519-dalek/src/verifying.rs
@@ -43,6 +43,9 @@ use crate::{
     signing::SigningKey,
 };
 
+mod stream;
+pub use self::stream::StreamVerifier;
+
 /// An ed25519 public key.
 ///
 /// # Note
@@ -398,8 +401,21 @@ impl VerifyingKey {
         }
     }
 
+    /// Constructs stream verifier with candidate `signature`.
+    ///
+    /// Useful for cases where the whole message is not available all at once, allowing the
+    /// internal signature state to be updated incrementally and verified at the end. In some cases,
+    /// this will reduce the need for additional allocations.
+    pub fn verify_stream(
+        &self,
+        signature: &ed25519::Signature,
+    ) -> Result<StreamVerifier, SignatureError> {
+        let signature = InternalSignature::try_from(signature)?;
+        Ok(StreamVerifier::new(*self, signature))
+    }
+
     /// Verify a `signature` on a `prehashed_message` using the Ed25519ph algorithm,
-    /// using strict signture checking as defined by [`Self::verify_strict`].
+    /// using strict signature checking as defined by [`Self::verify_strict`].
     ///
     /// # Inputs
     ///

--- a/ed25519-dalek/src/verifying.rs
+++ b/ed25519-dalek/src/verifying.rs
@@ -187,58 +187,8 @@ impl VerifyingKey {
         self.point.is_small_order()
     }
 
-    // A helper function that computes `H(R || A || M)` where `H` is the 512-bit hash function
-    // given by `CtxDigest` (this is SHA-512 in spec-compliant Ed25519). If `context.is_some()`,
-    // this does the prehashed variant of the computation using its contents.
-    #[allow(non_snake_case)]
-    fn compute_challenge<CtxDigest>(
-        context: Option<&[u8]>,
-        R: &CompressedEdwardsY,
-        A: &CompressedEdwardsY,
-        M: &[u8],
-    ) -> Scalar
-    where
-        CtxDigest: Digest<OutputSize = U64>,
-    {
-        let mut h = CtxDigest::new();
-        if let Some(c) = context {
-            h.update(b"SigEd25519 no Ed25519 collisions");
-            h.update([1]); // Ed25519ph
-            h.update([c.len() as u8]);
-            h.update(c);
-        }
-        h.update(R.as_bytes());
-        h.update(A.as_bytes());
-        h.update(M);
-
-        Scalar::from_hash(h)
-    }
-
-    // Helper function for verification. Computes the _expected_ R component of the signature. The
-    // caller compares this to the real R component.  If `context.is_some()`, this does the
-    // prehashed variant of the computation using its contents.
-    // Note that this returns the compressed form of R and the caller does a byte comparison. This
-    // means that all our verification functions do not accept non-canonically encoded R values.
-    // See the validation criteria blog post for more details:
-    //     https://hdevalence.ca/blog/2020-10-04-its-25519am
-    #[allow(non_snake_case)]
-    fn recompute_R<CtxDigest>(
-        &self,
-        context: Option<&[u8]>,
-        signature: &InternalSignature,
-        M: &[u8],
-    ) -> CompressedEdwardsY
-    where
-        CtxDigest: Digest<OutputSize = U64>,
-    {
-        let k = Self::compute_challenge::<CtxDigest>(context, &signature.R, &self.compressed, M);
-        let minus_A: EdwardsPoint = -self.point;
-        // Recall the (non-batched) verification equation: -[k]A + [s]B = R
-        EdwardsPoint::vartime_double_scalar_mul_basepoint(&k, &(minus_A), &signature.s).compress()
-    }
-
     /// The ordinary non-batched Ed25519 verification check, rejecting non-canonical R values. (see
-    /// [`Self::recompute_R`]). `CtxDigest` is the digest used to calculate the pseudorandomness
+    /// [`Self::RCompute`]). `CtxDigest` is the digest used to calculate the pseudorandomness
     /// needed for signing. According to the spec, `CtxDigest = Sha512`.
     ///
     /// This definition is loose in its parameters so that end-users of the `hazmat` module can
@@ -254,7 +204,7 @@ impl VerifyingKey {
     {
         let signature = InternalSignature::try_from(signature)?;
 
-        let expected_R = self.recompute_R::<CtxDigest>(None, &signature, message);
+        let expected_R = RCompute::<CtxDigest>::compute(self, signature, None, message);
         if expected_R == signature.R {
             Ok(())
         } else {
@@ -290,7 +240,8 @@ impl VerifyingKey {
         );
 
         let message = prehashed_message.finalize();
-        let expected_R = self.recompute_R::<CtxDigest>(Some(ctx), &signature, &message);
+
+        let expected_R = RCompute::<CtxDigest>::compute(self, signature, Some(ctx), &message);
 
         if expected_R == signature.R {
             Ok(())
@@ -416,7 +367,7 @@ impl VerifyingKey {
             return Err(InternalError::Verify.into());
         }
 
-        let expected_R = self.recompute_R::<Sha512>(None, &signature, message);
+        let expected_R = RCompute::<Sha512>::compute(self, signature, None, message);
         if expected_R == signature.R {
             Ok(())
         } else {
@@ -478,7 +429,7 @@ impl VerifyingKey {
         }
 
         let message = prehashed_message.finalize();
-        let expected_R = self.recompute_R::<Sha512>(Some(ctx), &signature, &message);
+        let expected_R = RCompute::<Sha512>::compute(self, signature, Some(ctx), &message);
 
         if expected_R == signature.R {
             Ok(())
@@ -504,6 +455,74 @@ impl VerifyingKey {
     /// [On using the same key pair for Ed25519 and an X25519 based KEM](https://eprint.iacr.org/2021/509).
     pub fn to_montgomery(&self) -> MontgomeryPoint {
         self.point.to_montgomery()
+    }
+}
+
+// Helper for verification. Computes the _expected_ R component of the signature. The
+// caller compares this to the real R component.
+// For prehashed variants a `h` with the context already included can be provided.
+// Note that this returns the compressed form of R and the caller does a byte comparison. This
+// means that all our verification functions do not accept non-canonically encoded R values.
+// See the validation criteria blog post for more details:
+//     https://hdevalence.ca/blog/2020-10-04-its-25519am
+pub(crate) struct RCompute<CtxDigest> {
+    key: VerifyingKey,
+    signature: InternalSignature,
+    h: CtxDigest,
+}
+
+#[allow(non_snake_case)]
+impl<CtxDigest> RCompute<CtxDigest>
+where
+    CtxDigest: Digest<OutputSize = U64>,
+{
+    pub fn compute(
+        key: &VerifyingKey,
+        signature: InternalSignature,
+        prehash_ctx: Option<&[u8]>,
+        message: &[u8],
+    ) -> CompressedEdwardsY {
+        let mut c = Self::new(key, signature, prehash_ctx);
+        c.update(message);
+        c.finish()
+    }
+
+    pub fn new(
+        key: &VerifyingKey,
+        signature: InternalSignature,
+        prehash_ctx: Option<&[u8]>,
+    ) -> Self {
+        let R = &signature.R;
+        let A = &key.compressed;
+
+        let mut h = CtxDigest::new();
+        if let Some(c) = prehash_ctx {
+            h.update(b"SigEd25519 no Ed25519 collisions");
+            h.update([1]); // Ed25519ph
+            h.update([c.len() as u8]);
+            h.update(c);
+        }
+
+        h.update(R.as_bytes());
+        h.update(A.as_bytes());
+        Self {
+            key: *key,
+            signature,
+            h,
+        }
+    }
+
+    pub fn update(&mut self, m: &[u8]) {
+        self.h.update(m)
+    }
+
+    pub fn finish(self) -> CompressedEdwardsY {
+        let k = Scalar::from_hash(self.h);
+
+        let minus_A: EdwardsPoint = -self.key.point;
+        // Recall the (non-batched) verification equation: -[k]A + [s]B = R
+        EdwardsPoint::vartime_double_scalar_mul_basepoint(&k, &(minus_A), &self.signature.s)
+            .compress()
     }
 }
 

--- a/ed25519-dalek/src/verifying/stream.rs
+++ b/ed25519-dalek/src/verifying/stream.rs
@@ -1,0 +1,58 @@
+use curve25519_dalek::{edwards::EdwardsPoint, scalar::Scalar};
+use sha2::{Digest, Sha512};
+
+use crate::{signature::InternalSignature, InternalError, SignatureError, VerifyingKey};
+
+/// An IUF verifier for ed25519.
+///
+/// Created with [`VerifyingKey::verify_stream()`] or [`SigningKey::verify_stream()`].
+///
+/// [`SigningKey::verify_stream()`]: super::SigningKey::verify_stream()
+#[derive(Debug)]
+pub struct StreamVerifier {
+    /// Public key to verify with.
+    pub(crate) public_key: VerifyingKey,
+
+    /// Candidate signature to verify against.
+    pub(crate) signature: InternalSignature,
+
+    /// Hash state.
+    pub(crate) hasher: Sha512,
+}
+
+impl StreamVerifier {
+    /// Constructs new stream verifier.
+    ///
+    /// Seeds hash state with public key and signature components.
+    pub(crate) fn new(public_key: VerifyingKey, signature: InternalSignature) -> Self {
+        let mut hasher = Sha512::new();
+        hasher.update(signature.R.as_bytes());
+        hasher.update(public_key.as_bytes());
+
+        Self {
+            public_key,
+            hasher,
+            signature,
+        }
+    }
+
+    /// Digest message chunk.
+    pub fn update(&mut self, chunk: impl AsRef<[u8]>) {
+        self.hasher.update(&chunk);
+    }
+
+    /// Finalize verifier and check against candidate signature.
+    #[allow(non_snake_case)]
+    pub fn finalize_and_verify(self) -> Result<(), SignatureError> {
+        let minus_A: EdwardsPoint = -self.public_key.point;
+        let k = Scalar::from_hash(self.hasher);
+        let R =
+            EdwardsPoint::vartime_double_scalar_mul_basepoint(&k, &(minus_A), &self.signature.s);
+
+        if R.compress() == self.signature.R {
+            Ok(())
+        } else {
+            Err(InternalError::Verify.into())
+        }
+    }
+}

--- a/ed25519-dalek/tests/ed25519.rs
+++ b/ed25519-dalek/tests/ed25519.rs
@@ -340,6 +340,45 @@ mod integrations {
 
     #[cfg(feature = "digest")]
     #[test]
+    fn sign_verify_digest_equivalence() {
+        // TestSignVerify
+        let keypair: SigningKey;
+        let good_sig: Signature;
+        let bad_sig: Signature;
+
+        let good: &[u8] = "test message".as_bytes();
+        let bad: &[u8] = "wrong message".as_bytes();
+
+        let mut csprng = OsRng {};
+
+        keypair = SigningKey::generate(&mut csprng);
+        good_sig = keypair.sign(&good);
+        bad_sig = keypair.sign(&bad);
+
+        let mut verifier = keypair.verify_stream(&good_sig).unwrap();
+        verifier.update(&good);
+        assert!(
+            verifier.finalize_and_verify().is_ok(),
+            "Verification of a valid signature failed!"
+        );
+
+        let mut verifier = keypair.verify_stream(&bad_sig).unwrap();
+        verifier.update(&good);
+        assert!(
+            verifier.finalize_and_verify().is_err(),
+            "Verification of a signature on a different message passed!"
+        );
+
+        let mut verifier = keypair.verify_stream(&good_sig).unwrap();
+        verifier.update(&bad);
+        assert!(
+            verifier.finalize_and_verify().is_err(),
+            "Verification of a signature on a different message passed!"
+        );
+    }
+
+    #[cfg(feature = "digest")]
+    #[test]
     fn ed25519ph_sign_verify() {
         let signing_key: SigningKey;
         let good_sig: Signature;


### PR DESCRIPTION
This replaces https://github.com/dalek-cryptography/ed25519-dalek/pull/304

I'd like to be able to sign/verify non-prehash signatures without the whole message in memory. The use case is for running on `no_std` embedded where the message is serialized directly into the sha512 digest. It's for SSH protocol so I can't use ed25519 prehashed.

The `StreamVerifier` pull request #542 provides similar functionality, though streaming is only possible for verify (signing needs two passes). Instead I've added `raw_sign_byupdate()` and `raw_verify_byupdate()` that take a closure to update the message digest.

I've included the `StreamVerifier` commit from #542 and moved `recompute_R` into its own struct `RCompute`. That lets all the verifier options use the same code path.

 `_byupdate` isn't the best name, but other names I came up with would get confused with prehashed methods. I'm open to other suggestions.