### PR TITLE
Adapt to new types introduced in fiat-crypto 0.2

### DIFF
--- a/curve25519-dalek/Cargo.toml
+++ b/curve25519-dalek/Cargo.toml
@@ -59,7 +59,7 @@ zeroize = { version = "1", default-features = false, optional = true }
 cpufeatures = "0.2.6"
 
 [target.'cfg(curve25519_dalek_backend = "fiat")'.dependencies]
-fiat-crypto = { version = "0.1.19", default-features = false }
+fiat-crypto = { version = "0.2.1", default-features = false }
 
 [features]
 default = ["alloc", "precomputed-tables", "zeroize"]

--- a/curve25519-dalek/src/backend/serial/fiat_u32/field.rs
+++ b/curve25519-dalek/src/backend/serial/fiat_u32/field.rs
@@ -55,73 +55,78 @@ use fiat_crypto::curve25519_32::*;
 /// The backend-specific type `FieldElement2625` should not be used
 /// outside of the `curve25519_dalek::field` module.
 #[derive(Copy, Clone)]
-pub struct FieldElement2625(pub(crate) [u32; 10]);
+pub struct FieldElement2625(pub(crate) fiat_25519_tight_field_element);
 
 impl Debug for FieldElement2625 {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        write!(f, "FieldElement2625({:?})", &self.0[..])
+        write!(f, "FieldElement2625({:?})", &(self.0).0[..])
     }
 }
 
 #[cfg(feature = "zeroize")]
 impl Zeroize for FieldElement2625 {
     fn zeroize(&mut self) {
-        self.0.zeroize();
+        (self.0).0.zeroize();
     }
 }
 
 impl<'b> AddAssign<&'b FieldElement2625> for FieldElement2625 {
-    fn add_assign(&mut self, _rhs: &'b FieldElement2625) {
-        let input = self.0;
-        fiat_25519_add(&mut self.0, &input, &_rhs.0);
-        let input = self.0;
-        fiat_25519_carry(&mut self.0, &input);
+    fn add_assign(&mut self, rhs: &'b FieldElement2625) {
+        let mut result_loose = fiat_25519_loose_field_element([0; 10]);
+        fiat_25519_add(&mut result_loose, &self.0, &rhs.0);
+        fiat_25519_carry(&mut self.0, &result_loose);
     }
 }
 
 impl<'a, 'b> Add<&'b FieldElement2625> for &'a FieldElement2625 {
     type Output = FieldElement2625;
-    fn add(self, _rhs: &'b FieldElement2625) -> FieldElement2625 {
-        let mut output = *self;
-        fiat_25519_add(&mut output.0, &self.0, &_rhs.0);
-        let input = output.0;
-        fiat_25519_carry(&mut output.0, &input);
+    fn add(self, rhs: &'b FieldElement2625) -> FieldElement2625 {
+        let mut result_loose = fiat_25519_loose_field_element([0; 10]);
+        fiat_25519_add(&mut result_loose, &self.0, &rhs.0);
+        let mut output = FieldElement2625::ZERO;
+        fiat_25519_carry(&mut output.0, &result_loose);
         output
     }
 }
 
 impl<'b> SubAssign<&'b FieldElement2625> for FieldElement2625 {
-    fn sub_assign(&mut self, _rhs: &'b FieldElement2625) {
-        let input = self.0;
-        fiat_25519_sub(&mut self.0, &input, &_rhs.0);
-        let input = self.0;
-        fiat_25519_carry(&mut self.0, &input);
+    fn sub_assign(&mut self, rhs: &'b FieldElement2625) {
+        let mut result_loose = fiat_25519_loose_field_element([0; 10]);
+        fiat_25519_sub(&mut result_loose, &self.0, &rhs.0);
+        fiat_25519_carry(&mut self.0, &result_loose);
     }
 }
 
 impl<'a, 'b> Sub<&'b FieldElement2625> for &'a FieldElement2625 {
     type Output = FieldElement2625;
-    fn sub(self, _rhs: &'b FieldElement2625) -> FieldElement2625 {
-        let mut output = *self;
-        fiat_25519_sub(&mut output.0, &self.0, &_rhs.0);
-        let input = output.0;
-        fiat_25519_carry(&mut output.0, &input);
+    fn sub(self, rhs: &'b FieldElement2625) -> FieldElement2625 {
+        let mut result_loose = fiat_25519_loose_field_element([0; 10]);
+        fiat_25519_sub(&mut result_loose, &self.0, &rhs.0);
+        let mut output = FieldElement2625::ZERO;
+        fiat_25519_carry(&mut output.0, &result_loose);
         output
     }
 }
 
 impl<'b> MulAssign<&'b FieldElement2625> for FieldElement2625 {
-    fn mul_assign(&mut self, _rhs: &'b FieldElement2625) {
-        let input = self.0;
-        fiat_25519_carry_mul(&mut self.0, &input, &_rhs.0);
+    fn mul_assign(&mut self, rhs: &'b FieldElement2625) {
+        let mut self_loose = fiat_25519_loose_field_element([0; 10]);
+        fiat_25519_relax(&mut self_loose, &self.0);
+        let mut rhs_loose = fiat_25519_loose_field_element([0; 10]);
+        fiat_25519_relax(&mut rhs_loose, &rhs.0);
+        fiat_25519_carry_mul(&mut self.0, &self_loose, &rhs_loose);
     }
 }
 
 impl<'a, 'b> Mul<&'b FieldElement2625> for &'a FieldElement2625 {
     type Output = FieldElement2625;
-    fn mul(self, _rhs: &'b FieldElement2625) -> FieldElement2625 {
-        let mut output = *self;
-        fiat_25519_carry_mul(&mut output.0, &self.0, &_rhs.0);
+    fn mul(self, rhs: &'b FieldElement2625) -> FieldElement2625 {
+        let mut self_loose = fiat_25519_loose_field_element([0; 10]);
+        fiat_25519_relax(&mut self_loose, &self.0);
+        let mut rhs_loose = fiat_25519_loose_field_element([0; 10]);
+        fiat_25519_relax(&mut rhs_loose, &rhs.0);
+        let mut output = FieldElement2625::ZERO;
+        fiat_25519_carry_mul(&mut output.0, &self_loose, &rhs_loose);
         output
     }
 }
@@ -129,10 +134,10 @@ impl<'a, 'b> Mul<&'b FieldElement2625> for &'a FieldElement2625 {
 impl<'a> Neg for &'a FieldElement2625 {
     type Output = FieldElement2625;
     fn neg(self) -> FieldElement2625 {
-        let mut output = *self;
-        fiat_25519_opp(&mut output.0, &self.0);
-        let input = output.0;
-        fiat_25519_carry(&mut output.0, &input);
+        let mut output_loose = fiat_25519_loose_field_element([0; 10]);
+        fiat_25519_opp(&mut output_loose, &self.0);
+        let mut output = FieldElement2625::ZERO;
+        fiat_25519_carry(&mut output.0, &output_loose);
         output
     }
 }
@@ -143,8 +148,13 @@ impl ConditionallySelectable for FieldElement2625 {
         b: &FieldElement2625,
         choice: Choice,
     ) -> FieldElement2625 {
-        let mut output = [0u32; 10];
-        fiat_25519_selectznz(&mut output, choice.unwrap_u8() as fiat_25519_u1, &a.0, &b.0);
+        let mut output = fiat_25519_tight_field_element([0u32; 10]);
+        fiat_25519_selectznz(
+            &mut output.0,
+            choice.unwrap_u8() as fiat_25519_u1,
+            &(a.0).0,
+            &(b.0).0,
+        );
         FieldElement2625(output)
     }
 
@@ -161,7 +171,7 @@ impl ConditionallySelectable for FieldElement2625 {
         fiat_25519_cmovznz_u32(&mut output[7], choicebit, self.0[7], other.0[7]);
         fiat_25519_cmovznz_u32(&mut output[8], choicebit, self.0[8], other.0[8]);
         fiat_25519_cmovznz_u32(&mut output[9], choicebit, self.0[9], other.0[9]);
-        *self = FieldElement2625(output);
+        *self = FieldElement2625::from_limbs(output);
     }
 
     fn conditional_swap(a: &mut FieldElement2625, b: &mut FieldElement2625, choice: Choice) {
@@ -179,12 +189,16 @@ impl ConditionallySelectable for FieldElement2625 {
 }
 
 impl FieldElement2625 {
+    pub(crate) const fn from_limbs(limbs: [u32; 10]) -> FieldElement2625 {
+        FieldElement2625(fiat_25519_tight_field_element(limbs))
+    }
+
     /// The scalar \\( 0 \\).
-    pub const ZERO: FieldElement2625 = FieldElement2625([0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+    pub const ZERO: FieldElement2625 = FieldElement2625::from_limbs([0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
     /// The scalar \\( 1 \\).
-    pub const ONE: FieldElement2625 = FieldElement2625([1, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+    pub const ONE: FieldElement2625 = FieldElement2625::from_limbs([1, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
     /// The scalar \\( -1 \\).
-    pub const MINUS_ONE: FieldElement2625 = FieldElement2625([
+    pub const MINUS_ONE: FieldElement2625 = FieldElement2625::from_limbs([
         0x3ffffec, 0x1ffffff, 0x3ffffff, 0x1ffffff, 0x3ffffff, 0x1ffffff, 0x3ffffff, 0x1ffffff,
         0x3ffffff, 0x1ffffff,
     ]);
@@ -220,7 +234,7 @@ impl FieldElement2625 {
         let mut temp = [0u8; 32];
         temp.copy_from_slice(data);
         temp[31] &= 127u8;
-        let mut output = [0u32; 10];
+        let mut output = fiat_25519_tight_field_element([0u32; 10]);
         fiat_25519_from_bytes(&mut output, &temp);
         FieldElement2625(output)
     }
@@ -235,20 +249,23 @@ impl FieldElement2625 {
 
     /// Compute `self^2`.
     pub fn square(&self) -> FieldElement2625 {
-        let mut output = *self;
-        fiat_25519_carry_square(&mut output.0, &self.0);
+        let mut self_loose = fiat_25519_loose_field_element([0; 10]);
+        fiat_25519_relax(&mut self_loose, &self.0);
+        let mut output = FieldElement2625::ZERO;
+        fiat_25519_carry_square(&mut output.0, &self_loose);
         output
     }
 
     /// Compute `2*self^2`.
     pub fn square2(&self) -> FieldElement2625 {
-        let mut output = *self;
-        let mut temp = *self;
-        // Void vs return type, measure cost of copying self
-        fiat_25519_carry_square(&mut temp.0, &self.0);
-        fiat_25519_add(&mut output.0, &temp.0, &temp.0);
-        let input = output.0;
-        fiat_25519_carry(&mut output.0, &input);
+        let mut self_loose = fiat_25519_loose_field_element([0; 10]);
+        fiat_25519_relax(&mut self_loose, &self.0);
+        let mut square = fiat_25519_tight_field_element([0; 10]);
+        fiat_25519_carry_square(&mut square, &self_loose);
+        let mut output_loose = fiat_25519_loose_field_element([0; 10]);
+        fiat_25519_add(&mut output_loose, &square, &square);
+        let mut output = FieldElement2625::ZERO;
+        fiat_25519_carry(&mut output.0, &output_loose);
         output
     }
 }

--- a/curve25519-dalek/src/backend/serial/fiat_u64/field.rs
+++ b/curve25519-dalek/src/backend/serial/fiat_u64/field.rs
@@ -44,73 +44,78 @@ use fiat_crypto::curve25519_64::*;
 /// The backend-specific type `FieldElement51` should not be used
 /// outside of the `curve25519_dalek::field` module.
 #[derive(Copy, Clone)]
-pub struct FieldElement51(pub(crate) [u64; 5]);
+pub struct FieldElement51(pub(crate) fiat_25519_tight_field_element);
 
 impl Debug for FieldElement51 {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        write!(f, "FieldElement51({:?})", &self.0[..])
+        write!(f, "FieldElement51({:?})", &(self.0).0[..])
     }
 }
 
 #[cfg(feature = "zeroize")]
 impl Zeroize for FieldElement51 {
     fn zeroize(&mut self) {
-        self.0.zeroize();
+        (self.0).0.zeroize();
     }
 }
 
 impl<'b> AddAssign<&'b FieldElement51> for FieldElement51 {
-    fn add_assign(&mut self, _rhs: &'b FieldElement51) {
-        let input = self.0;
-        fiat_25519_add(&mut self.0, &input, &_rhs.0);
-        let input = self.0;
-        fiat_25519_carry(&mut self.0, &input);
+    fn add_assign(&mut self, rhs: &'b FieldElement51) {
+        let mut result_loose = fiat_25519_loose_field_element([0; 5]);
+        fiat_25519_add(&mut result_loose, &self.0, &rhs.0);
+        fiat_25519_carry(&mut self.0, &result_loose);
     }
 }
 
 impl<'a, 'b> Add<&'b FieldElement51> for &'a FieldElement51 {
     type Output = FieldElement51;
-    fn add(self, _rhs: &'b FieldElement51) -> FieldElement51 {
-        let mut output = *self;
-        fiat_25519_add(&mut output.0, &self.0, &_rhs.0);
-        let input = output.0;
-        fiat_25519_carry(&mut output.0, &input);
+    fn add(self, rhs: &'b FieldElement51) -> FieldElement51 {
+        let mut result_loose = fiat_25519_loose_field_element([0; 5]);
+        fiat_25519_add(&mut result_loose, &self.0, &rhs.0);
+        let mut output = FieldElement51::ZERO;
+        fiat_25519_carry(&mut output.0, &result_loose);
         output
     }
 }
 
 impl<'b> SubAssign<&'b FieldElement51> for FieldElement51 {
-    fn sub_assign(&mut self, _rhs: &'b FieldElement51) {
-        let input = self.0;
-        fiat_25519_sub(&mut self.0, &input, &_rhs.0);
-        let input = self.0;
-        fiat_25519_carry(&mut self.0, &input);
+    fn sub_assign(&mut self, rhs: &'b FieldElement51) {
+        let mut result_loose = fiat_25519_loose_field_element([0; 5]);
+        fiat_25519_sub(&mut result_loose, &self.0, &rhs.0);
+        fiat_25519_carry(&mut self.0, &result_loose);
     }
 }
 
 impl<'a, 'b> Sub<&'b FieldElement51> for &'a FieldElement51 {
     type Output = FieldElement51;
-    fn sub(self, _rhs: &'b FieldElement51) -> FieldElement51 {
-        let mut output = *self;
-        fiat_25519_sub(&mut output.0, &self.0, &_rhs.0);
-        let input = output.0;
-        fiat_25519_carry(&mut output.0, &input);
+    fn sub(self, rhs: &'b FieldElement51) -> FieldElement51 {
+        let mut result_loose = fiat_25519_loose_field_element([0; 5]);
+        fiat_25519_sub(&mut result_loose, &self.0, &rhs.0);
+        let mut output = FieldElement51::ZERO;
+        fiat_25519_carry(&mut output.0, &result_loose);
         output
     }
 }
 
 impl<'b> MulAssign<&'b FieldElement51> for FieldElement51 {
-    fn mul_assign(&mut self, _rhs: &'b FieldElement51) {
-        let input = self.0;
-        fiat_25519_carry_mul(&mut self.0, &input, &_rhs.0);
+    fn mul_assign(&mut self, rhs: &'b FieldElement51) {
+        let mut self_loose = fiat_25519_loose_field_element([0; 5]);
+        fiat_25519_relax(&mut self_loose, &self.0);
+        let mut rhs_loose = fiat_25519_loose_field_element([0; 5]);
+        fiat_25519_relax(&mut rhs_loose, &rhs.0);
+        fiat_25519_carry_mul(&mut self.0, &self_loose, &rhs_loose);
     }
 }
 
 impl<'a, 'b> Mul<&'b FieldElement51> for &'a FieldElement51 {
     type Output = FieldElement51;
-    fn mul(self, _rhs: &'b FieldElement51) -> FieldElement51 {
-        let mut output = *self;
-        fiat_25519_carry_mul(&mut output.0, &self.0, &_rhs.0);
+    fn mul(self, rhs: &'b FieldElement51) -> FieldElement51 {
+        let mut self_loose = fiat_25519_loose_field_element([0; 5]);
+        fiat_25519_relax(&mut self_loose, &self.0);
+        let mut rhs_loose = fiat_25519_loose_field_element([0; 5]);
+        fiat_25519_relax(&mut rhs_loose, &rhs.0);
+        let mut output = FieldElement51::ZERO;
+        fiat_25519_carry_mul(&mut output.0, &self_loose, &rhs_loose);
         output
     }
 }
@@ -118,10 +123,10 @@ impl<'a, 'b> Mul<&'b FieldElement51> for &'a FieldElement51 {
 impl<'a> Neg for &'a FieldElement51 {
     type Output = FieldElement51;
     fn neg(self) -> FieldElement51 {
-        let mut output = *self;
-        fiat_25519_opp(&mut output.0, &self.0);
-        let input = output.0;
-        fiat_25519_carry(&mut output.0, &input);
+        let mut output_loose = fiat_25519_loose_field_element([0; 5]);
+        fiat_25519_opp(&mut output_loose, &self.0);
+        let mut output = FieldElement51::ZERO;
+        fiat_25519_carry(&mut output.0, &output_loose);
         output
     }
 }
@@ -132,8 +137,13 @@ impl ConditionallySelectable for FieldElement51 {
         b: &FieldElement51,
         choice: Choice,
     ) -> FieldElement51 {
-        let mut output = [0u64; 5];
-        fiat_25519_selectznz(&mut output, choice.unwrap_u8() as fiat_25519_u1, &a.0, &b.0);
+        let mut output = fiat_25519_tight_field_element([0u64; 5]);
+        fiat_25519_selectznz(
+            &mut output.0,
+            choice.unwrap_u8() as fiat_25519_u1,
+            &(a.0).0,
+            &(b.0).0,
+        );
         FieldElement51(output)
     }
 
@@ -145,25 +155,29 @@ impl ConditionallySelectable for FieldElement51 {
         u64::conditional_swap(&mut a.0[4], &mut b.0[4], choice);
     }
 
-    fn conditional_assign(&mut self, _rhs: &FieldElement51, choice: Choice) {
+    fn conditional_assign(&mut self, rhs: &FieldElement51, choice: Choice) {
         let mut output = [0u64; 5];
         let choicebit = choice.unwrap_u8() as fiat_25519_u1;
-        fiat_25519_cmovznz_u64(&mut output[0], choicebit, self.0[0], _rhs.0[0]);
-        fiat_25519_cmovznz_u64(&mut output[1], choicebit, self.0[1], _rhs.0[1]);
-        fiat_25519_cmovznz_u64(&mut output[2], choicebit, self.0[2], _rhs.0[2]);
-        fiat_25519_cmovznz_u64(&mut output[3], choicebit, self.0[3], _rhs.0[3]);
-        fiat_25519_cmovznz_u64(&mut output[4], choicebit, self.0[4], _rhs.0[4]);
-        *self = FieldElement51(output);
+        fiat_25519_cmovznz_u64(&mut output[0], choicebit, self.0[0], rhs.0[0]);
+        fiat_25519_cmovznz_u64(&mut output[1], choicebit, self.0[1], rhs.0[1]);
+        fiat_25519_cmovznz_u64(&mut output[2], choicebit, self.0[2], rhs.0[2]);
+        fiat_25519_cmovznz_u64(&mut output[3], choicebit, self.0[3], rhs.0[3]);
+        fiat_25519_cmovznz_u64(&mut output[4], choicebit, self.0[4], rhs.0[4]);
+        *self = FieldElement51::from_limbs(output);
     }
 }
 
 impl FieldElement51 {
+    pub(crate) const fn from_limbs(limbs: [u64; 5]) -> FieldElement51 {
+        FieldElement51(fiat_25519_tight_field_element(limbs))
+    }
+
     /// The scalar \\( 0 \\).
-    pub const ZERO: FieldElement51 = FieldElement51([0, 0, 0, 0, 0]);
+    pub const ZERO: FieldElement51 = FieldElement51::from_limbs([0, 0, 0, 0, 0]);
     /// The scalar \\( 1 \\).
-    pub const ONE: FieldElement51 = FieldElement51([1, 0, 0, 0, 0]);
+    pub const ONE: FieldElement51 = FieldElement51::from_limbs([1, 0, 0, 0, 0]);
     /// The scalar \\( -1 \\).
-    pub const MINUS_ONE: FieldElement51 = FieldElement51([
+    pub const MINUS_ONE: FieldElement51 = FieldElement51::from_limbs([
         2251799813685228,
         2251799813685247,
         2251799813685247,
@@ -174,10 +188,11 @@ impl FieldElement51 {
     /// Given 64-bit input limbs, reduce to enforce the bound 2^(51 + epsilon).
     #[inline(always)]
     #[allow(dead_code)] // Need this to not complain about reduce not being used
-    fn reduce(mut limbs: [u64; 5]) -> FieldElement51 {
-        let input = limbs;
-        fiat_25519_carry(&mut limbs, &input);
-        FieldElement51(limbs)
+    fn reduce(limbs: [u64; 5]) -> FieldElement51 {
+        let input = fiat_25519_loose_field_element(limbs);
+        let mut output = fiat_25519_tight_field_element([0; 5]);
+        fiat_25519_carry(&mut output, &input);
+        FieldElement51(output)
     }
 
     /// Load a `FieldElement51` from the low 255 bits of a 256-bit
@@ -196,7 +211,7 @@ impl FieldElement51 {
         let mut temp = [0u8; 32];
         temp.copy_from_slice(bytes);
         temp[31] &= 127u8;
-        let mut output = [0u64; 5];
+        let mut output = fiat_25519_tight_field_element([0u64; 5]);
         fiat_25519_from_bytes(&mut output, &temp);
         FieldElement51(output)
     }
@@ -213,7 +228,8 @@ impl FieldElement51 {
     pub fn pow2k(&self, mut k: u32) -> FieldElement51 {
         let mut output = *self;
         loop {
-            let input = output.0;
+            let mut input = fiat_25519_loose_field_element([0; 5]);
+            fiat_25519_relax(&mut input, &output.0);
             fiat_25519_carry_square(&mut output.0, &input);
             k -= 1;
             if k == 0 {
@@ -224,20 +240,23 @@ impl FieldElement51 {
 
     /// Returns the square of this field element.
     pub fn square(&self) -> FieldElement51 {
-        let mut output = *self;
-        fiat_25519_carry_square(&mut output.0, &self.0);
+        let mut self_loose = fiat_25519_loose_field_element([0; 5]);
+        fiat_25519_relax(&mut self_loose, &self.0);
+        let mut output = FieldElement51::ZERO;
+        fiat_25519_carry_square(&mut output.0, &self_loose);
         output
     }
 
     /// Returns 2 times the square of this field element.
     pub fn square2(&self) -> FieldElement51 {
-        let mut output = *self;
-        let mut temp = *self;
-        // Void vs return type, measure cost of copying self
-        fiat_25519_carry_square(&mut temp.0, &self.0);
-        fiat_25519_add(&mut output.0, &temp.0, &temp.0);
-        let input = output.0;
-        fiat_25519_carry(&mut output.0, &input);
+        let mut self_loose = fiat_25519_loose_field_element([0; 5]);
+        fiat_25519_relax(&mut self_loose, &self.0);
+        let mut square = fiat_25519_tight_field_element([0; 5]);
+        fiat_25519_carry_square(&mut square, &self_loose);
+        let mut output_loose = fiat_25519_loose_field_element([0; 5]);
+        fiat_25519_add(&mut output_loose, &square, &square);
+        let mut output = FieldElement51::ZERO;
+        fiat_25519_carry(&mut output.0, &output_loose);
         output
     }
 }

--- a/curve25519-dalek/src/backend/serial/u32/constants.rs
+++ b/curve25519-dalek/src/backend/serial/u32/constants.rs
@@ -25,61 +25,61 @@ use crate::{
 };
 
 /// The value of minus one, equal to `-&FieldElement::ONE`
-pub(crate) const MINUS_ONE: FieldElement2625 = FieldElement2625([
+pub(crate) const MINUS_ONE: FieldElement2625 = FieldElement2625::from_limbs([
     67108844, 33554431, 67108863, 33554431, 67108863, 33554431, 67108863, 33554431, 67108863,
     33554431,
 ]);
 
 /// Edwards `d` value, equal to `-121665/121666 mod p`.
-pub(crate) const EDWARDS_D: FieldElement2625 = FieldElement2625([
+pub(crate) const EDWARDS_D: FieldElement2625 = FieldElement2625::from_limbs([
     56195235, 13857412, 51736253, 6949390, 114729, 24766616, 60832955, 30306712, 48412415, 21499315,
 ]);
 
 /// Edwards `2*d` value, equal to `2*(-121665/121666) mod p`.
-pub(crate) const EDWARDS_D2: FieldElement2625 = FieldElement2625([
+pub(crate) const EDWARDS_D2: FieldElement2625 = FieldElement2625::from_limbs([
     45281625, 27714825, 36363642, 13898781, 229458, 15978800, 54557047, 27058993, 29715967, 9444199,
 ]);
 
 /// One minus edwards `d` value squared, equal to `(1 - (-121665/121666) mod p) pow 2`
-pub(crate) const ONE_MINUS_EDWARDS_D_SQUARED: FieldElement2625 = FieldElement2625([
+pub(crate) const ONE_MINUS_EDWARDS_D_SQUARED: FieldElement2625 = FieldElement2625::from_limbs([
     6275446, 16937061, 44170319, 29780721, 11667076, 7397348, 39186143, 1766194, 42675006, 672202,
 ]);
 
 /// Edwards `d` value minus one squared, equal to `(((-121665/121666) mod p) - 1) pow 2`
-pub(crate) const EDWARDS_D_MINUS_ONE_SQUARED: FieldElement2625 = FieldElement2625([
+pub(crate) const EDWARDS_D_MINUS_ONE_SQUARED: FieldElement2625 = FieldElement2625::from_limbs([
     15551776, 22456977, 53683765, 23429360, 55212328, 10178283, 40474537, 4729243, 61826754,
     23438029,
 ]);
 
 /// `= sqrt(a*d - 1)`, where `a = -1 (mod p)`, `d` are the Edwards curve parameters.
-pub(crate) const SQRT_AD_MINUS_ONE: FieldElement2625 = FieldElement2625([
+pub(crate) const SQRT_AD_MINUS_ONE: FieldElement2625 = FieldElement2625::from_limbs([
     24849947, 33400850, 43495378, 6347714, 46036536, 32887293, 41837720, 18186727, 66238516,
     14525638,
 ]);
 
 /// `= 1/sqrt(a-d)`, where `a = -1 (mod p)`, `d` are the Edwards curve parameters.
-pub(crate) const INVSQRT_A_MINUS_D: FieldElement2625 = FieldElement2625([
+pub(crate) const INVSQRT_A_MINUS_D: FieldElement2625 = FieldElement2625::from_limbs([
     6111466, 4156064, 39310137, 12243467, 41204824, 120896, 20826367, 26493656, 6093567, 31568420,
 ]);
 
 /// Precomputed value of one of the square roots of -1 (mod p)
-pub(crate) const SQRT_M1: FieldElement2625 = FieldElement2625([
+pub(crate) const SQRT_M1: FieldElement2625 = FieldElement2625::from_limbs([
     34513072, 25610706, 9377949, 3500415, 12389472, 33281959, 41962654, 31548777, 326685, 11406482,
 ]);
 
 /// `APLUS2_OVER_FOUR` is (A+2)/4. (This is used internally within the Montgomery ladder.)
 pub(crate) const APLUS2_OVER_FOUR: FieldElement2625 =
-    FieldElement2625([121666, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+    FieldElement2625::from_limbs([121666, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
 
 /// `MONTGOMERY_A` is equal to 486662, which is a constant of the curve equation
 /// for Curve25519 in its Montgomery form. (This is used internally within the
 /// Elligator map.)
 pub(crate) const MONTGOMERY_A: FieldElement2625 =
-    FieldElement2625([486662, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+    FieldElement2625::from_limbs([486662, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
 
 /// `MONTGOMERY_A_NEG` is equal to -486662. (This is used internally within the
 /// Elligator map.)
-pub(crate) const MONTGOMERY_A_NEG: FieldElement2625 = FieldElement2625([
+pub(crate) const MONTGOMERY_A_NEG: FieldElement2625 = FieldElement2625::from_limbs([
     66622183, 33554431, 67108863, 33554431, 67108863, 33554431, 67108863, 33554431, 67108863,
     33554431,
 ]);
@@ -112,16 +112,16 @@ pub(crate) const RR: Scalar29 = Scalar29([
 /// `ED25519_BASEPOINT_TABLE`, which should be used for scalar
 /// multiplication (it's much faster).
 pub const ED25519_BASEPOINT_POINT: EdwardsPoint = EdwardsPoint {
-    X: FieldElement2625([
+    X: FieldElement2625::from_limbs([
         52811034, 25909283, 16144682, 17082669, 27570973, 30858332, 40966398, 8378388, 20764389,
         8758491,
     ]),
-    Y: FieldElement2625([
+    Y: FieldElement2625::from_limbs([
         40265304, 26843545, 13421772, 20132659, 26843545, 6710886, 53687091, 13421772, 40265318,
         26843545,
     ]),
-    Z: FieldElement2625([1, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
-    T: FieldElement2625([
+    Z: FieldElement2625::from_limbs([1, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+    T: FieldElement2625::from_limbs([
         28827043, 27438313, 39759291, 244362, 8635006, 11264893, 19351346, 13413597, 16611511,
         27139452,
     ]),
@@ -144,94 +144,94 @@ pub const EIGHT_TORSION: [EdwardsPoint; 8] = EIGHT_TORSION_INNER_DOC_HIDDEN;
 #[doc(hidden)]
 pub const EIGHT_TORSION_INNER_DOC_HIDDEN: [EdwardsPoint; 8] = [
     EdwardsPoint {
-        X: FieldElement2625([0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
-        Y: FieldElement2625([1, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
-        Z: FieldElement2625([1, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
-        T: FieldElement2625([0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+        X: FieldElement2625::from_limbs([0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+        Y: FieldElement2625::from_limbs([1, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+        Z: FieldElement2625::from_limbs([1, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+        T: FieldElement2625::from_limbs([0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
     },
     EdwardsPoint {
-        X: FieldElement2625([
+        X: FieldElement2625::from_limbs([
             21352778, 5345713, 4660180, 25206575, 24143089, 14568123, 30185756, 21306662, 33579924,
             8345318,
         ]),
-        Y: FieldElement2625([
+        Y: FieldElement2625::from_limbs([
             6952903, 1265500, 60246523, 7057497, 4037696, 5447722, 35427965, 15325401, 19365852,
             31985330,
         ]),
-        Z: FieldElement2625([1, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
-        T: FieldElement2625([
+        Z: FieldElement2625::from_limbs([1, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+        T: FieldElement2625::from_limbs([
             41846657, 21581751, 11716001, 27684820, 48915701, 16297738, 20670665, 24995334,
             3541542, 28543251,
         ]),
     },
     EdwardsPoint {
-        X: FieldElement2625([
+        X: FieldElement2625::from_limbs([
             32595773, 7943725, 57730914, 30054016, 54719391, 272472, 25146209, 2005654, 66782178,
             22147949,
         ]),
-        Y: FieldElement2625([0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
-        Z: FieldElement2625([1, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
-        T: FieldElement2625([0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+        Y: FieldElement2625::from_limbs([0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+        Z: FieldElement2625::from_limbs([1, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+        T: FieldElement2625::from_limbs([0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
     },
     EdwardsPoint {
-        X: FieldElement2625([
+        X: FieldElement2625::from_limbs([
             21352778, 5345713, 4660180, 25206575, 24143089, 14568123, 30185756, 21306662, 33579924,
             8345318,
         ]),
-        Y: FieldElement2625([
+        Y: FieldElement2625::from_limbs([
             60155942, 32288931, 6862340, 26496934, 63071167, 28106709, 31680898, 18229030,
             47743011, 1569101,
         ]),
-        Z: FieldElement2625([1, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
-        T: FieldElement2625([
+        Z: FieldElement2625::from_limbs([1, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+        T: FieldElement2625::from_limbs([
             25262188, 11972680, 55392862, 5869611, 18193162, 17256693, 46438198, 8559097, 63567321,
             5011180,
         ]),
     },
     EdwardsPoint {
-        X: FieldElement2625([0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
-        Y: FieldElement2625([
+        X: FieldElement2625::from_limbs([0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+        Y: FieldElement2625::from_limbs([
             67108844, 33554431, 67108863, 33554431, 67108863, 33554431, 67108863, 33554431,
             67108863, 33554431,
         ]),
-        Z: FieldElement2625([1, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
-        T: FieldElement2625([0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+        Z: FieldElement2625::from_limbs([1, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+        T: FieldElement2625::from_limbs([0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
     },
     EdwardsPoint {
-        X: FieldElement2625([
+        X: FieldElement2625::from_limbs([
             45756067, 28208718, 62448683, 8347856, 42965774, 18986308, 36923107, 12247769,
             33528939, 25209113,
         ]),
-        Y: FieldElement2625([
+        Y: FieldElement2625::from_limbs([
             60155942, 32288931, 6862340, 26496934, 63071167, 28106709, 31680898, 18229030,
             47743011, 1569101,
         ]),
-        Z: FieldElement2625([1, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
-        T: FieldElement2625([
+        Z: FieldElement2625::from_limbs([1, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+        T: FieldElement2625::from_limbs([
             41846657, 21581751, 11716001, 27684820, 48915701, 16297738, 20670665, 24995334,
             3541542, 28543251,
         ]),
     },
     EdwardsPoint {
-        X: FieldElement2625([
+        X: FieldElement2625::from_limbs([
             34513072, 25610706, 9377949, 3500415, 12389472, 33281959, 41962654, 31548777, 326685,
             11406482,
         ]),
-        Y: FieldElement2625([0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
-        Z: FieldElement2625([1, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
-        T: FieldElement2625([0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+        Y: FieldElement2625::from_limbs([0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+        Z: FieldElement2625::from_limbs([1, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+        T: FieldElement2625::from_limbs([0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
     },
     EdwardsPoint {
-        X: FieldElement2625([
+        X: FieldElement2625::from_limbs([
             45756067, 28208718, 62448683, 8347856, 42965774, 18986308, 36923107, 12247769,
             33528939, 25209113,
         ]),
-        Y: FieldElement2625([
+        Y: FieldElement2625::from_limbs([
             6952903, 1265500, 60246523, 7057497, 4037696, 5447722, 35427965, 15325401, 19365852,
             31985330,
         ]),
-        Z: FieldElement2625([1, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
-        T: FieldElement2625([
+        Z: FieldElement2625::from_limbs([1, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+        T: FieldElement2625::from_limbs([
             25262188, 11972680, 55392862, 5869611, 18193162, 17256693, 46438198, 8559097, 63567321,
             5011180,
         ]),
@@ -249,113 +249,113 @@ pub static ED25519_BASEPOINT_TABLE: &'static EdwardsBasepointTable =
 static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = EdwardsBasepointTable([
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 93076338, 52752828, 29566454, 37215328, 54414518, 37569218, 94653489, 21800160,
                 61029707, 35602036,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 54563134, 934261, 64385954, 3049989, 66381436, 9406985, 12720692, 5043384,
                 19500929, 18085054,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 58370664, 4489569, 9688441, 18769238, 10184608, 21191052, 29287918, 11864899,
                 42594502, 29115885,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 54292951, 54132516, 45527619, 11784319, 41753206, 30803714, 55390960, 29739860,
                 66750418, 23343128,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 45405608, 6903824, 27185491, 6451973, 37531140, 24000426, 51492312, 11189267,
                 40279186, 28235350,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 26966623, 11152617, 32442495, 15396054, 14353839, 20802097, 63980037, 24013313,
                 51636816, 29387734,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 82745136, 23865874, 24204772, 25642034, 67725840, 16869169, 94896463, 52336674,
                 28944398, 32004408,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 16568933, 4717097, 55552716, 32452109, 15682895, 21747389, 16354576, 21778470,
                 7689661, 11199574,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 30464137, 27578307, 55329429, 17883566, 23220364, 15915852, 7512774, 10017326,
                 49359771, 23634074,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 50071967, 13921891, 78054670, 27521000, 27105051, 17470053, 105291517, 15006021,
                 70393432, 27277891,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 23599295, 25248385, 55915199, 25867015, 13236773, 10506355, 7464579, 9656445,
                 13059162, 10374397,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 7798537, 16710257, 3033922, 2874086, 28997861, 2835604, 32406664, 29715387,
                 66467155, 33453106,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 77970208, 11473153, 27284546, 35535607, 37044514, 46132292, 99976748, 48069538,
                 118779423, 44373810,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 4708026, 6336745, 20377586, 9066809, 55836755, 6594695, 41455196, 12483687,
                 54440373, 5581305,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 19563141, 16186464, 37722007, 4097518, 10237984, 29206317, 28542349, 13850243,
                 43430843, 17738489,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 51736881, 20691677, 32573249, 4720197, 107781206, 39429941, 115029100, 18329611,
                 124398787, 21468653,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 58559652, 109982, 15149363, 2178705, 22900618, 4543417, 3044240, 17864545, 1762327,
                 14866737,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 48909169, 17603008, 56635573, 1707277, 49922944, 3916100, 38872452, 3959420,
                 27914454, 4383652,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 72262591, 43463716, 68832610, 30776557, 97632468, 39071304, 86589715, 38784565,
                 43156424, 18378665,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 36839857, 30090922, 7665485, 10083793, 28475525, 1649722, 20654025, 16520125,
                 30598449, 7715701,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 28881826, 14381568, 9657904, 3680757, 46927229, 7843315, 35708204, 1370707,
                 29794553, 32145132,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 14499452, 64379265, 33917749, 62854211, 95603724, 14271266, 97399599, 10876453,
                 33954766, 35936157,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 59913433, 30899068, 52378708, 462250, 39384538, 3941371, 60872247, 3696004,
                 34808032, 15351954,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 27431194, 8222322, 16448760, 29646437, 48401861, 11938354, 34147463, 30583916,
                 29551812, 10109425,
             ]),
@@ -363,113 +363,113 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 53451805, 20399000, 102933977, 45331528, 88556249, 40073815, 64730579, 31926875,
                 77201646, 28790260,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 27939166, 14210322, 4677035, 16277044, 44144402, 21156292, 34600109, 12005537,
                 49298737, 12803509,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 17228999, 17892808, 65875336, 300139, 65883994, 21839654, 30364212, 24516238,
                 18016356, 4397660,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 56150002, 25864224, 4776340, 18600194, 27850027, 17952220, 40489757, 14544524,
                 49631360, 34537070,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 29253598, 15796703, 64244882, 23645547, 10057022, 3163536, 7332899, 29434304,
                 46061167, 9934962,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 5793284, 16271923, 42977250, 23438027, 29188559, 1206517, 52360934, 4559894,
                 36984942, 22656481,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 39464893, 55615857, 83391519, 22517938, 28414020, 52096600, 24191032, 38096129,
                 53770554, 39054999,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 12650548, 32057319, 9052870, 11355358, 49428827, 25154267, 49678271, 12264342,
                 10874051, 13524335,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 25556948, 30508442, 714650, 2510400, 23394682, 23139102, 33119037, 5080568,
                 44580805, 5376627,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 108129445, 29543378, 50095164, 30016803, 60382070, 35475328, 44787558, 57661420,
                 71644630, 35123438,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 64853442, 14606629, 45416424, 25514613, 28430648, 8775819, 36614302, 3044289,
                 31848280, 12543772,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 45080285, 2943892, 35251351, 6777305, 13784462, 29262229, 39731668, 31491700,
                 7718481, 14474653,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 69494160, 36008644, 44477543, 33601034, 62670928, 51428448, 67765827, 26317766,
                 91425031, 28300864,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 13741529, 10911568, 33875447, 24950694, 46931033, 32521134, 33040650, 20129900,
                 46379407, 8321685,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 21060490, 31341688, 15712756, 29218333, 1639039, 10656336, 23845965, 21679594,
                 57124405, 608371,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 53436113, 18466845, 56219170, 25997372, 61071954, 11305546, 68232832, 60328286,
                 94338261, 33578318,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 43864724, 33260226, 55364135, 14712570, 37643165, 31524814, 12797023, 27114124,
                 65475458, 16678953,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 37608244, 4770661, 51054477, 14001337, 7830047, 9564805, 65600720, 28759386,
                 49939598, 4904952,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 91168402, 48171434, 86146020, 18514523, 86874956, 18648002, 72278074, 16191879,
                 69237100, 29227598,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 50127693, 4124965, 58568254, 22900634, 30336521, 19449185, 37302527, 916032,
                 60226322, 30567899,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 44477957, 12419371, 59974635, 26081060, 50629959, 16739174, 285431, 2763829,
                 15736322, 4143876,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 69488197, 11839344, 62998462, 27565766, 78383161, 34349388, 67321664, 18959768,
                 23527083, 17096164,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 33431108, 22423954, 49269897, 17927531, 8909498, 8376530, 34483524, 4087880,
                 51919953, 19138217,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 1767664, 7197987, 53903638, 31531796, 54017513, 448825, 5799055, 4357868, 62334673,
                 17231393,
             ]),
@@ -477,113 +477,113 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 6721947, 47388255, 43585475, 32003117, 93463156, 21691110, 90474010, 29604699,
                 74499753, 36314231,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 4409022, 2052381, 23373853, 10530217, 7676779, 20668478, 21302352, 29290375,
                 1244379, 20634787,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 62687625, 7169618, 4982368, 30596842, 30256824, 30776892, 14086412, 9208236,
                 15886429, 16489664,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 69104920, 43930080, 81455230, 46865633, 60234728, 17116020, 120524529, 33952799,
                 36502408, 32841498,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 41801399, 9795879, 64331450, 14878808, 33577029, 14780362, 13348553, 12076947,
                 36272402, 5113181,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 49338080, 11797795, 31950843, 13929123, 41220562, 12288343, 36767763, 26218045,
                 13847710, 5387222,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 48526682, 30138214, 84933706, 64767897, 89853205, 56666252, 75871923, 37172217,
                 47508201, 43925422,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 20246567, 19185054, 22358228, 33010720, 18507282, 23140436, 14554436, 24808340,
                 32232923, 16763880,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 9648486, 10094563, 26416693, 14745928, 36734546, 27081810, 11094160, 15689506,
                 3140038, 17044340,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 50948773, 39027126, 31895587, 38299426, 75932378, 43920116, 39884063, 43003044,
                 38334409, 33920726,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 19153450, 11523972, 56012374, 27051289, 42461232, 5420646, 28344573, 8041113,
                 719605, 11671788,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 8678006, 2694440, 60300850, 2517371, 4964326, 11152271, 51675948, 18287915,
                 27000812, 23358879,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 119059805, 40688742, 75748150, 30739554, 59873175, 43976173, 67672928, 38890528,
                 73859840, 19033405,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 11836410, 29574944, 26297893, 16080799, 23455045, 15735944, 1695823, 24735310,
                 8169719, 16220347,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 48993007, 8653646, 17578566, 27461813, 59083086, 17541668, 55964556, 30926767,
                 61118155, 19388398,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 43800347, 22586119, 82322091, 23473217, 36255258, 22504427, 27884328, 36401716,
                 69764724, 35292826,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 39571412, 19301410, 41772562, 25551651, 57738101, 8129820, 21651608, 30315096,
                 48021414, 22549153,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 1533110, 3437855, 23735889, 459276, 29970501, 11335377, 26030092, 5821408,
                 10478196, 8544890,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 32173083, 50979553, 24896205, 37475929, 22579055, 63698010, 19270447, 45771905,
                 84897880, 63712868,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 36555903, 31326030, 51530034, 23407230, 13243888, 517024, 15479401, 29701199,
                 30460519, 1052596,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 55493970, 13323617, 32618793, 8175907, 51878691, 12596686, 27491595, 28942073,
                 3179267, 24075541,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 99055914, 52742212, 62468279, 18214510, 51982886, 27514722, 52352086, 17142691,
                 19072639, 24043372,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 11685058, 11822410, 3158003, 19601838, 33402193, 29389366, 5977895, 28339415,
                 473098, 5040608,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 46817982, 8198641, 39698732, 11602122, 1290375, 30754672, 28326861, 1721092,
                 47550222, 30422825,
             ]),
@@ -591,113 +591,113 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 74990396, 10687936, 74687587, 7738377, 48157852, 31000479, 88929649, 8076148,
                 39240368, 11538388,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 47173198, 3899860, 18283497, 26752864, 51380203, 22305220, 8754524, 7446702,
                 61432810, 5797015,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 55813245, 29760862, 51326753, 25589858, 12708868, 25098233, 2014098, 24503858,
                 64739691, 27677090,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 111745333, 55540121, 106535706, 34700805, 86065554, 50194990, 68301593, 29840232,
                 82232482, 44365936,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 14352079, 30134717, 48166819, 10822654, 32750596, 4699007, 67038501, 15776355,
                 38222085, 21579878,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 38867681, 25481956, 62129901, 28239114, 29416930, 1847569, 46454691, 17069576,
                 4714546, 23953777,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 15200313, 41923004, 86787964, 15970073, 35236190, 35513882, 24611598, 29010600,
                 55362987, 45894651,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 12876937, 23074376, 33134380, 6590940, 60801088, 14872439, 9613953, 8241152,
                 15370987, 9608631,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 62965568, 21540023, 8446280, 33162829, 4407737, 13629032, 59383996, 15866073,
                 38898243, 24740332,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 26660609, 51431209, 75502596, 33912478, 59707572, 34547419, 43204630, 34413128,
                 87680086, 41974987,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 14620696, 13067227, 51661590, 8264466, 14106269, 15080814, 33531827, 12516406,
                 45534429, 21077682,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 236881, 10476226, 57258, 18877408, 6472997, 2466984, 17258519, 7256740, 8791136,
                 15069930,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 68385255, 24182513, 90058498, 17231624, 43615824, 61406677, 81820737, 38428660,
                 36445723, 31223040,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 5855666, 4990204, 53397016, 7294283, 59304582, 1924646, 65685689, 25642053,
                 34039526, 9234252,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 20590503, 24535444, 31529743, 26201766, 64402029, 10650547, 31559055, 21944845,
                 18979185, 13396066,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 24474268, 38522535, 22267081, 37961786, 91172745, 25229251, 48291976, 13594781,
                 33514650, 40576390,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 55541958, 26988926, 45743778, 15928891, 40950559, 4315420, 41160136, 29637754,
                 45628383, 12868081,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 38473832, 13504660, 19988037, 31421671, 21078224, 6443208, 45662757, 2244499,
                 54653067, 25465048,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 36513317, 13793478, 61256044, 33873567, 41385691, 60844964, 100195408, 8957936,
                 51875216, 39094952,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 55478669, 22050529, 58989363, 25911358, 2620055, 1022908, 43398120, 31985447,
                 50980335, 18591624,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 23152952, 775386, 27395463, 14006635, 57407746, 4649511, 1689819, 892185, 55595587,
                 18348483,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 76878974, 43141169, 93604957, 37878551, 68665374, 30004407, 94562682, 38317558,
                 47929249, 39421565,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 34343820, 1927589, 31726409, 28801137, 23962433, 17534932, 27846558, 5931263,
                 37359161, 17445976,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 27461885, 30576896, 22380809, 1815854, 44075111, 30522493, 7283489, 18406359,
                 47582163, 7734628,
             ]),
@@ -705,113 +705,113 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 59098581, 57518046, 55988459, 39750469, 29344157, 20123547, 74694158, 30377805,
                 85658360, 48856500,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 34450527, 27383209, 59436070, 22502750, 6258877, 13504381, 10458790, 27135971,
                 58236621, 8424745,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 24687186, 8613276, 36441818, 30320886, 1863891, 31723888, 19206233, 7134917,
                 55824382, 32725512,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 11334880, 24336410, 75134156, 46261950, 84632755, 23078360, 77352601, 18868970,
                 62042829, 50053268,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 8911542, 6887158, 57524604, 26595841, 11145640, 24010752, 17303924, 19430194,
                 6536640, 10543906,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 38162480, 15479762, 49642029, 568875, 65611181, 11223453, 64439674, 16928857,
                 39873154, 8876770,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 41365946, 54541999, 118567760, 32707823, 101191041, 32758142, 33627041, 15824473,
                 66504438, 24514614,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 10330056, 70051, 7957388, 24551765, 9764901, 15609756, 27698697, 28664395, 1657393,
                 3084098,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 10477963, 26084172, 12119565, 20303627, 29016246, 28188843, 31280318, 14396151,
                 36875289, 15272408,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 54820536, 36723894, 28813182, 16658753, 92225296, 27923965, 109043770, 54472724,
                 42094105, 35504935,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 40928506, 9489186, 11053416, 18808271, 36055143, 5825629, 58724558, 24786899,
                 15341278, 8373727,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 28685821, 7759505, 52730348, 21551571, 35137043, 4079241, 298136, 23321830,
                 64230656, 15190419,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 34175950, 47360767, 52771378, 51314432, 110213106, 10940926, 75778582, 36296824,
                 108184414, 60233859,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 65528476, 21825014, 41129205, 22109408, 49696989, 22641577, 9291593, 17306653,
                 54954121, 6048604,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 36803549, 14843443, 1539301, 11864366, 20201677, 1900163, 13934231, 5128323,
                 11213262, 9168384,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 40828313, 44562278, 19408959, 32613674, 115624762, 29225850, 62020803, 22449281,
                 20470156, 50710163,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 43972811, 9282191, 14855179, 18164354, 59746048, 19145871, 44324911, 14461607,
                 14042978, 5230683,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 29969548, 30812838, 50396996, 25001989, 9175485, 31085458, 21556950, 3506042,
                 61174973, 21104723,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 63964099, 42299092, 19704002, 38135710, 46678177, 6830682, 45824694, 42525944,
                 38569674, 48880994,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 47644235, 10110287, 49846336, 30050539, 43608476, 1355668, 51585814, 15300987,
                 46594746, 9168259,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 61755510, 4488612, 43305616, 16314346, 7780487, 17915493, 38160505, 9601604,
                 33087103, 24543045,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 47665675, 18041531, 46311396, 21109108, 104393280, 43783891, 39664534, 52108332,
                 61111992, 49219103,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 23294591, 16921819, 44458082, 25083453, 27844203, 11461195, 13099750, 31094076,
                 18151675, 13417686,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 42385932, 29377914, 35958184, 5988918, 40250079, 6685064, 1661597, 21002991,
                 15271675, 18101767,
             ]),
@@ -819,113 +819,113 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 78541887, 20325766, 75348494, 28274914, 65123427, 32828713, 48410099, 35721975,
                 60187562, 20114249,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 35672693, 15575145, 30436815, 12192228, 44645511, 9395378, 57191156, 24915434,
                 12215109, 12028277,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 14098381, 6555944, 23007258, 5757252, 51681032, 20603929, 30123439, 4617780,
                 50208775, 32898803,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 63082644, 51868028, 79002030, 47273095, 52299401, 35401816, 51288864, 43708440,
                 91082124, 20869957,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 40577025, 29858441, 65199965, 2534300, 35238307, 17004076, 18341389, 22134481,
                 32013173, 23450893,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 41629544, 10876442, 55337778, 18929291, 54739296, 1838103, 21911214, 6354752,
                 4425632, 32716610,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 56675456, 18941465, 89338721, 30463384, 53917697, 34331160, 116802352, 55088400,
                 71833867, 47599401,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 19268631, 26250011, 1555348, 8692754, 45634805, 23643767, 6347389, 32142648,
                 47586572, 17444675,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 42244775, 12986007, 56209986, 27995847, 55796492, 33405905, 19541417, 8180106,
                 9282262, 10282508,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 108012627, 37982977, 58447667, 20360168, 71207265, 52943606, 15522533, 8372215,
                 72651459, 22851748,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 56546323, 14895632, 26814552, 16880582, 49628109, 31065071, 64326972, 6993760,
                 49014979, 10114654,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 47001790, 32625013, 31422703, 10427861, 59998115, 6150668, 38017109, 22025285,
                 25953724, 33448274,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 62874448, 59069571, 57989737, 36600431, 69210472, 54501569, 86498882, 39648727,
                 63793584, 46385556,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 51110167, 7578151, 5310217, 14408357, 33560244, 33329692, 31575953, 6326196,
                 7381791, 31132593,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 46206085, 3296810, 24736065, 17226043, 18374253, 7318640, 6295303, 8082724,
                 51746375, 12339663,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 27724736, 35845589, 73197064, 19369633, 68901590, 39412065, 80957277, 15768921,
                 92200031, 14856293,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 48242193, 8331042, 24373479, 8541013, 66406866, 24284974, 12927299, 20858939,
                 44926390, 24541532,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 55685435, 28132841, 11632844, 3405020, 30536730, 21880393, 39848098, 13866389,
                 30146206, 9142070,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 71032974, 18246915, 120400605, 23499470, 79400683, 32886065, 39406089, 9326383,
                 58871006, 37725725,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 51186905, 16037936, 6713787, 16606682, 45496729, 2790943, 26396185, 3731949,
                 345228, 28091483,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 45781307, 13448258, 25284571, 1143661, 20614966, 24705045, 2031538, 21163201,
                 50855680, 19972348,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 98125037, 16832002, 93480255, 52657630, 62081513, 14854136, 17477601, 37397089,
                 28012649, 50703444,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 62033029, 9368965, 58546785, 28953529, 51858910, 6970559, 57918991, 16292056,
                 58241707, 3507939,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 29439664, 3537914, 23333589, 6997794, 49553303, 22536363, 51899661, 18503164,
                 57943934, 6580395,
             ]),
@@ -933,113 +933,113 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 54922984, 59429075, 83547131, 10826159, 58412047, 27318820, 84969307, 24280585,
                 65013061, 42858998,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 20714545, 29217521, 29088194, 7406487, 11426967, 28458727, 14792666, 18945815,
                 5289420, 33077305,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 50443312, 22903641, 60948518, 20248671, 9192019, 31751970, 17271489, 12349094,
                 26939669, 29802138,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 54218947, 9373457, 98704712, 16374214, 21471720, 13221525, 39825369, 54760304,
                 63410056, 33672318,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 22263325, 26994382, 3984569, 22379786, 51994855, 32987646, 28311252, 5358056,
                 43789084, 541963,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 16259200, 3261970, 2309254, 18019958, 50223152, 28972515, 24134069, 16848603,
                 53771797, 20002236,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 76487005, 20414245, 111371745, 20809166, 95307144, 59864765, 64709178, 32837080,
                 67799289, 48430675,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 24977353, 33240048, 58884894, 20089345, 28432342, 32378079, 54040059, 21257083,
                 44727879, 6618998,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 65570671, 11685645, 12944378, 13682314, 42719353, 19141238, 8044828, 19737104,
                 32239828, 27901670,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 48505798, 38317421, 66182613, 42439735, 105805247, 30367115, 76890510, 23204372,
                 32779358, 5095274,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 34100715, 28339925, 34843976, 29869215, 9460460, 24227009, 42507207, 14506723,
                 21639561, 30924196,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 50707921, 20442216, 25239337, 15531969, 3987758, 29055114, 65819361, 26690896,
                 17874573, 558605,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 53508716, 10240080, 76280747, 16131052, 46239610, 43154131, 100608350, 38634582,
                 69194755, 38674192,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 44903700, 31034903, 50727262, 414690, 42089314, 2170429, 30634760, 25190818,
                 35108870, 27794547,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 60263160, 15791201, 8550074, 32241778, 29928808, 21462176, 27534429, 26362287,
                 44757485, 12961481,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 42616785, 57538092, 10368192, 11582341, 110820435, 31309143, 83642793, 8206995,
                 104023076, 28394792,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 55987368, 30172197, 2307365, 6362031, 66973409, 8868176, 50273234, 7031274,
                 7589640, 8945490,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 34956097, 8917966, 6661220, 21876816, 65916803, 17761038, 7251488, 22372252,
                 24099108, 19098262,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 72128384, 25646961, 71352990, 18840075, 107284455, 40007595, 47990681, 20265406,
                 127985831, 56828126,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 10853575, 10721687, 26480089, 5861829, 44113045, 1972174, 65242217, 22996533,
                 63745412, 27113307,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 50106456, 5906789, 221599, 26991285, 7828207, 20305514, 24362660, 31546264,
                 53242455, 7421391,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 75248772, 27007934, 99366509, 27663885, 97484582, 1886180, 113042620, 48995682,
                 95935221, 29431402,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 6267067, 9695052, 7709135, 16950835, 34239795, 31668296, 14795159, 25714308,
                 13746020, 31812384,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 28584883, 7787108, 60375922, 18503702, 22846040, 25983196, 63926927, 33190907,
                 4771361, 25134474,
             ]),
@@ -1047,113 +1047,113 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 92058101, 6376278, 39642383, 25379823, 48462709, 23623825, 100652432, 54967168,
                 70678489, 44897024,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 26514970, 4740088, 27912651, 3697550, 19331575, 22082093, 6809885, 4608608,
                 7325975, 18753361,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 55490446, 19000001, 42787651, 7655127, 65739590, 5214311, 39708324, 10258389,
                 49462170, 25367739,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 11431185, 49377439, 93679108, 47883555, 85138853, 38350513, 35662684, 49135095,
                 76389221, 29580744,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 66948081, 23228174, 44253547, 29249434, 46247496, 19933429, 34297962, 22372809,
                 51563772, 4387440,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 46309467, 12194511, 3937617, 27748540, 39954043, 9340369, 42594872, 8548136,
                 20617071, 26072431,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 66170039, 29623845, 58394552, 49679149, 91711988, 27329038, 53333511, 55233041,
                 91454545, 10325459,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 47253587, 31985546, 44906155, 8714033, 14007766, 6928528, 16318175, 32543743,
                 4766742, 3552007,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 45357481, 16823515, 1351762, 32751011, 63099193, 3950934, 3217514, 14481909,
                 10988822, 29559670,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 15564288, 19242862, 70210106, 39238579, 97555643, 25503075, 79785990, 27049088,
                 58813011, 46850436,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 57666574, 6624295, 36809900, 21640754, 62437882, 31497052, 31521203, 9614054,
                 37108040, 12074673,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 4771172, 33419193, 14290748, 20464580, 27992297, 14998318, 65694928, 31997715,
                 29832612, 17163397,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 7064865, 59567690, 115055764, 62041325, 48217593, 30641695, 92934105, 38847728,
                 39986203, 46656021,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 64810282, 2439669, 59642254, 1719964, 39841323, 17225986, 32512468, 28236839,
                 36752793, 29363474,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 37102324, 10162315, 33928688, 3981722, 50626726, 20484387, 14413973, 9515896,
                 19568978, 9628812,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 33053784, 33753789, 83003454, 35137490, 94489106, 28973996, 49269969, 61002024,
                 60817076, 36992171,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 48129987, 3884492, 19469877, 12726490, 15913552, 13614290, 44147131, 70103,
                 7463304, 4176122,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 39984863, 10659916, 11482427, 17484051, 12771466, 26919315, 34389459, 28231680,
                 24216881, 5944158,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 76002989, 41005405, 64444714, 57343111, 106137209, 21165315, 19345745, 48235228,
                 78741856, 5847884,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 26942781, 31239115, 9129563, 28647825, 26024104, 11769399, 55590027, 6367193,
                 57381634, 4782139,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 19916442, 28726022, 44198159, 22140040, 25606323, 27581991, 33253852, 8220911,
                 6358847, 31680575,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 67910273, 31472729, 16569427, 44619599, 29875703, 33651059, 75017251, 29073951,
                 53570360, 34941586,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 19646058, 5720633, 55692158, 12814208, 11607948, 12749789, 14147075, 15156355,
                 45242033, 11835259,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 19299512, 1155910, 28703737, 14890794, 2925026, 7269399, 26121523, 15467869,
                 40548314, 5052482,
             ]),
@@ -1161,113 +1161,113 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 64091413, 43612637, 69089700, 37518674, 22160965, 12322533, 60677741, 20936246,
                 12228556, 26550755,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 32944382, 14922211, 44263970, 5188527, 21913450, 24834489, 4001464, 13238564,
                 60994061, 8653814,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 22865569, 28901697, 27603667, 21009037, 14348957, 8234005, 24808405, 5719875,
                 28483275, 2841751,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 117796741, 32441125, 66781144, 21446575, 21886281, 51556090, 65220896, 33238773,
                 87040921, 20815228,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 55452759, 10087520, 58243976, 28018288, 47830290, 30498519, 3999227, 13239134,
                 62331395, 19644223,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 1382174, 21859713, 17266789, 9194690, 53784508, 9720080, 20403944, 11284705,
                 53095046, 3093229,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 83759766, 56070931, 66044684, 35125060, 58779117, 40907184, 66806439, 16271224,
                 43059443, 26862581,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 45197768, 27626490, 62497547, 27994275, 35364760, 22769138, 24123613, 15193618,
                 45456747, 16815042,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 57172930, 29264984, 41829040, 4372841, 2087473, 10399484, 31870908, 14690798,
                 17361620, 11864968,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 55801216, 39764803, 80315437, 39360751, 105200035, 19587230, 54777658, 26067830,
                 41530403, 50868174,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 14668443, 21284197, 26039038, 15305210, 25515617, 4542480, 10453892, 6577524,
                 9145645, 27110552,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 5974855, 3053895, 57675815, 23169240, 35243739, 3225008, 59136222, 3936127,
                 61456591, 30504127,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 97734231, 28825031, 41552902, 20761565, 46624288, 41249530, 17097187, 50805368,
                 106217947, 35358062,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 63555773, 9865098, 61880298, 4272700, 61435032, 16864731, 14911343, 12196514,
                 45703375, 7047411,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 20093258, 9920966, 55970670, 28210574, 13161586, 12044805, 34252013, 4124600,
                 34765036, 23296865,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 46320021, 14084653, 53577151, 41396578, 19119037, 19731827, 71861240, 24839791,
                 45429205, 35842469,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 40289628, 30270716, 29965058, 3039786, 52635099, 2540456, 29457502, 14625692,
                 42289247, 12570231,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 66045306, 22002608, 16920317, 12494842, 1278292, 27685323, 45948920, 30055751,
                 55134159, 4724942,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 85069815, 21778897, 62967895, 23851901, 58232301, 32143814, 54201480, 24894499,
                 104641427, 35458286,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 23134274, 19275300, 56426866, 31942495, 20684484, 15770816, 54119114, 3190295,
                 26955097, 14109738,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 15308788, 5320727, 36995055, 19235554, 22902007, 7767164, 29425325, 22276870,
                 31960941, 11934971,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 39713134, 41990227, 71218507, 12222638, 109589860, 14818667, 87747037, 38429459,
                 77600255, 34934149,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 53949449, 9197840, 3875503, 24618324, 65725151, 27674630, 33518458, 16176658,
                 21432314, 12180697,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 55321537, 11500837, 13787581, 19721842, 44678184, 10140204, 1465425, 12689540,
                 56807545, 19681548,
             ]),
@@ -1275,113 +1275,113 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 72522936, 18168390, 46101199, 43198001, 79943833, 34740580, 64485947, 32212200,
                 26128230, 39587344,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 40771450, 19788269, 32496024, 19900513, 17847800, 20885276, 3604024, 8316894,
                 41233830, 23117073,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 3296484, 6223048, 24680646, 21307972, 44056843, 5903204, 58246567, 28915267,
                 12376616, 3188849,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 29190450, 18895386, 27549112, 32370916, 70628929, 22857130, 32049514, 26245319,
                 50999629, 57256556,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 52364359, 24245275, 735817, 32955454, 46701176, 28496527, 25246077, 17758763,
                 18640740, 32593455,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 60180029, 17123636, 10361373, 5642961, 4910474, 12345252, 35470478, 33060001,
                 10530746, 1053335,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 104951742, 52922057, 120679510, 54991489, 47651803, 56453479, 102755357, 30605445,
                 24018830, 48581076,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 44516310, 30409154, 64819587, 5953842, 53668675, 9425630, 25310643, 13003497,
                 64794073, 18408815,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 39688860, 32951110, 59064879, 31885314, 41016598, 13987818, 39811242, 187898,
                 43942445, 31022696,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 45364447, 19743956, 68953703, 38575859, 123783328, 17642957, 76825530, 49821353,
                 62038646, 34280530,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 29370903, 27500434, 7334070, 18212173, 9385286, 2247707, 53446902, 28714970,
                 30007387, 17731091,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 66172485, 16086690, 23751945, 33011114, 65941325, 28365395, 9137108, 730663,
                 9835848, 4555336,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 43732410, 34964877, 44855110, 54209249, 97976497, 49381408, 17693929, 34099128,
                 55123565, 45977077,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 31117226, 21338698, 53606025, 6561946, 57231997, 20796761, 61990178, 29457725,
                 29120152, 13924425,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 49707966, 19321222, 19675798, 30819676, 56101901, 27695611, 57724924, 22236731,
                 7240930, 33317044,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 35747087, 22207651, 119210280, 27698212, 111764387, 54956091, 68331198, 37943914,
                 70402500, 51557120,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 50424044, 19110186, 11038543, 11054958, 53307689, 30215898, 42789283, 7733546,
                 12796905, 27218610,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 58349431, 22736595, 41689999, 10783768, 36493307, 23807620, 38855524, 3647835,
                 3222231, 22393970,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 85714958, 35247531, 108769341, 51938590, 71221215, 43599452, 23603892, 31506198,
                 59558087, 36039416,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 9255298, 30423235, 54952701, 32550175, 13098012, 24339566, 16377219, 31451620,
                 47306788, 30519729,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 44379556, 7496159, 61366665, 11329248, 19991973, 30206930, 35390715, 9936965,
                 37011176, 22935634,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 88987435, 28553134, 71447199, 47198328, 64071998, 13160959, 86817760, 5415496,
                 59748361, 29445138,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 27736842, 10103576, 12500508, 8502413, 63695848, 23920873, 10436917, 32004156,
                 43449720, 25422331,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 19492550, 21450067, 37426887, 32701801, 63900692, 12403436, 30066266, 8367329,
                 13243957, 8709688,
             ]),
@@ -1389,113 +1389,113 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 79123950, 36355692, 95306994, 10151020, 91926984, 28811298, 55914672, 27908697,
                 72259831, 40828617,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 2831347, 21062286, 1478974, 6122054, 23825128, 20820846, 31097298, 6083058,
                 31021603, 23760822,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 64578913, 31324785, 445612, 10720828, 53259337, 22048494, 43601132, 16354464,
                 15067285, 19406725,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 74949787, 47592304, 100852864, 49488446, 66380650, 29911725, 88512851, 34612017,
                 47729401, 21151211,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 915865, 17085158, 15608284, 24765302, 42751837, 6060029, 49737545, 8410996,
                 59888403, 16527024,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 32922597, 32997445, 20336073, 17369864, 10903704, 28169945, 16957573, 52992,
                 23834301, 6588044,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 32752011, 44787382, 70490858, 24839565, 22652987, 22810329, 17159698, 50243539,
                 46794283, 32248439,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 62419196, 9166775, 41398568, 22707125, 11576751, 12733943, 7924251, 30802151,
                 1976122, 26305405,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 21251203, 16309901, 64125849, 26771309, 30810596, 12967303, 156041, 30183180,
                 12331344, 25317235,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 75760459, 29077399, 118132091, 28557436, 80111370, 36505236, 96163290, 28447461,
                 77116999, 28886530,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 31486061, 15114593, 52847614, 12951353, 14369431, 26166587, 16347320, 19892343,
                 8684154, 23021480,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 19443825, 11385320, 24468943, 23895364, 43189605, 2187568, 40845657, 27467510,
                 31316347, 14219878,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 38514355, 1193784, 99354083, 11392484, 31092169, 49277233, 94254877, 40546840,
                 29126554, 42761822,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 32382916, 1110093, 18477781, 11028262, 39697101, 26006320, 62128346, 10843781,
                 59151264, 19118701,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 2814918, 7836403, 27519878, 25686276, 46214848, 22000742, 45614304, 8550129,
                 28346258, 1994730,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 47530546, 41639976, 53108344, 29605809, 69894701, 17323124, 47591912, 40729325,
                 22628101, 41669612,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 36703732, 955510, 55975026, 18476362, 34661776, 20276352, 41457285, 3317159,
                 57165847, 930271,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 51805164, 26720662, 28856489, 1357446, 23421993, 1057177, 24091212, 32165462,
                 44343487, 22903716,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 44357614, 28250434, 54201256, 54339997, 51297351, 25757378, 52269845, 50554643,
                 65241844, 41953401,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 35139535, 2106402, 62372504, 1362500, 12813763, 16200670, 22981545, 27263159,
                 18009407, 17781660,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 49887941, 24009210, 39324209, 14166834, 29815394, 7444469, 29551787, 29827013,
                 19288548, 1325865,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 82209002, 51273111, 110293748, 32549332, 107767535, 49063838, 79485593, 30075285,
                 100274970, 25511681,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 20909212, 13023121, 57899112, 16251777, 61330449, 25459517, 12412150, 10018715,
                 2213263, 19676059,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 32529814, 22479743, 30361438, 16864679, 57972923, 1513225, 22922121, 6382134,
                 61341936, 8371347,
             ]),
@@ -1503,113 +1503,113 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 77032307, 44825931, 79725657, 37099153, 104219359, 31832804, 12891686, 25361300,
                 40665920, 44040575,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 44511638, 26541766, 8587002, 25296571, 4084308, 20584370, 361725, 2610596,
                 43187334, 22099236,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 5408392, 32417741, 62139741, 10561667, 24145918, 14240566, 31319731, 29318891,
                 19985174, 30118346,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 53114388, 50171252, 81658109, 36895530, 99264821, 13648975, 49531796, 8849296,
                 67173894, 41925115,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 58787919, 21504805, 31204562, 5839400, 46481576, 32497154, 47665921, 6922163,
                 12743482, 23753914,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 64747493, 12678784, 28815050, 4759974, 43215817, 4884716, 23783145, 11038569,
                 18800704, 255233,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 61839168, 31780545, 13957885, 41545147, 23132994, 34283205, 80502710, 42621388,
                 86367551, 52355070,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 64172210, 22726896, 56676774, 14516792, 63468078, 4372540, 35173943, 2209389,
                 65584811, 2055793,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 580882, 16705327, 5468415, 30871414, 36182444, 18858431, 59905517, 24560042,
                 37087844, 7394434,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 90947654, 35377159, 118479284, 48797157, 75426955, 29821327, 45436683, 30062226,
                 62287122, 48354352,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 13345610, 9759151, 3371034, 17416641, 16353038, 8577942, 31129804, 13496856,
                 58052846, 7402517,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 2286874, 29118501, 47066405, 31546095, 53412636, 5038121, 11006906, 17794080,
                 8205060, 1607563,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 81522931, 25552299, 70440693, 63900646, 89358013, 27960243, 85473524, 30647473,
                 30019586, 24525154,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 39420813, 1585952, 56333811, 931068, 37988643, 22552112, 52698034, 12029092,
                 9944378, 8024,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 4368715, 29844802, 29874199, 18531449, 46878477, 22143727, 50994269, 32555346,
                 58966475, 5640029,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 77408455, 13746482, 11661824, 16234854, 74739102, 5998373, 76918751, 16859867,
                 82328661, 19226648,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 27425505, 27835351, 3055005, 10660664, 23458024, 595578, 51710259, 32381236,
                 48766680, 9742716,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 6744077, 2427284, 26042789, 2720740, 66260958, 1118973, 32324614, 7406442,
                 12420155, 1994844,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 81121366, 62084143, 115833273, 23975961, 107732385, 29617991, 121184249, 22644627,
                 91428792, 27108098,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 16412671, 29047065, 10772640, 15929391, 50040076, 28895810, 10555944, 23070383,
                 37006495, 28815383,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 22397363, 25786748, 57815702, 20761563, 17166286, 23799296, 39775798, 6199365,
                 21880021, 21303672,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 62825538, 5368522, 35991846, 41717820, 103894664, 36763558, 83666014, 42445160,
                 75949308, 38512191,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 51661137, 709326, 60189418, 22684253, 37330941, 6522331, 45388683, 12130071,
                 52312361, 5005756,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 64994094, 19246303, 23019041, 15765735, 41839181, 6002751, 10183197, 20315106,
                 50713577, 31378319,
             ]),
@@ -1617,113 +1617,113 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 115191953, 35186435, 80575154, 59113763, 110577275, 16573535, 35094956, 30497327,
                 22208661, 35554900,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 3065054, 32141671, 41510189, 33192999, 49425798, 27851016, 58944651, 11248526,
                 63417650, 26140247,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 10379208, 27508878, 8877318, 1473647, 37817580, 21046851, 16690914, 2553332,
                 63976176, 16400288,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 82825513, 34808697, 115745037, 41000704, 58659945, 6344163, 45011593, 26268851,
                 26894936, 42686498,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 24158868, 12938817, 11085297, 25376834, 39045385, 29097348, 36532400, 64451,
                 60291780, 30861549,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 13488534, 7794716, 22236231, 5989356, 25426474, 20976224, 2350709, 30135921,
                 62420857, 2364225,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 83443897, 9132433, 92749446, 40233319, 68834491, 42072368, 55301839, 21856974,
                 15445874, 25756331,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 29004188, 25687351, 28661401, 32914020, 54314860, 25611345, 31863254, 29418892,
                 66830813, 17795152,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 60986784, 18687766, 38493958, 14569918, 56250865, 29962602, 10343411, 26578142,
                 37280576, 22738620,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 94190495, 37018415, 14099041, 29036828, 68725166, 27348827, 96651499, 15372178,
                 84402661, 34515140,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 20263915, 11434237, 61343429, 11236809, 13505955, 22697330, 50997518, 6493121,
                 47724353, 7639713,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 64278047, 18715199, 25403037, 25339236, 58791851, 17380732, 18006286, 17510682,
                 29994676, 17746311,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 76878673, 38757082, 110060329, 19923038, 106166724, 21992806, 42495722, 53248081,
                 35924287, 34263895,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 12286395, 13076066, 45333675, 32377809, 42105665, 4057651, 35090736, 24663557,
                 16102006, 13205847,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 13733362, 5599946, 10557076, 3195751, 61550873, 8536969, 41568694, 8525971,
                 10151379, 10394400,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 71133505, 17416880, 89545125, 12276533, 58009849, 64422764, 86807091, 11743038,
                 100915394, 42488844,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 51229064, 29029191, 58528116, 30620370, 14634844, 32856154, 57659786, 3137093,
                 55571978, 11721157,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 17555920, 28540494, 8268605, 2331751, 44370049, 9761012, 9319229, 8835153,
                 57903375, 32274386,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 66647436, 25724417, 87722981, 16688287, 59594098, 28747312, 89409167, 34059860,
                 73217325, 27371016,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 62038564, 12367916, 36445330, 3234472, 32617080, 25131790, 29880582, 20071101,
                 40210373, 25686972,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 35133562, 5726538, 26934134, 10237677, 63935147, 32949378, 24199303, 3795095,
                 7592688, 18562353,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 21594413, 18590204, 84575271, 63031641, 32537082, 36294330, 73516586, 12018832,
                 38852812, 37852843,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 46458361, 21592935, 39872588, 570497, 3767144, 31836892, 13891941, 31985238,
                 13717173, 10805743,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 52432215, 17910135, 15287173, 11927123, 24177847, 25378864, 66312432, 14860608,
                 40169934, 27690595,
             ]),
@@ -1731,113 +1731,113 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 80071405, 38866230, 57048095, 45212711, 85964149, 25600230, 80395126, 54300159,
                 62727806, 9882021,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 18512060, 11319350, 46985740, 15090308, 18818594, 5271736, 44380960, 3666878,
                 43141434, 30255002,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 60319844, 30408388, 16192428, 13241070, 15898607, 19348318, 57023983, 26893321,
                 64705764, 5276064,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 97278672, 28236783, 93415069, 55358004, 94923826, 40623698, 74261714, 37239413,
                 68558087, 13082860,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 10342807, 3098505, 2119311, 193222, 25702612, 12233820, 23697382, 15056736,
                 46092426, 25352431,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 33958735, 3261607, 22745853, 7948688, 19370557, 18376767, 40936887, 6482813,
                 56808784, 22494330,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 32869439, 61700319, 25609741, 49233102, 56421094, 51637792, 26112419, 36075440,
                 44444575, 40459246,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 29506904, 4457497, 3377935, 23757988, 36598817, 12935079, 1561737, 3841096,
                 38105225, 26896789,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 10340844, 26924055, 48452231, 31276001, 12621150, 20215377, 30878496, 21730062,
                 41524312, 5181965,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 25940096, 20896407, 17324187, 56801490, 58437394, 15029093, 91505116, 17103509,
                 64786011, 21165857,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 45343161, 9916822, 65808455, 4079497, 66080518, 11909558, 1782390, 12641087,
                 20603771, 26992690,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 48226577, 21881051, 24849421, 11501709, 13161720, 28785558, 1925522, 11914390,
                 4662781, 7820689,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 79349895, 33128449, 75241554, 42948365, 32846759, 31954812, 29749455, 45727356,
                 83245615, 48818451,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 56758909, 18873868, 58896884, 2330219, 49446315, 19008651, 10658212, 6671822,
                 19012087, 3772772,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 3753511, 30133366, 10617073, 2028709, 14841030, 26832768, 28718731, 17791548,
                 20527770, 12988982,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 52286341, 27757162, 63400876, 12689772, 66209881, 22639565, 110034681, 56543919,
                 70408527, 54683910,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 50331161, 18301130, 57466446, 4978982, 3308785, 8755439, 6943197, 6461331,
                 41525717, 8991217,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 49882601, 1816361, 65435576, 27467992, 31783887, 25378441, 34160718, 7417949,
                 36866577, 1507264,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 29692644, 40384323, 56610063, 37889327, 88054838, 21647935, 38221255, 41763822,
                 14606361, 22907359,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 63627275, 8707080, 32188102, 5672294, 22096700, 1711240, 34088169, 9761486,
                 4170404, 31469107,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 55521375, 14855944, 62981086, 32022574, 40459774, 15084045, 22186522, 16002000,
                 52832027, 25153633,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 62297389, 47315460, 35404986, 31070512, 63796392, 41423478, 59995291, 23934339,
                 80349708, 44520301,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 59366301, 25297669, 52340529, 19898171, 43876480, 12387165, 4498947, 14147411,
                 29514390, 4302863,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 53695440, 21146572, 20757301, 19752600, 14785142, 8976368, 62047588, 31410058,
                 17846987, 19582505,
             ]),
@@ -1845,113 +1845,113 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 64864393, 32799703, 62511833, 32488122, 60861691, 35009730, 112569999, 24339641,
                 61886162, 46204698,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 57202067, 17484121, 21134159, 12198166, 40044289, 708125, 387813, 13770293,
                 47974538, 10958662,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 22470984, 12369526, 23446014, 28113323, 45588061, 23855708, 55336367, 21979976,
                 42025033, 4271861,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 109048144, 57055220, 47199530, 48916026, 61124505, 35713623, 67184238, 62830334,
                 101691505, 42024103,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 15854951, 4148314, 58214974, 7259001, 11666551, 13824734, 36577666, 2697371,
                 24154791, 24093489,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 15446137, 17747788, 29759746, 14019369, 30811221, 23944241, 35526855, 12840103,
                 24913809, 9815020,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 62399559, 27940162, 35267365, 21265538, 52665326, 44353845, 125114051, 46993199,
                 85843991, 43020669,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 11933045, 9281483, 5081055, 28370608, 64480701, 28648802, 59381042, 22658328,
                 44380208, 16199063,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 14576810, 379472, 40322331, 25237195, 37682355, 22741457, 67006097, 1876698,
                 30801119, 2164795,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 15995067, 36754305, 13672554, 13712240, 47730029, 62461217, 121136116, 51612593,
                 53616055, 34822483,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 56818250, 29895392, 63822271, 10948817, 23037027, 3794475, 63638526, 20954210,
                 50053494, 3565903,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 29210069, 24135095, 61189071, 28601646, 10834810, 20226706, 50596761, 22733718,
                 39946641, 19523900,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 121055819, 49063018, 83772567, 25398281, 38758921, 42573554, 37925442, 29785008,
                 69352974, 19552452,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 61955989, 29753495, 57802388, 27482848, 16243068, 14684434, 41435776, 17373631,
                 13491505, 4641841,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 10813398, 643330, 47920349, 32825515, 30292061, 16954354, 27548446, 25833190,
                 14476988, 20787001,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 77400943, 9984944, 73590300, 41834336, 59857349, 40587174, 27282936, 31910173,
                 106304917, 12651322,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 35923332, 32741048, 22271203, 11835308, 10201545, 15351028, 17099662, 3988035,
                 21721536, 30405492,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 10202177, 27008593, 35735631, 23979793, 34958221, 25434748, 54202543, 3852693,
                 13216206, 14842320,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 51293205, 22953365, 60569911, 26295436, 60124204, 26972653, 35608016, 47320255,
                 106783330, 43454614,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 14465486, 19721101, 34974879, 18815558, 39665676, 12990491, 33046193, 15796406,
                 60056998, 25514317,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 30924398, 25274812, 6359015, 20738097, 16508376, 9071735, 41620263, 15413634,
                 9524356, 26535554,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 12274182, 20378885, 99736504, 65323537, 73845487, 13267304, 72346523, 28444948,
                 82772379, 37590215,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 64157555, 8903984, 17349946, 601635, 50676049, 28941875, 53376124, 17665097,
                 44850385, 4659090,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 50192582, 28601458, 36715152, 18395610, 20774811, 15897498, 5736189, 15026997,
                 64930608, 20098846,
             ]),
@@ -1959,113 +1959,113 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 58249865, 31335375, 28571665, 56953346, 66634395, 23448733, 63307367, 33832526,
                 23440561, 33264224,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 10226222, 27625730, 15139955, 120818, 52241171, 5218602, 32937275, 11551483,
                 50536904, 26111567,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 17932739, 21117156, 43069306, 10749059, 11316803, 7535897, 22503767, 5561594,
                 63462240, 3898660,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 74858752, 32584864, 50769132, 33537967, 42090752, 15122142, 65535333, 40706961,
                 88940025, 34799664,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 26958440, 18896406, 4314585, 8346991, 61431100, 11960071, 34519569, 32934396,
                 36706772, 16838219,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 54942968, 9166946, 33491384, 13673479, 29787085, 13096535, 6280834, 14587357,
                 44770839, 13987524,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 109867800, 7778773, 88224864, 49127028, 62275597, 28196653, 62807965, 28429792,
                 59639082, 30696363,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 9681908, 26817309, 35157219, 13591837, 60225043, 386949, 31622781, 6439245,
                 52527852, 4091396,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 58682418, 1470726, 38999185, 31957441, 3978626, 28430809, 47486180, 12092162,
                 29077877, 18812444,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 72378032, 26694705, 120987516, 25533715, 25932562, 35317984, 61502753, 28048550,
                 47091016, 2357888,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 32264008, 18146780, 61721128, 32394338, 65017541, 29607531, 23104803, 20684524,
                 5727337, 189038,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 14609104, 24599962, 61108297, 16931650, 52531476, 25810533, 40363694, 10942114,
                 41219933, 18669734,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 87622345, 39112362, 51504250, 41383962, 93522806, 31535027, 45729895, 41026212,
                 13913676, 28416557,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 41534488, 11967825, 29233242, 12948236, 60354399, 4713226, 58167894, 14059179,
                 12878652, 8511905,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 41452044, 3393630, 64153449, 26478905, 64858154, 9366907, 36885446, 6812973,
                 5568676, 30426776,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 78738868, 12144453, 69225203, 47160468, 94487748, 49231348, 49700110, 20050058,
                 119822531, 8070816,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 27117677, 23547054, 35826092, 27984343, 1127281, 12772488, 37262958, 10483305,
                 55556115, 32525717,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 10637467, 27866368, 5674780, 1072708, 40765276, 26572129, 65424888, 9177852,
                 39615702, 15431202,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 87633990, 44446997, 121475255, 12779441, 104724694, 16150073, 105977209, 14943140,
                 52052074, 25618500,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 37084402, 5626925, 66557297, 23573344, 753597, 11981191, 25244767, 30314666,
                 63752313, 9594023,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 43356201, 2636869, 61944954, 23450613, 585133, 7877383, 11345683, 27062142,
                 13352334, 22577348,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 65177046, 28146973, 70413512, 54223994, 84124668, 62231772, 104433876, 25801948,
                 53893326, 33235227,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 20239939, 6607058, 6203985, 3483793, 48721888, 32775202, 46385121, 15077869,
                 44358105, 14523816,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 27406023, 27512775, 27423595, 29057038, 4996213, 10002360, 38266833, 29008937,
                 36936121, 28748764,
             ]),
@@ -2073,113 +2073,113 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 78483087, 12660714, 17861383, 21013599, 78044431, 34653658, 53222787, 24462691,
                 106490683, 44912934,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 54378055, 10311866, 1510375, 10778093, 64989409, 24408729, 32676002, 11149336,
                 40985213, 4985767,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 48012542, 341146, 60911379, 33315398, 15756972, 24757770, 66125820, 13794113,
                 47694557, 17933176,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 73598907, 45494717, 25495922, 59382504, 75777235, 24803115, 70476466, 40524436,
                 65417798, 58104073,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 1656478, 13457317, 15370807, 6364910, 13605745, 8362338, 47934242, 28078708,
                 50312267, 28522993,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 44835530, 20030007, 67044178, 29220208, 48503227, 22632463, 46537798, 26546453,
                 67009010, 23317098,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 84856310, 43593691, 86477162, 29503840, 46478228, 51067577, 99101545, 17696455,
                 104957364, 28042459,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 31932008, 28568291, 47496481, 16366579, 22023614, 88450, 11371999, 29810185,
                 4882241, 22927527,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 29796488, 37186, 19818052, 10115756, 55279832, 3352735, 18551198, 3272828,
                 61917932, 29392022,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 12501267, 4044383, 58495907, 53716478, 101787674, 38691029, 47878485, 30024734,
                 330069, 29895023,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 6384877, 2899513, 17807477, 7663917, 64749976, 12363164, 25366522, 24980540,
                 66837568, 12071498,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 58743349, 29511910, 25133447, 29037077, 60897836, 2265926, 34339246, 1936674,
                 61949167, 3829362,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 28425947, 27718999, 66531773, 28857233, 120000172, 40425360, 75030413, 26986644,
                 26333139, 47822096,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 56041645, 11871230, 27385719, 22994888, 62522949, 22365119, 10004785, 24844944,
                 45347639, 8930323,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 45911060, 17158396, 25654215, 31829035, 12282011, 11008919, 1541940, 4757911,
                 40617363, 17145491,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 80646107, 25794941, 113612887, 44516357, 61186043, 20336366, 53952279, 39771685,
                 118274028, 47369420,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 49686272, 15157789, 18705543, 29619, 24409717, 33293956, 27361680, 9257833,
                 65152338, 31777517,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 42063564, 23362465, 15366584, 15166509, 54003778, 8423555, 37937324, 12361134,
                 48422886, 4578289,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 91688613, 3711569, 68451186, 22374305, 107212592, 47679386, 44564334, 14074918,
                 21964432, 41789689,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 60580251, 31142934, 9442965, 27628844, 12025639, 32067012, 64127349, 31885225,
                 13006805, 2355433,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 50803946, 19949172, 60476436, 28412082, 16974358, 22643349, 27202043, 1719366,
                 1141648, 20758196,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 54244901, 53888877, 58790596, 56090772, 60298717, 28710537, 13475065, 30420460,
                 32674894, 47269477,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 11423316, 28086373, 32344215, 8962751, 24989809, 9241752, 53843611, 16086211,
                 38367983, 17912338,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 65699196, 12530727, 60740138, 10847386, 19531186, 19422272, 55399715, 7791793,
                 39862921, 4383346,
             ]),
@@ -2187,113 +2187,113 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 38137947, 38825878, 65842854, 23817442, 121762491, 50287029, 62246456, 62202414,
                 27193555, 39799623,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 51914908, 5362277, 65324971, 2695833, 4960227, 12840725, 23061898, 3260492,
                 22510453, 8577507,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 54476394, 11257345, 34415870, 13548176, 66387860, 10879010, 31168030, 13952092,
                 37537372, 29918525,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 70986166, 23981692, 99525555, 38959755, 56104456, 19897796, 70868632, 45489751,
                 72720723, 41718449,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 50833043, 14667796, 15906460, 12155291, 44997715, 24514713, 32003001, 24722143,
                 5773084, 25132323,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 43320746, 25300131, 1950874, 8937633, 18686727, 16459170, 66203139, 12376319,
                 31632953, 190926,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 109624102, 17415545, 58684872, 13378745, 81271271, 6901327, 58820115, 38062995,
                 41767308, 29926903,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 8884438, 27670423, 6023973, 10104341, 60227295, 28612898, 18722940, 18768427,
                 65436375, 827624,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 34388281, 17265135, 34605316, 7101209, 13354605, 2659080, 65308289, 19446395,
                 42230385, 1541285,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 70010192, 32436744, 70989239, 57049475, 116596786, 29941649, 45306746, 29986950,
                 87565708, 31669398,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 27019610, 12299467, 53450576, 31951197, 54247203, 28692960, 47568713, 28538373,
                 29439640, 15138866,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 21536104, 26928012, 34661045, 22864223, 44700786, 5175813, 61688824, 17193268,
                 7779327, 109896,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 97388589, 48203181, 59063992, 39979989, 80748484, 32810922, 28698389, 45734550,
                 23177718, 33000357,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 26572828, 3405927, 35407164, 12890904, 47843196, 5335865, 60615096, 2378491,
                 4439158, 20275085,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 44392139, 3489069, 57883598, 33221678, 18875721, 32414337, 14819433, 20822905,
                 49391106, 28092994,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 62052362, 50120982, 83062524, 37322183, 56672364, 49181491, 66287909, 35731656,
                 75658945, 18440266,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 48635543, 16596774, 66727204, 15663610, 22860960, 15585581, 39264755, 29971692,
                 43848403, 25125843,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 34628313, 15707274, 58902952, 27902350, 29464557, 2713815, 44383727, 15860481,
                 45206294, 1494192,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 47546754, 53021470, 41524990, 24254879, 80236705, 34314140, 21923481, 16529112,
                 75851568, 46521448,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 38643965, 1553204, 32536856, 23080703, 42417258, 33148257, 58194238, 30620535,
                 37205105, 15553882,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 21877890, 3230008, 9881174, 10539357, 62311749, 2841331, 11543572, 14513274,
                 19375923, 20906471,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 75941133, 52613378, 80362373, 38692006, 72146734, 37633208, 24880817, 60886148,
                 69971515, 9455042,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 29306751, 5123106, 20245049, 19404543, 9592565, 8447059, 65031740, 30564351,
                 15511448, 4789663,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 46429108, 7004546, 8824831, 24119455, 63063159, 29803695, 61354101, 108892,
                 23513200, 16652362,
             ]),
@@ -2301,113 +2301,113 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 100961536, 37699212, 62632834, 26975308, 77878902, 26398889, 60458447, 54172563,
                 115898528, 43767290,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 2756062, 8598110, 7383731, 26694540, 22312758, 32449420, 21179800, 2600940,
                 57120566, 21047965,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 42463153, 13317461, 36659605, 17900503, 21365573, 22684775, 11344423, 864440,
                 64609187, 16844368,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 107784906, 6148327, 49924452, 19080277, 85891792, 33278434, 44547329, 33765731,
                 69828620, 38495428,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 65784982, 3911312, 60160120, 14759764, 37081714, 7851206, 21690126, 8518463,
                 26699843, 5276295,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 53958991, 27125364, 9396248, 365013, 24703301, 23065493, 1321585, 149635, 51656090,
                 7159368,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 77096625, 30149672, 84616825, 43059961, 76840398, 31388917, 89464872, 41866607,
                 89586081, 25151046,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 18155857, 17049442, 19744715, 9006923, 15154154, 23015456, 24256459, 28689437,
                 44560690, 9334108,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 2986088, 28642539, 10776627, 30080588, 10620589, 26471229, 45695018, 14253544,
                 44521715, 536905,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 71486582, 41670267, 91675941, 15495313, 78733938, 46619030, 74499414, 44144056,
                 77946923, 51688439,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 47766460, 867879, 9277171, 30335973, 52677291, 31567988, 19295825, 17757482,
                 6378259, 699185,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 7895007, 4057113, 60027092, 20476675, 49222032, 33231305, 66392824, 15693154,
                 62063800, 20180469,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 59371282, 27685029, 119651408, 26147511, 78494517, 46756047, 31730677, 22591592,
                 63190227, 23885106,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 10188286, 17783598, 59772502, 13427542, 22223443, 14896287, 30743455, 7116568,
                 45322357, 5427592,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 696102, 13206899, 27047647, 22922350, 15285304, 23701253, 10798489, 28975712,
                 19236242, 12477404,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 55879406, 44798227, 50054593, 25513566, 66320635, 58940896, 63211193, 44734935,
                 43939347, 41288075,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 17800790, 19518253, 40108434, 21787760, 23887826, 3149671, 23466177, 23016261,
                 10322026, 15313801,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 26246234, 11968874, 32263343, 28085704, 6830754, 20231401, 51314159, 33452449,
                 42659621, 10890803,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 35743198, 43825794, 54448238, 27287163, 83799070, 54046319, 119235514, 50039361,
                 92289660, 28219547,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 66522290, 10376443, 34522450, 22268075, 19801892, 10997610, 2276632, 9482883,
                 316878, 13820577,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 57226037, 29044064, 64993357, 16457135, 56008783, 11674995, 30756178, 26039378,
                 30696929, 29841583,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 100097781, 23951019, 12499365, 41465219, 56491606, 21622917, 59766047, 57123466,
                 34759345, 7392472,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 58253184, 15927860, 9866406, 29905021, 64711949, 16898650, 36699387, 24419436,
                 25112946, 30627788,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 64604801, 33117465, 25621773, 27875660, 15085041, 28074555, 42223985, 20028237,
                 5537437, 19640113,
             ]),
@@ -2415,113 +2415,113 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 55883261, 2320284, 57524584, 10149186, 100773065, 5808646, 119341477, 31824763,
                 98343453, 39645030,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 57475529, 116425, 26083934, 2897444, 60744427, 30866345, 609720, 15878753,
                 60138459, 24519663,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 39351007, 247743, 51914090, 24551880, 23288160, 23542496, 43239268, 6503645,
                 20650474, 1804084,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 106627923, 49010854, 76081380, 42024039, 82749485, 37994278, 70230858, 56779150,
                 94951478, 33352103,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 51801891, 2839643, 22530074, 10026331, 4602058, 5048462, 28248656, 5031932,
                 55733782, 12714368,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 20807691, 26283607, 29286140, 11421711, 39232341, 19686201, 45881388, 1035545,
                 47375635, 12796919,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 79185725, 52807577, 58323861, 21705509, 42096072, 49955115, 49517368, 20654993,
                 70589528, 51926048,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 34747315, 5457596, 28548107, 7833186, 7303070, 21600887, 42745799, 17632556,
                 33734809, 2771024,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 45719598, 421931, 26597266, 6860826, 22486084, 26817260, 49971378, 29344205,
                 42556581, 15673396,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 46924223, 35892647, 19788684, 57487908, 63107597, 24813538, 46837679, 38287685,
                 70836007, 20619983,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 6120100, 814863, 55314462, 32931715, 6812204, 17806661, 2019593, 7975683, 31123697,
                 22595451,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 30069250, 22119100, 30434653, 2958439, 18399564, 32578143, 12296868, 9204260,
                 50676426, 9648164,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 32705413, 32003455, 97814521, 41005496, 55303257, 43186244, 70414129, 38803035,
                 108209395, 22176929,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 17219846, 2375039, 35537917, 27978816, 47649184, 9219902, 294711, 15298639,
                 2662509, 17257359,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 65935918, 25995736, 62742093, 29266687, 45762450, 25120105, 32087528, 32331655,
                 32247247, 19164571,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 14312609, 34775988, 17395389, 58408721, 62163121, 58424228, 106019982, 23916613,
                 51081240, 20175586,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 65680039, 23875441, 57873182, 6549686, 59725795, 33085767, 23046501, 9803137,
                 17597934, 2346211,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 18510781, 15337574, 26171504, 981392, 44867312, 7827555, 43617730, 22231079,
                 3059832, 21771562,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 77250443, 39637338, 84938156, 31606788, 76938955, 13613135, 41552228, 28009845,
                 33606651, 37146527,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 33114149, 17665080, 40583177, 20211034, 33076704, 8716171, 1151462, 1521897,
                 66126199, 26716628,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 34169699, 29298616, 23947180, 33230254, 34035889, 21248794, 50471177, 3891703,
                 26353178, 693168,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 97483084, 35150011, 117333688, 46741361, 71709207, 33961335, 76694157, 33153763,
                 31375463, 47924397,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 52738210, 25781902, 1510300, 6434173, 48324075, 27291703, 32732229, 20445593,
                 17901440, 16011505,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 18171223, 21619806, 54608461, 15197121, 56070717, 18324396, 47936623, 17508055,
                 8764034, 12309598,
             ]),
@@ -2529,113 +2529,113 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 73084753, 28311243, 47649501, 23872684, 55567586, 14015781, 110551971, 34782749,
                 17544095, 22960650,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 5811932, 31839139, 3442886, 31285122, 48741515, 25194890, 49064820, 18144304,
                 61543482, 12348899,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 35709185, 11407554, 25755363, 6891399, 63851926, 14872273, 42259511, 8141294,
                 56476330, 32968952,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 121542424, 34248456, 62032718, 46854775, 81124121, 19103037, 124519055, 22225380,
                 30944592, 1130208,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 8247747, 26843490, 40546482, 25845122, 52706924, 18905521, 4652151, 2488540,
                 23550156, 33283200,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 17294297, 29765994, 7026747, 15626851, 22990044, 113481, 2267737, 27646286,
                 66700045, 33416712,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 83199930, 17300505, 85708115, 40895109, 69246500, 32332774, 63744702, 48105367,
                 70369388, 26388160,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 62198760, 20221544, 18550886, 10864893, 50649539, 26262835, 44079994, 20349526,
                 54360141, 2701325,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 58534169, 16099414, 4629974, 17213908, 46322650, 27548999, 57090500, 9276970,
                 11329923, 1862132,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 14763057, 17650824, 103299457, 3689865, 70620756, 43867957, 45157775, 45773662,
                 58070900, 32614131,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 8894987, 30108338, 6150752, 3013931, 301220, 15693451, 35127648, 30644714,
                 51670695, 11595569,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 15214943, 3537601, 40870142, 19495559, 4418656, 18323671, 13947275, 10730794,
                 53619402, 29190761,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 64570539, 41237224, 99867876, 33817540, 104232996, 25598978, 111885603, 23365795,
                 68085971, 34254425,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 54642373, 4195083, 57897332, 550903, 51543527, 12917919, 19118110, 33114591,
                 36574330, 19216518,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 31788442, 19046775, 4799988, 7372237, 8808585, 18806489, 9408236, 23502657,
                 12493931, 28145115,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 41428258, 5260743, 47873055, 27269961, 63412921, 16566086, 94327144, 36161552,
                 29375954, 6024730,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 842132, 30759739, 62345482, 24831616, 26332017, 21148791, 11831879, 6985184,
                 57168503, 2854095,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 62261602, 25585100, 2516241, 27706719, 9695690, 26333246, 16512644, 960770,
                 12121869, 16648078,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 51890193, 48221527, 53772634, 35568148, 97707150, 33090294, 35603941, 25672367,
                 20237805, 36392843,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 47820798, 4453151, 15298546, 17376044, 22115042, 17581828, 12544293, 20083975,
                 1068880, 21054527,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 57549981, 17035596, 33238497, 13506958, 30505848, 32439836, 58621956, 30924378,
                 12521377, 4845654,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 106019188, 44298538, 64150483, 43754095, 74868174, 54020263, 70518210, 32681031,
                 127735421, 20668560,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 43547042, 6230155, 46726851, 10655313, 43068279, 21933259, 10477733, 32314216,
                 63995636, 13974497,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 12966261, 15550616, 35069916, 31939085, 21025979, 32924988, 5642324, 7188737,
                 18895762, 12629579,
             ]),
@@ -2643,113 +2643,113 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 14741860, 18607545, 89286071, 21833194, 68388604, 41613031, 11758139, 34343875,
                 32195180, 37450109,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 10758205, 15755439, 62598914, 9243697, 62229442, 6879878, 64904289, 29988312,
                 58126794, 4429646,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 64654951, 15725972, 46672522, 23143759, 61304955, 22514211, 59972993, 21911536,
                 18047435, 18272689,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 41935825, 55801698, 29759954, 45331216, 111955344, 51288407, 78101976, 54258026,
                 49488161, 57700395,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 21987233, 700364, 42603816, 14972007, 59334599, 27836036, 32155025, 2581431,
                 37149879, 8773374,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 41540495, 454462, 53896929, 16126714, 25240068, 8594567, 20656846, 12017935,
                 59234475, 19634276,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 73137027, 39817509, 103205921, 55807152, 66289943, 36016203, 102376553, 61640820,
                 65387074, 30777706,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 54829870, 16624276, 987579, 27631834, 32908202, 1248608, 7719845, 29387734,
                 28408819, 6816612,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 56750770, 25316602, 19549650, 21385210, 22082622, 16147817, 20613181, 13982702,
                 56769294, 5067942,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 36602859, 29732664, 79183544, 13582411, 47230892, 35998382, 47389577, 12746131,
                 72440074, 57002919,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 30528792, 3601899, 65151774, 4619784, 39747042, 18118043, 24180792, 20984038,
                 27679907, 31905504,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 9402385, 19597367, 32834042, 10838634, 40528714, 20317236, 26653273, 24868867,
                 22611443, 20839026,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 89299435, 34672460, 22736440, 48684895, 103757035, 27563109, 86298488, 62459921,
                 71963721, 40176570,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 58798126, 30600981, 58846284, 30166382, 56707132, 33282502, 13424425, 29987205,
                 26404408, 13001963,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 35867026, 18138731, 64114613, 8939345, 11562230, 20713762, 41044498, 21932711,
                 51703708, 11020692,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 68974887, 59159374, 59210213, 23253421, 12483314, 47031979, 70284499, 21130268,
                 28761761, 34961166,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 66660290, 31776765, 13018550, 3194501, 57528444, 22392694, 24760584, 29207344,
                 25577410, 20175752,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 42818486, 4759344, 66418211, 31701615, 2066746, 10693769, 37513074, 9884935,
                 57739938, 4745409,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 57967561, 39604145, 47577802, 29213020, 102956929, 43498706, 51646855, 55797011,
                 78040786, 21622500,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 50547351, 14112679, 59096219, 4817317, 59068400, 22139825, 44255434, 10856640,
                 46638094, 13434653,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 22759470, 23480998, 50342599, 31683009, 13637441, 23386341, 1765143, 20900106,
                 28445306, 28189722,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 29875044, 46048045, 69904399, 63322533, 68819482, 48735613, 56913146, 24765756,
                 9074233, 34721612,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 40903181, 11014232, 57266213, 30918946, 40200743, 7532293, 48391976, 24018933,
                 3843902, 9367684,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 56139269, 27150720, 9591133, 9582310, 11349256, 108879, 16235123, 8601684,
                 66969667, 4242894,
             ]),
@@ -2757,113 +2757,113 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 89201818, 53917740, 65066069, 21585919, 99295616, 55591475, 60534521, 36025091,
                 106800361, 16625499,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 56051142, 3042015, 13770083, 24296510, 584235, 33009577, 59338006, 2602724,
                 39757248, 14247412,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 6314156, 23289540, 34336361, 15957556, 56951134, 168749, 58490057, 14290060,
                 27108877, 32373552,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 58522248, 26383465, 80350645, 44514587, 34117848, 19759835, 100656839, 22495542,
                 107069276, 34536304,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 22833421, 9293594, 34459416, 19935764, 57971897, 14756818, 44180005, 19583651,
                 56629059, 17356469,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 59340277, 3326785, 38997067, 10783823, 19178761, 14905060, 22680049, 13906969,
                 51175174, 3797898,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 88830182, 29341685, 54902740, 42864613, 63226624, 19901321, 90849087, 30845199,
                 87600846, 59066711,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 9209251, 18419377, 53852306, 27386633, 66377847, 15289672, 25947805, 15286587,
                 30997318, 26851369,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 7392013, 16618386, 23946583, 25514540, 53843699, 32020573, 52911418, 31232855,
                 17649997, 33304352,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 57807757, 52915036, 97718388, 30504888, 41933794, 32270679, 51867297, 24028707,
                 64875610, 41216577,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 49550191, 1763593, 33994528, 15908609, 37067994, 21380136, 7335079, 25082233,
                 63934189, 3440182,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 47219164, 27577423, 42997570, 23865561, 10799742, 16982475, 40449, 29122597,
                 4862399, 1133,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 34252636, 25680474, 61686474, 48415381, 50789832, 41510573, 74366924, 33866292,
                 36513872, 26175010,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 63335436, 31988495, 28985339, 7499440, 24445838, 9325937, 29727763, 16527196,
                 18278453, 15405622,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 62726958, 8508651, 47210498, 29880007, 61124410, 15149969, 53795266, 843522,
                 45233802, 13626196,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 69390312, 20067376, 56193445, 30944521, 68988221, 49718638, 56324981, 37508223,
                 80449702, 15928662,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 31727126, 26374577, 48671360, 25270779, 2875792, 17164102, 41838969, 26539605,
                 43656557, 5964752,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 4100401, 27594980, 49929526, 6017713, 48403027, 12227140, 40424029, 11344143,
                 2538215, 25983677,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 57675240, 6123112, 78268667, 31397823, 97125143, 48520672, 46633880, 35039852,
                 66479607, 17595569,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 40304287, 4260918, 11851389, 9658551, 35091757, 16367491, 46903439, 20363143,
                 11659921, 22439314,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 26180377, 10015009, 36264640, 24973138, 5418196, 9480663, 2231568, 23384352,
                 33100371, 32248261,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 82229958, 28352560, 56718958, 48982252, 39598926, 17561924, 88779810, 38041106,
                 61177053, 19088051,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 16166467, 24070699, 56004733, 6023907, 35182066, 32189508, 2340059, 17299464,
                 56373093, 23514607,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 28042865, 29997343, 54982337, 12259705, 63391366, 26608532, 6766452, 24864833,
                 18036435, 5803270,
             ]),
@@ -2871,113 +2871,113 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 66291264, 40318343, 78912424, 35140016, 78067310, 30883266, 23855390, 4598332,
                 60949433, 19436993,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 36077558, 19298237, 17332028, 31170912, 31312681, 27587249, 696308, 50292,
                 47013125, 11763583,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 66514282, 31040148, 34874710, 12643979, 12650761, 14811489, 665117, 20940800,
                 47335652, 22840869,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 97573435, 55845991, 62981386, 20819953, 86944190, 60003250, 109821551, 35630203,
                 50088706, 34546902,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 18357166, 26559999, 7766381, 16342475, 37783946, 411173, 14578841, 8080033,
                 55534529, 22952821,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 19598397, 10334610, 12555054, 2555664, 18821899, 23214652, 21873262, 16014234,
                 26224780, 16452269,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 36884920, 5145195, 73053412, 49940397, 71085598, 35564328, 122839923, 25936244,
                 46575034, 37253081,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 14187449, 3448569, 56472628, 22743496, 44444983, 30120835, 7268409, 22663988,
                 27394300, 12015369,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 19695742, 16087646, 28032085, 12999827, 6817792, 11427614, 20244189, 32241655,
                 53849736, 30151970,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 97968948, 12735207, 65220619, 28854697, 50133957, 35811371, 126051714, 45852742,
                 58558339, 23160969,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 61389038, 22309106, 65198214, 15569034, 26642876, 25966672, 61319509, 18435777,
                 62132699, 12651792,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 64260450, 9953420, 11531313, 28271553, 26895122, 20857343, 53990043, 17036529,
                 9768697, 31021214,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 109498250, 35449081, 66821165, 28850346, 82457582, 25397901, 32767512, 46319882,
                 72048958, 44232657,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 18860224, 15980149, 48121624, 31991861, 40875851, 22482575, 59264981, 13944023,
                 42736516, 16582018,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 51604604, 4970267, 37215820, 4175592, 46115652, 31354675, 55404809, 15444559,
                 56105103, 7989036,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 98599278, 39122492, 64696060, 35736814, 34772016, 38086117, 35030594, 39754637,
                 47422750, 52308692,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 49800177, 17674491, 35586086, 33551600, 34221481, 16375548, 8680158, 17182719,
                 28550067, 26697300,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 38981977, 27866340, 16837844, 31733974, 60258182, 12700015, 37068883, 4364037,
                 1155602, 5988841,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 88999280, 20281524, 121593716, 12154347, 59276991, 48854927, 90257846, 29083950,
                 91727270, 41837612,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 33972757, 23041680, 9975415, 6841041, 35549071, 16356535, 3070187, 26528504,
                 1466168, 10740210,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 65599446, 18066246, 53605478, 22898515, 32799043, 909394, 53169961, 27774712,
                 34944214, 18227391,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 71069668, 19286628, 39082773, 51190812, 47704004, 46701299, 82676190, 34505938,
                 63848542, 32980496,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 24740822, 5052253, 37014733, 8961360, 25877428, 6165135, 42740684, 14397371,
                 59728495, 27410326,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 38220480, 3510802, 39005586, 32395953, 55870735, 22922977, 51667400, 19101303,
                 65483377, 27059617,
             ]),
@@ -2985,113 +2985,113 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 67902144, 24323953, 75945165, 27318724, 39747955, 31184838, 100261706, 62223612,
                 57202662, 32932579,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 5666214, 525582, 20782575, 25516013, 42570364, 14657739, 16099374, 1468826,
                 60937436, 18367850,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 62249590, 29775088, 64191105, 26806412, 7778749, 11688288, 36704511, 23683193,
                 65549940, 23690785,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 10896313, 25834728, 67933138, 34027032, 114757419, 36564017, 25248957, 48337770,
                 36527387, 17796587,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 10566929, 12612572, 35164652, 11118702, 54475488, 12362878, 21752402, 8822496,
                 24003793, 14264025,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 27713843, 26198459, 56100623, 9227529, 27050101, 2504721, 23886875, 20436907,
                 13958494, 27821979,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 110736080, 38421656, 39861735, 37454952, 29838368, 25342141, 102328328, 23512649,
                 74449384, 51698795,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 4646495, 25543308, 44342840, 22021777, 23184552, 8566613, 31366726, 32173371,
                 52042079, 23179239,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 49838347, 12723031, 50115803, 14878793, 21619651, 27356856, 27584816, 3093888,
                 58265170, 3849920,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 58043933, 35657603, 92670503, 51983125, 61869038, 43137389, 99585908, 24536476,
                 72111157, 18004172,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 55051311, 22376525, 21115584, 20189277, 8808711, 21523724, 16489529, 13378448,
                 41263148, 12741425,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 61162478, 10645102, 36197278, 15390283, 63821882, 26435754, 24306471, 15852464,
                 28834118, 25908360,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 49773097, 24447374, 109686448, 42989383, 58636779, 32971069, 54018092, 34010272,
                 87570721, 39045736,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 13669229, 17458950, 54626889, 23351392, 52539093, 21661233, 42112877, 11293806,
                 38520660, 24132599,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 28497909, 6272777, 34085870, 14470569, 8906179, 32328802, 18504673, 19389266,
                 29867744, 24758489,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 50901822, 47071627, 39309233, 19856633, 24009063, 60734973, 60741262, 53933471,
                 22853427, 29542421,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 24191359, 16712145, 53177067, 15217830, 14542237, 1646131, 18603514, 22516545,
                 12876622, 31441985,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 17902668, 4518229, 66697162, 30725184, 26878216, 5258055, 54248111, 608396,
                 16031844, 3723494,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 105584936, 12763726, 46662418, 41131935, 33001347, 54091119, 17558840, 59235974,
                 23896952, 29240187,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 47103464, 21542479, 31520463, 605201, 2543521, 5991821, 64163800, 7229063,
                 57189218, 24727572,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 28816026, 298879, 38943848, 17633493, 19000927, 31888542, 54428030, 30605106,
                 49057085, 31471516,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 16000882, 33209536, 70601955, 55661665, 37604267, 20394642, 79686603, 49595699,
                 47393623, 7847706,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 10151868, 10572098, 27312476, 7922682, 14825339, 4723128, 34252933, 27035413,
                 57088296, 3852847,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 55678375, 15697595, 45987307, 29133784, 5386313, 15063598, 16514493, 17622322,
                 29330898, 18478208,
             ]),
@@ -3099,113 +3099,113 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 41609110, 29175637, 51885955, 26653220, 83724594, 35606215, 70412565, 33569921,
                 106668931, 45868821,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 15683501, 27551389, 18109119, 23573784, 15337967, 27556609, 50391428, 15921865,
                 16103996, 29823217,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 43939021, 22773182, 13588191, 31925625, 63310306, 32479502, 47835256, 5402698,
                 37293151, 23713330,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 90299521, 35939014, 34394523, 37016585, 104314072, 32025298, 55842007, 8911516,
                 109011869, 36294143,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 21374101, 30000182, 33584214, 9874410, 15377179, 11831242, 33578960, 6134906,
                 4931255, 11987849,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 67101132, 30575573, 50885377, 7277596, 105524, 33232381, 35628324, 13861387,
                 37032554, 10117929,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 37607694, 22809559, 40945095, 13051538, 41483300, 38644074, 127892224, 40258509,
                 79998882, 15728939,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 45136504, 21783052, 66157804, 29135591, 14704839, 2695116, 903376, 23126293,
                 12885166, 8311031,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 49592363, 5352193, 10384213, 19742774, 7506450, 13453191, 26423267, 4384730,
                 1888765, 28119028,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 108400371, 64001550, 120723127, 30371924, 98005322, 19632702, 101966083, 20846561,
                 47644429, 30214188,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 43500868, 30888657, 66582772, 4651135, 5765089, 4618330, 6092245, 14845197,
                 17151279, 23700316,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 42278406, 20820711, 51942885, 10367249, 37577956, 33289075, 22825804, 26467153,
                 50242379, 16176524,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 43525570, 40119392, 87172552, 37352659, 129477549, 40913655, 69115045, 23191005,
                 38362610, 56911354,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 56482264, 29068029, 53788301, 28429114, 3432135, 27161203, 23632036, 31613822,
                 32808309, 1099883,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 15030958, 5768825, 39657628, 30667132, 60681485, 18193060, 51830967, 26745081,
                 2051440, 18328567,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 63746522, 26315059, 74626753, 43379423, 90664713, 33849800, 72257261, 52954675,
                 44422508, 50188091,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 4577067, 16802144, 13249840, 18250104, 19958762, 19017158, 18559669, 22794883,
                 8402477, 23690159,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 38702534, 32502850, 40318708, 32646733, 49896449, 22523642, 9453450, 18574360,
                 17983009, 9967138,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 41346351, 40079153, 93694351, 43523701, 24709297, 34774792, 65430873, 7806336,
                 84616260, 37205991,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 56688388, 29436320, 14584638, 15971087, 51340543, 8861009, 26556809, 27979875,
                 48555541, 22197296,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 2839082, 14284142, 4029895, 3472686, 14402957, 12689363, 40466743, 8459446,
                 61503401, 25932490,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 62269556, 30018987, 76853824, 2871047, 92222842, 36741449, 109106914, 32705364,
                 84366947, 25576692,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 18164541, 22959256, 49953981, 32012014, 19237077, 23809137, 23357532, 18337424,
                 26908269, 12150756,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 36843994, 25906566, 5112248, 26517760, 65609056, 26580174, 43167, 28016731,
                 34806789, 16215818,
             ]),
@@ -3213,113 +3213,113 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 60209940, 43378825, 54804084, 29153342, 102820586, 27277595, 99683352, 46087336,
                 59605791, 24879084,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 39765323, 17038963, 39957339, 22831480, 946345, 16291093, 254968, 7168080,
                 21676107, 31611404,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 21260942, 25129680, 50276977, 21633609, 43430902, 3968120, 63456915, 27338965,
                 63552672, 25641356,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 16544735, 46804798, 50304435, 49100673, 62525860, 46311689, 64646555, 24874095,
                 48201831, 23891632,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 64693606, 17976703, 18312302, 4964443, 51836334, 20900867, 26820650, 16690659,
                 25459437, 28989823,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 41964155, 11425019, 28423002, 22533875, 60963942, 17728207, 9142794, 31162830,
                 60676445, 31909614,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 44004193, 39807907, 16964146, 29785560, 109103755, 54812425, 39651637, 50764205,
                 73444554, 40804420,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 36775618, 13979674, 7503222, 21186118, 55152142, 28932738, 36836594, 2682241,
                 25993170, 21075909,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 4364628, 5930691, 32304656, 23509878, 59054082, 15091130, 22857016, 22955477,
                 31820367, 15075278,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 98987979, 24635738, 84367624, 33645057, 126175891, 28636721, 91271651, 23903545,
                 116247489, 46387475,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 19073683, 14851414, 42705695, 21694263, 7625277, 11091125, 47489674, 2074448,
                 57694925, 14905376,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 24483648, 21618865, 64589997, 22007013, 65555733, 15355505, 41826784, 9253128,
                 27628530, 25998952,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 84706452, 41895034, 86464480, 34106618, 26198469, 30377849, 71702187, 24396849,
                 120106852, 48851446,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 510886, 14337390, 35323607, 16638631, 6328095, 2713355, 46891447, 21690211,
                 8683220, 2921426,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 18606791, 11874196, 27155355, 28272950, 43077121, 6265445, 41930624, 32275507,
                 4674689, 13890525,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 13609605, 13069022, 106845367, 20498522, 91469449, 43147405, 82086020, 43389536,
                 71498550, 33842827,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 9922506, 33035038, 13613106, 5883594, 48350519, 33120168, 54804801, 8317627,
                 23388070, 16052080,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 12719997, 11937594, 35138804, 28525742, 26900119, 8561328, 46953177, 21921452,
                 52354592, 22741539,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 83070703, 47704840, 93825794, 32888599, 111423399, 47157999, 78938436, 41022275,
                 38286735, 34483706,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 11038231, 21972036, 39798381, 26237869, 56610336, 17246600, 43629330, 24182562,
                 45715720, 2465073,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 20017144, 29231206, 27915241, 1529148, 12396362, 15675764, 13817261, 23896366,
                 2463390, 28932292,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 50749967, 20890520, 122152544, 38550884, 65852441, 34628003, 76692421, 12851106,
                 71112760, 46228148,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 65377275, 18398561, 63845933, 16143081, 19294135, 13385325, 14741514, 24450706,
                 7903885, 2348101,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 24536016, 17039225, 12715591, 29692277, 1511292, 10047386, 63266518, 26425272,
                 38731325, 10048126,
             ]),
@@ -3327,113 +3327,113 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 54486638, 27349611, 97827688, 2591311, 56491836, 12192839, 85982162, 59811773,
                 34811106, 15221631,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 40630742, 22450567, 11546243, 31701949, 9180879, 7656409, 45764914, 2095754,
                 29769758, 6593415,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 35114656, 30646970, 4176911, 3264766, 12538965, 32686321, 26312344, 27435754,
                 30958053, 8292160,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 98538667, 53149747, 96282394, 15632447, 12174511, 64348770, 99917693, 37531617,
                 93251999, 30405555,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 22648882, 1402143, 44308880, 13746058, 7936347, 365344, 58440231, 31879998,
                 63350620, 31249806,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 51616947, 8012312, 64594134, 20851969, 43143017, 23300402, 65496150, 32018862,
                 50444388, 8194477,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 27338047, 26047012, 59694639, 10140404, 48082437, 26964542, 94386054, 42409807,
                 95681149, 36559595,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 26287105, 4821776, 25476601, 29408529, 63344350, 17765447, 49100281, 1182478,
                 41014043, 20474836,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 59937691, 3178079, 23970071, 6201893, 49913287, 29065239, 45232588, 19571804,
                 32208682, 32356184,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 50451143, 36372074, 56822501, 14811297, 73133531, 46903936, 39793359, 56611021,
                 39436277, 22014573,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 15941010, 24148500, 45741813, 8062054, 31876073, 33315803, 51830470, 32110002,
                 15397330, 29424239,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 8934485, 20068965, 43822466, 20131190, 34662773, 14047985, 31170398, 32113411,
                 39603297, 15087183,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 115860466, 31397939, 24524912, 16876564, 82629290, 27193655, 118715321, 11461894,
                 83897392, 27685489,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 65161459, 16013772, 21750665, 3714552, 49707082, 17498998, 63338576, 23231111,
                 31322513, 21938797,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 21426636, 27904214, 53460576, 28206894, 38296674, 28633461, 48833472, 18933017,
                 13040861, 21441484,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 78402740, 46032517, 107081326, 48638180, 104910306, 14748870, 14555558, 20137329,
                 68722574, 38451366,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 41213962, 15323293, 58619073, 25496531, 25967125, 20128972, 2825959, 28657387,
                 43137087, 22287016,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 51184079, 28324551, 49665331, 6410663, 3622847, 10243618, 20615400, 12405433,
                 43355834, 25118015,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 127126414, 46110638, 114026375, 9025185, 50036385, 4333800, 71487300, 35986461,
                 23097948, 32988414,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 4565804, 17528778, 20084411, 25711615, 1724998, 189254, 24767264, 10103221,
                 48596551, 2424777,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 366633, 21577626, 8173089, 26664313, 30788633, 5745705, 59940186, 1344108,
                 63466311, 12412658,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 110215918, 41244716, 82038279, 33386174, 102006892, 53695876, 91271559, 51782359,
                 63967361, 44733816,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 18289503, 18829478, 8056944, 16430056, 45379140, 7842513, 61107423, 32067534,
                 48424218, 22110928,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 476239, 6601091, 60956074, 23831056, 17503544, 28690532, 27672958, 13403813,
                 11052904, 5219329,
             ]),
@@ -3441,113 +3441,113 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 87787372, 25178693, 34436965, 42403554, 129207969, 48129182, 98295834, 29580701,
                 9014761, 58529808,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 53464795, 23204192, 51146355, 5075807, 65594203, 22019831, 34006363, 9160279,
                 8473550, 30297594,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 24900749, 14435722, 17209120, 18261891, 44516588, 9878982, 59419555, 17218610,
                 42540382, 11788947,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 63990690, 22159237, 53306774, 48351872, 76761311, 26708527, 47071426, 43965164,
                 42540393, 32095740,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 51449703, 16736705, 44641714, 10215877, 58011687, 7563910, 11871841, 21049238,
                 48595538, 8464117,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 43708233, 8348506, 52522913, 32692717, 63158658, 27181012, 14325288, 8628612,
                 33313881, 25183915,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 46921853, 28586496, 89476219, 38825978, 66011746, 28765593, 109412060, 23317576,
                 58168128, 61290594,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 60160060, 31759219, 34483180, 17533252, 32635413, 26180187, 15989196, 20716244,
                 28358191, 29300528,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 43547083, 30755372, 34757181, 31892468, 57961144, 10429266, 50471180, 4072015,
                 61757200, 5596588,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 105981130, 30164382, 79421759, 39767609, 3117141, 49632997, 29266238, 36111653,
                 68877164, 15373192,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 59865506, 30307471, 62515396, 26001078, 66980936, 32642186, 66017961, 29049440,
                 42448372, 3442909,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 36898293, 5124042, 14181784, 8197961, 18964734, 21615339, 22597930, 7176455,
                 48523386, 13365929,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 59231455, 32054473, 75433536, 38244510, 73370723, 34444877, 24538106, 24984246,
                 57419264, 30522764,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 25008885, 22782833, 62803832, 23916421, 16265035, 15721635, 683793, 21730648,
                 15723478, 18390951,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 57448220, 12374378, 40101865, 26528283, 59384749, 21239917, 11879681, 5400171,
                 519526, 32318556,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 22258378, 50776631, 59239045, 14613015, 44588609, 30603508, 46754982, 40870398,
                 16648396, 41160072,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 59027556, 25089834, 58885552, 9719709, 19259459, 18206220, 23994941, 28272877,
                 57640015, 4763277,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 45409620, 9220968, 51378240, 1084136, 41632757, 30702041, 31088446, 25789909,
                 55752334, 728111,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 26047201, 55357393, 127317403, 50587064, 91200930, 9158118, 62835319, 20998873,
                 104852291, 28056158,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 17510331, 33231575, 5854288, 8403524, 17133918, 30441820, 38997856, 12327944,
                 10750447, 10014012,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 56796096, 3936951, 9156313, 24656749, 16498691, 32559785, 39627812, 32887699,
                 3424690, 7540221,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 97431206, 26590321, 78469868, 29411114, 74542167, 4989747, 127146306, 50791643,
                 57864597, 48812477,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 13054543, 30774935, 19155473, 469045, 54626067, 4566041, 5631406, 2711395, 1062915,
                 28418087,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 47868616, 22299832, 37599834, 26054466, 61273100, 13005410, 61042375, 12194496,
                 32960380, 1459310,
             ]),
@@ -3555,113 +3555,113 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 86960860, 40582355, 90778216, 43574797, 75695366, 26896524, 67503060, 27452546,
                 85746866, 55933926,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 31395515, 15098109, 26581030, 8030562, 50580950, 28547297, 9012485, 25970078,
                 60465776, 28111795,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 57916680, 31207054, 65111764, 4529533, 25766844, 607986, 67095642, 9677542,
                 34813975, 27098423,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 64664330, 33404494, 96457765, 8186664, 68982624, 12489862, 103283149, 25714738,
                 59256019, 58970434,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 51872508, 18120922, 7766469, 746860, 26346930, 23332670, 39775412, 10754587,
                 57677388, 5203575,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 31834314, 14135496, 66338857, 5159117, 20917671, 16786336, 59640890, 26216907,
                 31809242, 7347066,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 57502122, 21680191, 87523322, 46588417, 80825387, 21862550, 86906833, 21343176,
                 82301739, 31466941,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 54445282, 31372712, 1168161, 29749623, 26747876, 19416341, 10609329, 12694420,
                 33473243, 20172328,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 33184999, 11180355, 15832085, 22169002, 65475192, 225883, 15089336, 22530529,
                 60973201, 14480052,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 98417562, 27934433, 98139703, 31657332, 82783410, 26971548, 72605071, 13685226,
                 27595050, 42291707,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 46790012, 18404192, 10933842, 17376410, 8335351, 26008410, 36100512, 20943827,
                 26498113, 66511,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 22644435, 24792703, 50437087, 4884561, 64003250, 19995065, 30540765, 29267685,
                 53781076, 26039336,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 106199862, 9834843, 85726071, 30873119, 63706907, 53801357, 75314402, 13585436,
                 117090263, 48669869,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 23711543, 32881517, 31206560, 25191721, 6164646, 23844445, 33572981, 32128335,
                 8236920, 16492939,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 43198286, 20038905, 40809380, 29050590, 25005589, 25867162, 19574901, 10071562,
                 6708380, 27332008,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 69210217, 28624377, 86811594, 35922006, 118790560, 34602105, 72409880, 42883131,
                 29955600, 55430554,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 3096359, 9271816, 45488000, 18032587, 52260867, 25961494, 41216721, 20918836,
                 57191288, 6216607,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 34493015, 338662, 41913253, 2510421, 37895298, 19734218, 24822829, 27407865,
                 40341383, 7525078,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 44042196, 53123240, 83242349, 25658253, 130828162, 34333218, 66198527, 30771936,
                 47722230, 45548532,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 21691500, 19929806, 66467532, 19187410, 3285880, 30070836, 42044197, 9718257,
                 59631427, 13381417,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 18445390, 29352196, 14979845, 11622458, 65381754, 29971451, 23111647, 27179185,
                 28535281, 15779576,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 30098034, 36644094, 124983340, 16662133, 45801924, 44862842, 53040409, 12021729,
                 77064149, 17251075,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 9734894, 18977602, 59635230, 24415696, 2060391, 11313496, 48682835, 9924398,
                 20194861, 13380996,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 40730762, 25589224, 44941042, 15789296, 49053522, 27385639, 65123949, 15707770,
                 26342023, 10146099,
             ]),
@@ -3669,113 +3669,113 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 41091971, 33334488, 88448054, 33513043, 86854119, 30675731, 37471583, 35781471,
                 21612325, 33008704,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 54031477, 1184227, 23562814, 27583990, 46757619, 27205717, 25764460, 12243797,
                 46252298, 11649657,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 57077370, 11262625, 27384172, 2271902, 26947504, 17556661, 39943, 6114064,
                 33514190, 2333242,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 112784121, 54687041, 75228644, 40774344, 45278341, 58092729, 60429112, 54438225,
                 91459440, 20104430,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 62992557, 22282898, 43222677, 4843614, 37020525, 690622, 35572776, 23147595,
                 8317859, 12352766,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 18200138, 19078521, 34021104, 30857812, 43406342, 24451920, 43556767, 31266881,
                 20712162, 6719373,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 26656189, 39629685, 59250307, 35440503, 105873684, 37816756, 78226393, 29791221,
                 26224234, 30256974,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 49939907, 18700334, 63713187, 17184554, 47154818, 14050419, 21728352, 9493610,
                 18620611, 17125804,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 53785524, 13325348, 11432106, 5964811, 18609221, 6062965, 61839393, 23828875,
                 36407290, 17074774,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 43248307, 55875704, 94070219, 35195292, 34695751, 16816491, 79357372, 28313792,
                 80844205, 35488493,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 25089769, 6742589, 17081145, 20148166, 21909292, 17486451, 51972569, 29789085,
                 45830866, 5473615,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 31883658, 25593331, 1083431, 21982029, 22828470, 13290673, 59983779, 12469655,
                 29111212, 28103418,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 91353792, 52058456, 107954750, 36345970, 52111264, 50221109, 91476329, 39943270,
                 56813276, 34006814,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 41468082, 30136590, 5217915, 16224624, 19987036, 29472163, 42872612, 27639183,
                 15766061, 8407814,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 46701865, 13990230, 15495425, 16395525, 5377168, 15166495, 58191841, 29165478,
                 59040954, 2276717,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 30157899, 46478498, 116505677, 42800183, 87003891, 36922573, 43281276, 38650650,
                 89849239, 26251014,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 2041139, 19298082, 7783686, 13876377, 41161879, 20201972, 24051123, 13742383,
                 51471265, 13295221,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 33338218, 25048699, 12532112, 7977527, 9106186, 31839181, 49388668, 28941459,
                 62657506, 18884987,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 47063564, 39008528, 52762315, 40001577, 28862070, 35438083, 64639597, 29412551,
                 74879432, 43175028,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 23208049, 7979712, 33071466, 8149229, 1758231, 22719437, 30945527, 31860109,
                 33606523, 18786461,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 1439939, 17283952, 66028874, 32760649, 4625401, 10647766, 62065063, 1220117,
                 30494170, 22113633,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 62071265, 20526136, 64138304, 30492664, 82749837, 26852765, 40369837, 34480481,
                 65424524, 20220784,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 13908495, 30005160, 30919927, 27280607, 45587000, 7989038, 9021034, 9078865,
                 3353509, 4033511,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 37445433, 18440821, 32259990, 33209950, 24295848, 20642309, 23161162, 8839127,
                 27485041, 7356032,
             ]),
@@ -3783,113 +3783,113 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 76769853, 34259874, 79088928, 28184277, 65480320, 14661172, 60762722, 36179446,
                 95539899, 50337029,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 43269631, 25243016, 41163352, 7480957, 49427195, 25200248, 44562891, 14150564,
                 15970762, 4099461,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 29262576, 16756590, 26350592, 24760869, 8529670, 22346382, 13617292, 23617289,
                 11465738, 8317062,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 41615764, 26591503, 99609063, 24135380, 44070139, 31252209, 82007500, 37402886,
                 88078197, 28396915,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 46724414, 19206718, 48772458, 13884721, 34069410, 2842113, 45498038, 29904543,
                 11177094, 14989547,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 42612143, 21838415, 16959895, 2278463, 12066309, 10137771, 13515641, 2581286,
                 38621356, 9930239,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 49357223, 31456605, 83653163, 54099563, 118302919, 18605349, 18345766, 53705111,
                 83400343, 28240393,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 33879670, 2553287, 32678213, 9875984, 8534129, 6889387, 57432090, 6957616, 4368891,
                 9788741,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 16660737, 7281060, 56278106, 12911819, 20108584, 25452756, 45386327, 24941283,
                 16250551, 22443329,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 47343357, 35944957, 117666696, 14161978, 69014150, 39969338, 71798447, 10604806,
                 104027325, 4782745,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 65754325, 14736940, 59741422, 20261545, 7710541, 19398842, 57127292, 4383044,
                 22546403, 437323,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 31665558, 21373968, 50922033, 1491338, 48740239, 3294681, 27343084, 2786261,
                 36475274, 19457415,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 52641566, 32870716, 33734756, 41002983, 19294359, 14334329, 47418233, 35909750,
                 47824192, 27440058,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 15121312, 17758270, 6377019, 27523071, 56310752, 20596586, 18952176, 15496498,
                 37728731, 11754227,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 64471568, 20071356, 8488726, 19250536, 12728760, 31931939, 7141595, 11724556,
                 22761615, 23420291,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 16918416, 11729663, 49025285, 36577418, 103201995, 53769203, 38367677, 21327038,
                 32851221, 11717399,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 11166615, 7338049, 60386341, 4531519, 37640192, 26252376, 31474878, 3483633,
                 65915689, 29523600,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 66923210, 9921304, 31456609, 20017994, 55095045, 13348922, 33142652, 6546660,
                 47123585, 29606055,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 101757113, 44821142, 55911756, 25655328, 31703693, 37410335, 58571732, 20721383,
                 36336829, 18068118,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 49102387, 12709067, 3991746, 27075244, 45617340, 23004006, 35973516, 17504552,
                 10928916, 3011958,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 60151107, 17960094, 31696058, 334240, 29576716, 14796075, 36277808, 20749251,
                 18008030, 10258577,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 44660220, 49210000, 74127342, 29144428, 36794597, 32352840, 65255398, 34921551,
                 92236737, 6671742,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 29701166, 19180498, 56230743, 9279287, 67091296, 13127209, 21382910, 11042292,
                 25838796, 4642684,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 46678630, 14955536, 42982517, 8124618, 61739576, 27563961, 30468146, 19653792,
                 18423288, 4177476,
             ]),
@@ -3903,897 +3903,897 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
 pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsPoint> =
     NafLookupTable8([
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 93076338, 52752828, 29566454, 37215328, 54414518, 37569218, 94653489, 21800160,
                 61029707, 35602036,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 54563134, 934261, 64385954, 3049989, 66381436, 9406985, 12720692, 5043384,
                 19500929, 18085054,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 58370664, 4489569, 9688441, 18769238, 10184608, 21191052, 29287918, 11864899,
                 42594502, 29115885,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 82745136, 23865874, 24204772, 25642034, 67725840, 16869169, 94896463, 52336674,
                 28944398, 32004408,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 16568933, 4717097, 55552716, 32452109, 15682895, 21747389, 16354576, 21778470,
                 7689661, 11199574,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 30464137, 27578307, 55329429, 17883566, 23220364, 15915852, 7512774, 10017326,
                 49359771, 23634074,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 77970208, 11473153, 27284546, 35535607, 37044514, 46132292, 99976748, 48069538,
                 118779423, 44373810,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 4708026, 6336745, 20377586, 9066809, 55836755, 6594695, 41455196, 12483687,
                 54440373, 5581305,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 19563141, 16186464, 37722007, 4097518, 10237984, 29206317, 28542349, 13850243,
                 43430843, 17738489,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 72262591, 43463716, 68832610, 30776557, 97632468, 39071304, 86589715, 38784565,
                 43156424, 18378665,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 36839857, 30090922, 7665485, 10083793, 28475525, 1649722, 20654025, 16520125,
                 30598449, 7715701,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 28881826, 14381568, 9657904, 3680757, 46927229, 7843315, 35708204, 1370707,
                 29794553, 32145132,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 44589852, 26862249, 14201701, 24808930, 43598457, 42399157, 85583074, 32192981,
                 54046167, 47376308,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 60653668, 25714560, 3374701, 28813570, 40010246, 22982724, 31655027, 26342105,
                 18853321, 19333481,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 4566811, 20590564, 38133974, 21313742, 59506191, 30723862, 58594505, 23123294,
                 2207752, 30344648,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 41954014, 62923042, 96790006, 41423232, 60254202, 24130566, 121780363, 32891430,
                 103106264, 17421994,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 25576264, 30851218, 7349803, 21739588, 16472781, 9300885, 3844789, 15725684,
                 171356, 6466918,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 23103977, 13316479, 9739013, 17404951, 817874, 18515490, 8965338, 19466374,
                 36393951, 16193876,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 100695917, 36735143, 64714733, 47558118, 50205389, 17283591, 84347261, 38283886,
                 49034350, 9256799,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 41926547, 29380300, 32336397, 5036987, 45872047, 11360616, 22616405, 9761698,
                 47281666, 630304,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 53388152, 2639452, 42871404, 26147950, 9494426, 27780403, 60554312, 17593437,
                 64659607, 19263131,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 63957664, 28508356, 76391577, 40420576, 102310665, 32691407, 48168288, 15033783,
                 92213982, 25659555,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 42782475, 15950225, 35307649, 18961608, 55446126, 28463506, 1573891, 30928545,
                 2198789, 17749813,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 64009494, 10324966, 64867251, 7453182, 61661885, 30818928, 53296841, 17317989,
                 34647629, 21263748,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 17735022, 27114469, 76149336, 40765111, 43325570, 26153544, 26948151, 45905235,
                 38656900, 62179684,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 2154119, 14782993, 28737794, 11906199, 36205504, 26488101, 19338132, 16910143,
                 50209922, 29794297,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 29935700, 6336041, 20999566, 30405369, 13628497, 24612108, 61639745, 22359641,
                 56973806, 18684690,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 29792811, 31379227, 113441390, 20675662, 58452680, 54138549, 42892249, 32958636,
                 31674345, 24275271,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 7606599, 22131225, 17376912, 15235046, 32822971, 7512882, 30227203, 14344178,
                 9952094, 8804749,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 32575079, 3961822, 36404898, 17773250, 67073898, 1319543, 30641032, 7823672,
                 63309858, 18878784,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 77823924, 52933642, 26572931, 18690221, 109143683, 23989794, 79129572, 53326100,
                 38888709, 55889506,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 37146997, 554126, 63326061, 20925660, 49205290, 8620615, 53375504, 25938867,
                 8752612, 31225894,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 4529887, 12416158, 60388162, 30157900, 15427957, 27628808, 61150927, 12724463,
                 23658330, 23690055,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 102043267, 54823614, 45810225, 19657305, 54297192, 7413280, 66851983, 39718512,
                 25005048, 18002658,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 5403481, 24654166, 61855580, 13522652, 14989680, 1879017, 43913069, 25724172,
                 20315901, 421248,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 34818947, 1705239, 25347020, 7938434, 51632025, 1720023, 54809726, 32655885,
                 64907986, 5517607,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 88543525, 16557377, 80359887, 30047148, 91602876, 27723948, 62710290, 52707861,
                 7715736, 61648232,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 14461032, 6393639, 22681353, 14533514, 52493587, 3544717, 57780998, 24657863,
                 59891807, 31628125,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 60864886, 31199953, 18524951, 11247802, 43517645, 21165456, 26204394, 27268421,
                 63221077, 29979135,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 97491378, 10077555, 94805128, 42472719, 30231379, 17961119, 76201413, 41182329,
                 41405214, 31798052,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 13670592, 720327, 7131696, 19360499, 66651570, 16947532, 3061924, 22871019,
                 39814495, 20141336,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 44847187, 28379568, 38472030, 23697331, 49441718, 3215393, 1669253, 30451034,
                 62323912, 29368533,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 74923758, 35244493, 27222384, 30715870, 48444195, 28125622, 116052444, 32330148,
                 92609232, 35372537,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 39340596, 15199968, 52787715, 18781603, 18787729, 5464578, 11652644, 8722118,
                 57056621, 5153960,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 5733861, 14534448, 59480402, 15892910, 30737296, 188529, 491756, 17646733,
                 33071791, 15771063,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 85239571, 21331573, 119690709, 30172286, 44350959, 55826224, 68258766, 16209406,
                 20222151, 32139086,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 52372801, 13847470, 52690845, 3802477, 48387139, 10595589, 13745896, 3112846,
                 50361463, 2761905,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 45982696, 12273933, 15897066, 704320, 31367969, 3120352, 11710867, 16405685,
                 19410991, 10591627,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 82008850, 34439758, 89319886, 49124188, 34309215, 29866047, 80308709, 27738519,
                 71739865, 46909287,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 36631997, 23300851, 59535242, 27474493, 59924914, 29067704, 17551261, 13583017,
                 37580567, 31071178,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 22641770, 21277083, 10843473, 1582748, 37504588, 634914, 15612385, 18139122,
                 59415250, 22563863,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 76721854, 52814714, 41722368, 35285867, 53022548, 38255176, 93163883, 27627617,
                 87963092, 33729456,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 61915349, 11733561, 59403492, 31381562, 29521830, 16845409, 54973419, 26057054,
                 49464700, 796779,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 3855018, 8248512, 12652406, 88331, 2948262, 971326, 15614761, 9441028, 29507685,
                 8583792,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 76968870, 14808584, 76708906, 57649718, 23400175, 24077237, 63783137, 37471119,
                 56750251, 30681804,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 33709664, 3740344, 52888604, 25059045, 46197996, 22678812, 45207164, 6431243,
                 21300862, 27646257,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 49811511, 9216232, 25043921, 18738174, 29145960, 3024227, 65580502, 530149,
                 66809973, 22275500,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 23499366, 24936714, 38355445, 35908587, 82540167, 39280880, 46809413, 41143783,
                 72530804, 49676198,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 45162189, 23851397, 9380591, 15192763, 36034862, 15525765, 5277811, 25040629,
                 33286237, 31693326,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 62424427, 13336013, 49368582, 1581264, 30884213, 15048226, 66823504, 4736577,
                 53805192, 29608355,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 25190215, 26304748, 58928336, 42665707, 64280342, 38580230, 61299598, 20659504,
                 30387592, 32519377,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 14480213, 17057820, 2286692, 32980967, 14693157, 22197912, 49247898, 9909859,
                 236428, 16857435,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 7877514, 29872867, 45886243, 25902853, 41998762, 6241604, 35694938, 15657879,
                 56797932, 8609105,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 54245189, 32562161, 57887697, 19509733, 45323534, 37472546, 27606727, 59528498,
                 74398957, 44973176,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 28964163, 20950093, 44929966, 26145892, 34786807, 18058153, 18187179, 27016486,
                 42438836, 14869174,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 55703901, 1222455, 64329400, 24533246, 11330890, 9135834, 3589529, 19555234,
                 53275553, 1207212,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 33323313, 35603165, 79328585, 6017848, 71286345, 23804207, 86644124, 44008367,
                 55775078, 31816581,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 64814718, 27217688, 29891310, 4504619, 8548709, 21986323, 62140656, 12555980,
                 34377058, 21436823,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 49069441, 9880212, 33350825, 24576421, 24446077, 15616561, 19302117, 9370836,
                 55172180, 28526191,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 95404934, 26757208, 123864063, 4572839, 69249194, 43584425, 53559055, 41742046,
                 41167331, 24643278,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 35101859, 30958612, 66105296, 3168612, 22836264, 10055966, 22893634, 13045780,
                 28576558, 30704591,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 59987873, 21166324, 43296694, 15387892, 39447987, 19996270, 5059183, 19972934,
                 30207804, 29631666,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 67444156, 16132892, 88330413, 37924284, 68147855, 57949418, 91481571, 24889160,
                 62329722, 50712214,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 56922508, 1347520, 23300731, 27393371, 42651667, 8512932, 27610931, 24436993,
                 3998295, 3835244,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 16327050, 22776956, 14746360, 22599650, 23700920, 11727222, 25900154, 21823218,
                 34907363, 25105813,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 59807886, 12089757, 115624210, 41476837, 67589715, 26361580, 71355762, 44268661,
                 67753061, 13128476,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 7174885, 26592113, 59892333, 6465478, 4145835, 17673606, 38764952, 22293290,
                 1360980, 25805937,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 40179568, 6331649, 42386021, 20205884, 15635073, 6103612, 56391180, 6789942,
                 7597240, 24095312,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 54776568, 36935932, 18757261, 41429535, 67215081, 34700142, 86560976, 61204154,
                 26496794, 19612129,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 46701540, 24101444, 49515651, 25946994, 45338156, 9941093, 55509371, 31298943,
                 1347425, 15381335,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 53576449, 26135856, 17092785, 3684747, 57829121, 27109516, 2987881, 10987137,
                 52269096, 15465522,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 80033010, 26264316, 72380996, 10039544, 94605936, 30615493, 60406855, 30400829,
                 120765849, 45301372,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 35668062, 24246990, 47788280, 25128298, 37456967, 19518969, 43459670, 10724644,
                 7294162, 4471290,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 33813988, 3549109, 101112, 21464449, 4858392, 3029943, 59999440, 21424738,
                 34313875, 1512799,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 29494960, 28240930, 51093230, 28823678, 92791151, 54796794, 77571888, 37795542,
                 75765856, 10649531,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 63536751, 7572551, 62249759, 25202639, 32046232, 32318941, 29315141, 15424555,
                 24706712, 28857648,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 47618751, 5819839, 19528172, 20715950, 40655763, 20611047, 4960954, 6496879,
                 2790858, 28045273,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 85174457, 55843901, 111946683, 31021158, 32797785, 48944265, 78338887, 31144772,
                 82688001, 38470222,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 49664705, 3638040, 57888693, 19234931, 40104182, 28143840, 28667142, 18386877,
                 18584835, 3592929,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 12065039, 18867394, 6430594, 17107159, 1727094, 13096957, 61520237, 27056604,
                 27026997, 13543966,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 68512926, 37577278, 94695528, 14209106, 95849194, 30038709, 51818051, 20241476,
                 68980056, 42251074,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 17325298, 33376175, 65271265, 4931225, 31708266, 6292284, 23064744, 22072792,
                 43945505, 9236924,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 51955585, 20268063, 61151838, 26383348, 4766519, 20788033, 21173534, 27030753,
                 9509140, 7790046,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 24124086, 38918775, 28620390, 10538620, 59433851, 19581010, 60862718, 43500219,
                 77600721, 32213801,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 7062127, 13930079, 2259902, 6463144, 32137099, 24748848, 41557343, 29331342,
                 47345194, 13022814,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 18921826, 392002, 55817981, 6420686, 8000611, 22415972, 14722962, 26246290,
                 20604450, 8079345,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 67710253, 26257798, 51499391, 46550521, 30228769, 53940987, 76234206, 43362242,
                 77953697, 21034392,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 25817710, 8020883, 50134679, 21244805, 47057788, 8766556, 29308546, 22307963,
                 49449920, 23874253,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 11081015, 13522660, 12474691, 29260223, 48687631, 9341946, 16850694, 18637605,
                 6199839, 14303642,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 64518173, 19894035, 117213833, 43031641, 79641718, 39533880, 66531934, 41205092,
                 117735515, 13989682,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 6921800, 4421166, 59739491, 30510778, 43106355, 30941531, 9363541, 3394240,
                 50874187, 23872585,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 54293979, 23466866, 47184247, 20627378, 8313211, 5865878, 5948507, 32290343,
                 52583140, 23139870,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 111574723, 24134616, 49842442, 23485580, 34844037, 45228427, 67103167, 25858409,
                 38508586, 35097070,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 19879846, 15259900, 25020018, 14261729, 22075205, 25189303, 787540, 31325033,
                 62422289, 16131171,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 39487053, 27893575, 34654176, 25620816, 60209846, 23603919, 8931189, 12275052,
                 38626469, 33438928,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 105416367, 9568747, 62672739, 49685015, 106242995, 4547918, 18403901, 38581738,
                 60829966, 33150322,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 7950033, 25841033, 47276506, 3884935, 62418883, 2342083, 50269031, 14194015,
                 27013685, 3320257,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 35270691, 18076829, 46994271, 4273335, 43595882, 31742297, 58328702, 4594760,
                 49180851, 18144010,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 30194115, 50068680, 49746331, 27470090, 40428285, 23271051, 70252167, 16153483,
                 123511881, 27809602,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 27113466, 6865046, 4512771, 29327742, 29021084, 7405965, 33302911, 9322435,
                 4307527, 32438240,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 29337813, 24673346, 10359233, 30347534, 57709483, 9930840, 60607771, 24076133,
                 20985293, 22480923,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 14579237, 33467236, 85745988, 15769997, 101228358, 21649866, 82685456, 59023858,
                 86175344, 24337101,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 4472119, 14702190, 10432042, 22460027, 708461, 18783996, 34234374, 30870323,
                 63796457, 10370850,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 36957127, 19555637, 16244231, 24367549, 58999881, 13440043, 35147632, 8718974,
                 43101064, 18487380,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 21818223, 34477173, 23913863, 22441963, 129271975, 14842154, 43035020, 9485973,
                 53819529, 22318987,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 10874834, 4351765, 66252340, 17269436, 64427034, 30735311, 5883785, 28998531,
                 44403022, 26064601,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 64017630, 9755550, 37507935, 22752543, 4031638, 29903925, 47267417, 32706846,
                 39147952, 21635901,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 81365001, 44927611, 97395185, 43985591, 66242539, 38517499, 52937891, 37374973,
                 73352483, 38476849,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 43460763, 24260930, 21493330, 30888969, 23329454, 24545577, 58286855, 12750266,
                 22391140, 26198125,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 20477567, 24078713, 1674568, 4102219, 25208396, 13972305, 30389482, 19572626,
                 1485666, 17679765,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 100511110, 23887606, 116505658, 30877106, 45483774, 25222431, 67931340, 37154158,
                 32618865, 18610785,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 48647066, 166413, 55454758, 8889513, 21027475, 32728181, 43100067, 4690060,
                 7520989, 16421303,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 14868391, 20996450, 64836606, 1042490, 27060176, 10253541, 53431276, 19516737,
                 41808946, 2239538,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 50228416, 29594943, 62030348, 10307368, 70970997, 20292574, 126292474, 51543890,
                 67827181, 15848795,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 5548701, 17911007, 33137864, 32764443, 31146554, 17931096, 64023370, 7290289,
                 6361313, 32861205,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 63374742, 30320053, 4091667, 30955480, 44819449, 2212055, 52638826, 22391938,
                 38484599, 7051029,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 50485560, 7033600, 57711425, 10740562, 72347547, 42328739, 7593987, 46950560,
                 85560721, 41970063,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 40930651, 3776911, 39108529, 2508077, 19371703, 7626128, 4092943, 15778278,
                 42044145, 24540103,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 44128555, 8867576, 8645499, 22222278, 11497130, 4344907, 10788462, 23382703,
                 3547104, 15368835,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 81786515, 51902785, 74560130, 22753403, 52379722, 41395524, 57994925, 6818020,
                 57707296, 16352835,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 21622574, 18581624, 36511951, 1212467, 36930308, 7910192, 20622927, 2438677,
                 52628762, 29068327,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 6797431, 2854059, 4269865, 8037366, 32016522, 15223213, 34765784, 15297582,
                 3559197, 26425254,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 107761639, 61759660, 79235166, 8794359, 48418924, 60111631, 87862210, 33613219,
                 68436482, 40229362,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 52388944, 32880897, 37676257, 8253690, 32826330, 2707379, 25088512, 17182878,
                 15053907, 11601568,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 43894091, 25425955, 50962615, 28097648, 30129084, 13258436, 39364589, 8197601,
                 58181660, 15003422,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 13470722, 47835674, 31012390, 30525035, 89789519, 50713267, 39648035, 13815677,
                 94028755, 62582101,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 54478677, 14782829, 56712503, 7094748, 41775828, 29409658, 9084386, 30179063,
                 64014926, 32519086,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 6314429, 20018828, 12535891, 19610611, 10074031, 28087963, 50489447, 26314252,
                 24553876, 32746308,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 105768482, 46629424, 103418946, 65789027, 85765355, 28316167, 56299027, 22780838,
                 122676432, 32376204,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 5654403, 26425050, 39347935, 963424, 5032477, 19850195, 30011537, 11153401,
                 63182039, 13343989,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 1130444, 29814849, 40569426, 8144467, 24179188, 6267924, 63847147, 2912740,
                 63870704, 29186744,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 49722534, 11073633, 52865263, 50829611, 33921405, 38614719, 32360242, 35465390,
                 50107050, 45035301,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 2003571, 2472803, 46902183, 1716406, 58609069, 15922982, 43766122, 27456369,
                 33468339, 29346282,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 18834217, 8245144, 29896065, 3490830, 62967493, 7220277, 146130, 18459164,
                 57533060, 30070422,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 77805507, 38474121, 73459597, 18553340, 107508318, 52705654, 33655873, 27331956,
                 44498407, 13768350,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 23652128, 27647291, 43351590, 13262712, 65238054, 26296349, 11902126, 2949002,
                 34445239, 25602117,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 55906958, 19046111, 28501158, 28224561, 14495533, 14714956, 32929972, 2643566,
                 17034893, 11645825,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 38181639, 29751709, 73650473, 17760526, 80753587, 17992258, 72670209, 41214427,
                 87524152, 37630124,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 6498441, 12053607, 10375600, 14764370, 24795955, 16159258, 57849421, 16071837,
                 31008329, 3792564,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 47930485, 9176956, 54248931, 8732776, 58000258, 10333519, 96092, 29273884,
                 13051277, 20121493,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 54190492, 49837594, 61282066, 10734597, 67926686, 36967416, 115462142, 30339271,
                 37200685, 30036936,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 21193614, 19929501, 18841215, 29565554, 64002173, 11123558, 14111648, 6069945,
                 30307604, 25935103,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 58539773, 2098685, 38301131, 15844175, 41633654, 16934366, 15145895, 5543861,
                 64050790, 6595361,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 34107945, 34731353, 51956038, 5614778, 79079051, 30288154, 47460410, 22186730,
                 30689695, 19628976,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 25043248, 19224237, 46048097, 32289319, 29339134, 12397721, 37385860, 12978240,
                 57951631, 31419653,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 46038439, 28501736, 62566522, 12609283, 35236982, 30457796, 64113609, 14800343,
                 6412849, 6276813,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 124528774, 39505727, 83050803, 41361190, 116071796, 37845759, 61633481, 38385016,
                 71255100, 31629488,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 249426, 17196749, 35434953, 13884216, 11701636, 24553269, 51821986, 12900910,
                 34844073, 16150118,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 2520516, 14697628, 15319213, 22684490, 62866663, 29666431, 13872507, 7473319,
                 12419515, 2958466,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 101517167, 22298305, 98222207, 59471046, 61547444, 50370568, 97111094, 42539051,
                 14298448, 49873561,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 19427905, 12004555, 9971383, 28189868, 32306269, 23648270, 34176633, 10760437,
                 53354280, 5634974,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 30044319, 23677863, 60273406, 14563839, 9734978, 19808149, 30899064, 30835691,
                 22828539, 23633348,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 25513026, 37111929, 37113703, 29589233, 77394412, 34745965, 95889446, 61766763,
                 92876242, 37566563,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 42139852, 9176396, 16274786, 33467453, 52558621, 7190768, 1490604, 31312359,
                 44767199, 18491072,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 4272877, 21431483, 45594743, 13027605, 59232641, 24151956, 38390319, 12906718,
                 45915869, 15503563,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 29874396, 35808736, 25494239, 37976524, 43036007, 37144111, 18198811, 35141252,
                 53490316, 47742788,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 59518553, 28520621, 59946871, 29462027, 3630300, 29398589, 60425462, 24588735,
                 53129947, 28399367,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 18192774, 12787801, 32021061, 9158184, 48389348, 16385092, 11799402, 9492011,
                 43154220, 15950102,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 68768204, 54638026, 33464925, 53430209, 66037964, 35360373, 22565155, 39168685,
                 46605438, 51897954,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 57660336, 29715319, 64414626, 32753338, 16894121, 935644, 53848937, 22684138,
                 10541713, 14174330,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 22888141, 12700209, 40301697, 6435658, 56329485, 5524686, 56715961, 6520808,
                 15754965, 9355803,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 79549820, 26746924, 54931884, 38547877, 49672847, 19708985, 52599424, 12757151,
                 93328625, 39524327,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 33888606, 13911610, 18921581, 1162763, 46616901, 13799218, 29525142, 21929286,
                 59295464, 503508,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 57865531, 22043577, 17998312, 3038439, 52838371, 9832208, 43311531, 660991,
                 25265267, 18977724,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 64010269, 23727746, 42277281, 48089313, 102316973, 34946803, 127880577, 38411468,
                 114816699, 43712746,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 56859315, 32558245, 41017090, 22610758, 13704990, 23215119, 2475037, 32344984,
                 12799418, 11135856,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 1867214, 27167702, 19772099, 16925005, 15366693, 25797692, 10829276, 15372827,
                 26582557, 31642714,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 57265197, 20059797, 107314987, 30587501, 60553812, 25602102, 29690666, 37127097,
                 103070929, 51772159,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 56432653, 6329655, 42770975, 4187982, 30677076, 9335071, 60103332, 14755050,
                 9451294, 574767,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 52859018, 2867107, 56258365, 15719081, 5959372, 8703738, 29137781, 21575537,
                 20249840, 31808689,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 74749335, 47235127, 9995910, 52200224, 92069015, 8964515, 33248715, 21201554,
                 57573145, 31605506,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 56307055, 23891752, 3613811, 30787942, 49031222, 26667524, 26985478, 31973510,
                 26785294, 29587427,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 30891460, 5254655, 47414930, 12769216, 42912782, 11830405, 7411958, 1394027,
                 18778535, 18209370,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 61227949, 26179350, 57501473, 13585864, 102855675, 40344975, 54134826, 59707765,
                 74122694, 12256219,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 5975515, 16302413, 24341148, 28270615, 18786096, 22405501, 28243950, 28328004,
                 53412289, 4381960,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 9394648, 8758552, 26189703, 16642536, 35993528, 5117040, 5977877, 13955594,
                 19244020, 24493735,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 111388362, 51822507, 30193028, 3993472, 110736308, 44014764, 107346699, 48464072,
                 92830877, 56442511,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 7236795, 30433657, 63588571, 620817, 11118384, 24979014, 66780154, 19877679,
                 16217590, 26311105,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 42540794, 21657271, 16455973, 23630199, 3992015, 21894417, 44876052, 19291718,
                 55429803, 30442389,
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement2625([
+            y_plus_x: FieldElement2625::from_limbs([
                 69421833, 26972132, 58859271, 20240912, 119664007, 29643940, 93968457, 34515112,
                 110902491, 44996669,
             ]),
-            y_minus_x: FieldElement2625([
+            y_minus_x: FieldElement2625::from_limbs([
                 3428668, 27807272, 41139948, 24786894, 4167808, 21423270, 52199622, 8021269,
                 53172251, 18070808,
             ]),
-            xy2d: FieldElement2625([
+            xy2d: FieldElement2625::from_limbs([
                 30631113, 26363656, 21279866, 23275794, 18311406, 466071, 42527968, 7989982,
                 29641567, 29446694,
             ]),

--- a/curve25519-dalek/src/backend/serial/u32/field.rs
+++ b/curve25519-dalek/src/backend/serial/u32/field.rs
@@ -284,12 +284,16 @@ impl ConditionallySelectable for FieldElement2625 {
 }
 
 impl FieldElement2625 {
+    pub(crate) const fn from_limbs(limbs: [u32; 10]) -> FieldElement2625 {
+        FieldElement2625(limbs)
+    }
+
     /// The scalar \\( 0 \\).
-    pub const ZERO: FieldElement2625 = FieldElement2625([0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+    pub const ZERO: FieldElement2625 = FieldElement2625::from_limbs([0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
     /// The scalar \\( 1 \\).
-    pub const ONE: FieldElement2625 = FieldElement2625([1, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+    pub const ONE: FieldElement2625 = FieldElement2625::from_limbs([1, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
     /// The scalar \\( -1 \\).
-    pub const MINUS_ONE: FieldElement2625 = FieldElement2625([
+    pub const MINUS_ONE: FieldElement2625 = FieldElement2625::from_limbs([
         0x3ffffec, 0x1ffffff, 0x3ffffff, 0x1ffffff, 0x3ffffff, 0x1ffffff, 0x3ffffff, 0x1ffffff,
         0x3ffffff, 0x1ffffff,
     ]);

--- a/curve25519-dalek/src/backend/serial/u64/constants.rs
+++ b/curve25519-dalek/src/backend/serial/u64/constants.rs
@@ -23,7 +23,7 @@ use crate::{
 };
 
 /// The value of minus one, equal to `-&FieldElement::ONE`
-pub(crate) const MINUS_ONE: FieldElement51 = FieldElement51([
+pub(crate) const MINUS_ONE: FieldElement51 = FieldElement51::from_limbs([
     2251799813685228,
     2251799813685247,
     2251799813685247,
@@ -32,7 +32,7 @@ pub(crate) const MINUS_ONE: FieldElement51 = FieldElement51([
 ]);
 
 /// Edwards `d` value, equal to `-121665/121666 mod p`.
-pub(crate) const EDWARDS_D: FieldElement51 = FieldElement51([
+pub(crate) const EDWARDS_D: FieldElement51 = FieldElement51::from_limbs([
     929955233495203,
     466365720129213,
     1662059464998953,
@@ -41,7 +41,7 @@ pub(crate) const EDWARDS_D: FieldElement51 = FieldElement51([
 ]);
 
 /// Edwards `2*d` value, equal to `2*(-121665/121666) mod p`.
-pub(crate) const EDWARDS_D2: FieldElement51 = FieldElement51([
+pub(crate) const EDWARDS_D2: FieldElement51 = FieldElement51::from_limbs([
     1859910466990425,
     932731440258426,
     1072319116312658,
@@ -50,7 +50,7 @@ pub(crate) const EDWARDS_D2: FieldElement51 = FieldElement51([
 ]);
 
 /// One minus edwards `d` value squared, equal to `(1 - (-121665/121666) mod p) pow 2`
-pub(crate) const ONE_MINUS_EDWARDS_D_SQUARED: FieldElement51 = FieldElement51([
+pub(crate) const ONE_MINUS_EDWARDS_D_SQUARED: FieldElement51 = FieldElement51::from_limbs([
     1136626929484150,
     1998550399581263,
     496427632559748,
@@ -59,7 +59,7 @@ pub(crate) const ONE_MINUS_EDWARDS_D_SQUARED: FieldElement51 = FieldElement51([
 ]);
 
 /// Edwards `d` value minus one squared, equal to `(((-121665/121666) mod p) - 1) pow 2`
-pub(crate) const EDWARDS_D_MINUS_ONE_SQUARED: FieldElement51 = FieldElement51([
+pub(crate) const EDWARDS_D_MINUS_ONE_SQUARED: FieldElement51 = FieldElement51::from_limbs([
     1507062230895904,
     1572317787530805,
     683053064812840,
@@ -68,7 +68,7 @@ pub(crate) const EDWARDS_D_MINUS_ONE_SQUARED: FieldElement51 = FieldElement51([
 ]);
 
 /// `= sqrt(a*d - 1)`, where `a = -1 (mod p)`, `d` are the Edwards curve parameters.
-pub(crate) const SQRT_AD_MINUS_ONE: FieldElement51 = FieldElement51([
+pub(crate) const SQRT_AD_MINUS_ONE: FieldElement51 = FieldElement51::from_limbs([
     2241493124984347,
     425987919032274,
     2207028919301688,
@@ -77,7 +77,7 @@ pub(crate) const SQRT_AD_MINUS_ONE: FieldElement51 = FieldElement51([
 ]);
 
 /// `= 1/sqrt(a-d)`, where `a = -1 (mod p)`, `d` are the Edwards curve parameters.
-pub(crate) const INVSQRT_A_MINUS_D: FieldElement51 = FieldElement51([
+pub(crate) const INVSQRT_A_MINUS_D: FieldElement51 = FieldElement51::from_limbs([
     278908739862762,
     821645201101625,
     8113234426968,
@@ -86,7 +86,7 @@ pub(crate) const INVSQRT_A_MINUS_D: FieldElement51 = FieldElement51([
 ]);
 
 /// Precomputed value of one of the square roots of -1 (mod p)
-pub(crate) const SQRT_M1: FieldElement51 = FieldElement51([
+pub(crate) const SQRT_M1: FieldElement51 = FieldElement51::from_limbs([
     1718705420411056,
     234908883556509,
     2233514472574048,
@@ -95,16 +95,17 @@ pub(crate) const SQRT_M1: FieldElement51 = FieldElement51([
 ]);
 
 /// `APLUS2_OVER_FOUR` is (A+2)/4. (This is used internally within the Montgomery ladder.)
-pub(crate) const APLUS2_OVER_FOUR: FieldElement51 = FieldElement51([121666, 0, 0, 0, 0]);
+pub(crate) const APLUS2_OVER_FOUR: FieldElement51 =
+    FieldElement51::from_limbs([121666, 0, 0, 0, 0]);
 
 /// `MONTGOMERY_A` is equal to 486662, which is a constant of the curve equation
 /// for Curve25519 in its Montgomery form. (This is used internally within the
 /// Elligator map.)
-pub(crate) const MONTGOMERY_A: FieldElement51 = FieldElement51([486662, 0, 0, 0, 0]);
+pub(crate) const MONTGOMERY_A: FieldElement51 = FieldElement51::from_limbs([486662, 0, 0, 0, 0]);
 
 /// `MONTGOMERY_A_NEG` is equal to -486662. (This is used internally within the
 /// Elligator map.)
-pub(crate) const MONTGOMERY_A_NEG: FieldElement51 = FieldElement51([
+pub(crate) const MONTGOMERY_A_NEG: FieldElement51 = FieldElement51::from_limbs([
     2251799813198567,
     2251799813685247,
     2251799813685247,
@@ -148,22 +149,22 @@ pub(crate) const RR: Scalar52 = Scalar52([
 /// `ED25519_BASEPOINT_TABLE`, which should be used for scalar
 /// multiplication (it's much faster).
 pub const ED25519_BASEPOINT_POINT: EdwardsPoint = EdwardsPoint {
-    X: FieldElement51([
+    X: FieldElement51::from_limbs([
         1738742601995546,
         1146398526822698,
         2070867633025821,
         562264141797630,
         587772402128613,
     ]),
-    Y: FieldElement51([
+    Y: FieldElement51::from_limbs([
         1801439850948184,
         1351079888211148,
         450359962737049,
         900719925474099,
         1801439850948198,
     ]),
-    Z: FieldElement51([1, 0, 0, 0, 0]),
-    T: FieldElement51([
+    Z: FieldElement51::from_limbs([1, 0, 0, 0, 0]),
+    T: FieldElement51::from_limbs([
         1841354044333475,
         16398895984059,
         755974180946558,
@@ -186,28 +187,28 @@ pub const EIGHT_TORSION: [EdwardsPoint; 8] = EIGHT_TORSION_INNER_DOC_HIDDEN;
 #[doc(hidden)]
 pub const EIGHT_TORSION_INNER_DOC_HIDDEN: [EdwardsPoint; 8] = [
     EdwardsPoint {
-        X: FieldElement51([0, 0, 0, 0, 0]),
-        Y: FieldElement51([1, 0, 0, 0, 0]),
-        Z: FieldElement51([1, 0, 0, 0, 0]),
-        T: FieldElement51([0, 0, 0, 0, 0]),
+        X: FieldElement51::from_limbs([0, 0, 0, 0, 0]),
+        Y: FieldElement51::from_limbs([1, 0, 0, 0, 0]),
+        Z: FieldElement51::from_limbs([1, 0, 0, 0, 0]),
+        T: FieldElement51::from_limbs([0, 0, 0, 0, 0]),
     },
     EdwardsPoint {
-        X: FieldElement51([
+        X: FieldElement51::from_limbs([
             358744748052810,
             1691584618240980,
             977650209285361,
             1429865912637724,
             560044844278676,
         ]),
-        Y: FieldElement51([
+        Y: FieldElement51::from_limbs([
             84926274344903,
             473620666599931,
             365590438845504,
             1028470286882429,
             2146499180330972,
         ]),
-        Z: FieldElement51([1, 0, 0, 0, 0]),
-        T: FieldElement51([
+        Z: FieldElement51::from_limbs([1, 0, 0, 0, 0]),
+        T: FieldElement51::from_limbs([
             1448326834587521,
             1857896831960481,
             1093722731865333,
@@ -216,34 +217,34 @@ pub const EIGHT_TORSION_INNER_DOC_HIDDEN: [EdwardsPoint; 8] = [
         ]),
     },
     EdwardsPoint {
-        X: FieldElement51([
+        X: FieldElement51::from_limbs([
             533094393274173,
             2016890930128738,
             18285341111199,
             134597186663265,
             1486323764102114,
         ]),
-        Y: FieldElement51([0, 0, 0, 0, 0]),
-        Z: FieldElement51([1, 0, 0, 0, 0]),
-        T: FieldElement51([0, 0, 0, 0, 0]),
+        Y: FieldElement51::from_limbs([0, 0, 0, 0, 0]),
+        Z: FieldElement51::from_limbs([1, 0, 0, 0, 0]),
+        T: FieldElement51::from_limbs([0, 0, 0, 0, 0]),
     },
     EdwardsPoint {
-        X: FieldElement51([
+        X: FieldElement51::from_limbs([
             358744748052810,
             1691584618240980,
             977650209285361,
             1429865912637724,
             560044844278676,
         ]),
-        Y: FieldElement51([
+        Y: FieldElement51::from_limbs([
             2166873539340326,
             1778179147085316,
             1886209374839743,
             1223329526802818,
             105300633354275,
         ]),
-        Z: FieldElement51([1, 0, 0, 0, 0]),
-        T: FieldElement51([
+        Z: FieldElement51::from_limbs([1, 0, 0, 0, 0]),
+        T: FieldElement51::from_limbs([
             803472979097708,
             393902981724766,
             1158077081819914,
@@ -252,34 +253,34 @@ pub const EIGHT_TORSION_INNER_DOC_HIDDEN: [EdwardsPoint; 8] = [
         ]),
     },
     EdwardsPoint {
-        X: FieldElement51([0, 0, 0, 0, 0]),
-        Y: FieldElement51([
+        X: FieldElement51::from_limbs([0, 0, 0, 0, 0]),
+        Y: FieldElement51::from_limbs([
             2251799813685228,
             2251799813685247,
             2251799813685247,
             2251799813685247,
             2251799813685247,
         ]),
-        Z: FieldElement51([1, 0, 0, 0, 0]),
-        T: FieldElement51([0, 0, 0, 0, 0]),
+        Z: FieldElement51::from_limbs([1, 0, 0, 0, 0]),
+        T: FieldElement51::from_limbs([0, 0, 0, 0, 0]),
     },
     EdwardsPoint {
-        X: FieldElement51([
+        X: FieldElement51::from_limbs([
             1893055065632419,
             560215195444267,
             1274149604399886,
             821933901047523,
             1691754969406571,
         ]),
-        Y: FieldElement51([
+        Y: FieldElement51::from_limbs([
             2166873539340326,
             1778179147085316,
             1886209374839743,
             1223329526802818,
             105300633354275,
         ]),
-        Z: FieldElement51([1, 0, 0, 0, 0]),
-        T: FieldElement51([
+        Z: FieldElement51::from_limbs([1, 0, 0, 0, 0]),
+        T: FieldElement51::from_limbs([
             1448326834587521,
             1857896831960481,
             1093722731865333,
@@ -288,34 +289,34 @@ pub const EIGHT_TORSION_INNER_DOC_HIDDEN: [EdwardsPoint; 8] = [
         ]),
     },
     EdwardsPoint {
-        X: FieldElement51([
+        X: FieldElement51::from_limbs([
             1718705420411056,
             234908883556509,
             2233514472574048,
             2117202627021982,
             765476049583133,
         ]),
-        Y: FieldElement51([0, 0, 0, 0, 0]),
-        Z: FieldElement51([1, 0, 0, 0, 0]),
-        T: FieldElement51([0, 0, 0, 0, 0]),
+        Y: FieldElement51::from_limbs([0, 0, 0, 0, 0]),
+        Z: FieldElement51::from_limbs([1, 0, 0, 0, 0]),
+        T: FieldElement51::from_limbs([0, 0, 0, 0, 0]),
     },
     EdwardsPoint {
-        X: FieldElement51([
+        X: FieldElement51::from_limbs([
             1893055065632419,
             560215195444267,
             1274149604399886,
             821933901047523,
             1691754969406571,
         ]),
-        Y: FieldElement51([
+        Y: FieldElement51::from_limbs([
             84926274344903,
             473620666599931,
             365590438845504,
             1028470286882429,
             2146499180330972,
         ]),
-        Z: FieldElement51([1, 0, 0, 0, 0]),
-        T: FieldElement51([
+        Z: FieldElement51::from_limbs([1, 0, 0, 0, 0]),
+        T: FieldElement51::from_limbs([
             803472979097708,
             393902981724766,
             1158077081819914,
@@ -336,21 +337,21 @@ pub static ED25519_BASEPOINT_TABLE: &EdwardsBasepointTable =
 static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = EdwardsBasepointTable([
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3540182452943730,
                 2497478415033846,
                 2521227595762870,
                 1462984067271729,
                 2389212253076811,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 62697248952638,
                 204681361388450,
                 631292143396476,
                 338455783676468,
                 1213667448819585,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 301289933810280,
                 1259582250014073,
                 1422107436869536,
@@ -359,21 +360,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3632771708514775,
                 790832306631235,
                 2067202295274102,
                 1995808275510000,
                 1566530869037010,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 463307831301544,
                 432984605774163,
                 1610641361907204,
                 750899048855000,
                 1894842303421586,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 748439484463711,
                 1033211726465151,
                 1396005112841647,
@@ -382,21 +383,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1601611775252272,
                 1720807796594148,
                 1132070835939856,
                 3512254832574799,
                 2147779492816910,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 316559037616741,
                 2177824224946892,
                 1459442586438991,
                 1461528397712656,
                 751590696113597,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1850748884277385,
                 1200145853858453,
                 1068094770532492,
@@ -405,21 +406,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 934282339813791,
                 1846903124198670,
                 1172395437954843,
                 1007037127761661,
                 1830588347719256,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1694390458783935,
                 1735906047636159,
                 705069562067493,
                 648033061693059,
                 696214010414170,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1121406372216585,
                 192876649532226,
                 190294192191717,
@@ -428,21 +429,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 769950342298400,
                 2384754244604994,
                 3095885746880802,
                 3225892188161580,
                 2977876099231263,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 425251763115706,
                 608463272472562,
                 442562545713235,
                 837766094556764,
                 374555092627893,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1086255230780037,
                 274979815921559,
                 1960002765731872,
@@ -451,21 +452,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1388594989461809,
                 316767091099457,
                 2646098655878230,
                 1230079486801004,
                 1440737038838979,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 7380825640100,
                 146210432690483,
                 304903576448906,
                 1198869323871120,
                 997689833219095,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1181317918772081,
                 114573476638901,
                 262805072233344,
@@ -474,21 +475,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2916800678241215,
                 2065379846933858,
                 2622030924071124,
                 2602788184473875,
                 1233371373142984,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 2019367628972465,
                 676711900706637,
                 110710997811333,
                 1108646842542025,
                 517791959672113,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 965130719900578,
                 247011430587952,
                 526356006571389,
@@ -497,21 +498,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 4320419353804412,
                 4218074731744053,
                 957728544705548,
                 729906502578991,
                 2411634706750414,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 2073601412052185,
                 31021124762708,
                 264500969797082,
                 248034690651703,
                 1030252227928288,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 551790716293402,
                 1989538725166328,
                 801169423371717,
@@ -522,21 +523,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1368953770187805,
                 3042147450398169,
                 2689308289352409,
                 2142576377050579,
                 1932081720066286,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 953638594433374,
                 1092333936795051,
                 1419774766716690,
                 805677984380077,
                 859228993502513,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1200766035879111,
                 20142053207432,
                 1465634435977050,
@@ -545,21 +546,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1735718747031538,
                 1248237894295956,
                 1204753118328107,
                 976066523550493,
                 2317743583219840,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1060098822528990,
                 1586825862073490,
                 212301317240126,
                 1975302711403555,
                 666724059764335,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1091990273418756,
                 1572899409348578,
                 80968014455247,
@@ -568,21 +569,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3732317023121341,
                 1511153322193951,
                 3496143672676420,
                 2556587964178488,
                 2620936670181690,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 2151330273626164,
                 762045184746182,
                 1688074332551515,
                 823046109005759,
                 907602769079491,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 2047386910586836,
                 168470092900250,
                 1552838872594810,
@@ -591,21 +592,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1982622644432037,
                 2014393600336956,
                 2380709022489462,
                 3869592437614438,
                 2357094095599062,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 980234343912898,
                 1712256739246056,
                 588935272190264,
                 204298813091998,
                 841798321043288,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 197561292938973,
                 454817274782871,
                 1963754960082318,
@@ -614,21 +615,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2416499262514576,
                 2254927265442919,
                 3451304785234000,
                 1766155447043651,
                 1899238924683527,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 732262946680281,
                 1674412764227063,
                 2182456405662809,
                 1350894754474250,
                 558458873295247,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 2103305098582922,
                 1960809151316468,
                 715134605001343,
@@ -637,21 +638,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1239289043050193,
                 1744654158124578,
                 758702410031698,
                 4048562808759936,
                 2253402870349013,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 2232056027107988,
                 987343914584615,
                 2115594492994461,
                 1819598072792159,
                 1119305654014850,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 320153677847348,
                 939613871605645,
                 641883205761567,
@@ -660,21 +661,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3232730304159378,
                 1242488692177892,
                 1251446316964684,
                 1086618677993530,
                 1961430968465772,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 276821765317453,
                 1536835591188030,
                 1305212741412361,
                 61473904210175,
                 2051377036983058,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 833449923882501,
                 1750270368490475,
                 1123347002068295,
@@ -683,21 +684,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 794524995833413,
                 1849907304548286,
                 2305148486158393,
                 1272368559505216,
                 1147304168324779,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1504846112759364,
                 1203096289004681,
                 562139421471418,
                 274333017451844,
                 1284344053775441,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 483048732424432,
                 2116063063343382,
                 30120189902313,
@@ -708,21 +709,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3180171966714267,
                 2147692869914563,
                 1455665844462196,
                 1986737809425946,
                 2437006863943337,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 137732961814206,
                 706670923917341,
                 1387038086865771,
                 1965643813686352,
                 1384777115696347,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 481144981981577,
                 2053319313589856,
                 2065402289827512,
@@ -731,21 +732,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2948097833334040,
                 3145099472726142,
                 1148636718636008,
                 2278533891034865,
                 2203955659340680,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 657390353372855,
                 998499966885562,
                 991893336905797,
                 810470207106761,
                 343139804608786,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 791736669492960,
                 934767652997115,
                 824656780392914,
@@ -754,21 +755,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2022541353055578,
                 4346500076272714,
                 3802807888710933,
                 2494585331103411,
                 2947785218648809,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1287487199965223,
                 2215311941380308,
                 1552928390931986,
                 1664859529680196,
                 1125004975265243,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 677434665154918,
                 989582503122485,
                 1817429540898386,
@@ -777,21 +778,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2619066141993637,
                 2570231002607651,
                 2947429167440602,
                 2885885471266079,
                 2276381426249673,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 773360688841258,
                 1815381330538070,
                 363773437667376,
                 539629987070205,
                 783280434248437,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 180820816194166,
                 168937968377394,
                 748416242794470,
@@ -800,21 +801,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2730575372268893,
                 2062896624554806,
                 2951191072970647,
                 2609899222113120,
                 1277310261461760,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1984740906540026,
                 1079164179400229,
                 1056021349262661,
                 1659958556483663,
                 1088529069025527,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 580736401511151,
                 1842931091388998,
                 1177201471228238,
@@ -823,21 +824,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1515728832059163,
                 1575261009617579,
                 1510246567196186,
                 2442877836294952,
                 2368461529974388,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1295295738269652,
                 1714742313707026,
                 545583042462581,
                 2034411676262552,
                 1513248090013606,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 230710545179830,
                 30821514358353,
                 760704303452229,
@@ -846,21 +847,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3421179921230875,
                 2514967047430861,
                 4274701112739695,
                 3071700566936367,
                 4275698278559832,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 2102254323485823,
                 1570832666216754,
                 34696906544624,
                 1993213739807337,
                 70638552271463,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 894132856735058,
                 548675863558441,
                 845349339503395,
@@ -869,21 +870,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3539470031223082,
                 1222355136884919,
                 1846481788678694,
                 1150426571265110,
                 1613523400722047,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 793388516527298,
                 1315457083650035,
                 1972286999342417,
                 1901825953052455,
                 338269477222410,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 550201530671806,
                 778605267108140,
                 2063911101902983,
@@ -894,21 +895,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 717255318455100,
                 519313764361315,
                 2080406977303708,
                 541981206705521,
                 774328150311600,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 261715221532238,
                 1795354330069993,
                 1496878026850283,
                 499739720521052,
                 389031152673770,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1997217696294013,
                 1717306351628065,
                 1684313917746180,
@@ -917,21 +918,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3727234538477877,
                 2328731709971226,
                 3368528843456914,
                 2002544139318041,
                 2977347647489186,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 2022306639183567,
                 726296063571875,
                 315345054448644,
                 1058733329149221,
                 1448201136060677,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1710065158525665,
                 1895094923036397,
                 123988286168546,
@@ -940,21 +941,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2813405189107769,
                 1071733543815036,
                 2383296312486238,
                 1946868434569998,
                 3079937947649451,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1548495173745801,
                 442310529226540,
                 998072547000384,
                 553054358385281,
                 644824326376171,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1445526537029440,
                 2225519789662536,
                 914628859347385,
@@ -963,21 +964,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3451490036797185,
                 2275827949507588,
                 2318438102929588,
                 2309425969971222,
                 2816893781664854,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 876926774220824,
                 554618976488214,
                 1012056309841565,
                 839961821554611,
                 1414499340307677,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 703047626104145,
                 1266841406201770,
                 165556500219173,
@@ -986,21 +987,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1622861044480487,
                 1156394801573634,
                 4120932379100752,
                 2578903799462977,
                 2095342781472283,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 334886927423922,
                 489511099221528,
                 129160865966726,
                 1720809113143481,
                 619700195649254,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1646545795166119,
                 1758370782583567,
                 714746174550637,
@@ -1009,21 +1010,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2585203586724508,
                 2547572356138185,
                 1693106465353609,
                 912330357530760,
                 2723035471635610,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1811196219982022,
                 1068969825533602,
                 289602974833439,
                 1988956043611592,
                 863562343398367,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 906282429780072,
                 2108672665779781,
                 432396390473936,
@@ -1032,21 +1033,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 925664675702309,
                 2273216662253932,
                 4083236455546587,
                 601157008940112,
                 2623617868729744,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1479786007267725,
                 1738881859066675,
                 68646196476567,
                 2146507056100328,
                 1247662817535471,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 52035296774456,
                 939969390708103,
                 312023458773250,
@@ -1055,21 +1056,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2895154920100990,
                 2541986621181021,
                 2013561737429022,
                 2571447883196794,
                 2645536492181409,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 129358342392716,
                 1932811617704777,
                 1176749390799681,
                 398040349861790,
                 1170779668090425,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 2051980782668029,
                 121859921510665,
                 2048329875753063,
@@ -1080,21 +1081,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3859970785658325,
                 2667608874045675,
                 1350468408164765,
                 2038620059057678,
                 3278704299674360,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1837656083115103,
                 1510134048812070,
                 906263674192061,
                 1821064197805734,
                 565375124676301,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 578027192365650,
                 2034800251375322,
                 2128954087207123,
@@ -1103,21 +1104,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1633188840273120,
                 3104586986058956,
                 1548762607215795,
                 1266275218902681,
                 3359018017010381,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 462189358480054,
                 1784816734159228,
                 1611334301651368,
                 1303938263943540,
                 707589560319424,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1038829280972848,
                 38176604650029,
                 753193246598573,
@@ -1126,21 +1127,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3660251634545082,
                 2194984964010832,
                 2198361797561729,
                 1061962440055713,
                 1645147963442934,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 4701053362120,
                 1647641066302348,
                 1047553002242085,
                 1923635013395977,
                 206970314902065,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1750479161778571,
                 1362553355169293,
                 1891721260220598,
@@ -1149,21 +1150,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2464498862816952,
                 1117950018299774,
                 1873945661751056,
                 3655602735669306,
                 2382695896337945,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 636808533673210,
                 1262201711667560,
                 390951380330599,
                 1663420692697294,
                 561951321757406,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 520731594438141,
                 1446301499955692,
                 273753264629267,
@@ -1172,21 +1173,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3178327305714638,
                 3443653291096626,
                 734233225181170,
                 2435838701226518,
                 4042225960010590,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1464651961852572,
                 1483737295721717,
                 1519450561335517,
                 1161429831763785,
                 405914998179977,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 996126634382301,
                 796204125879525,
                 127517800546509,
@@ -1195,21 +1196,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2990523894660505,
                 2188666632415295,
                 1961313708559162,
                 1506545807547587,
                 3403101452654988,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 622917337413835,
                 1218989177089035,
                 1284857712846592,
                 970502061709359,
                 351025208117090,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 2067814584765580,
                 1677855129927492,
                 2086109782475197,
@@ -1218,21 +1219,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2838644076315587,
                 2559244195637442,
                 458399356043425,
                 2853867838192310,
                 3280348017100490,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 678489922928203,
                 2016657584724032,
                 90977383049628,
                 1026831907234582,
                 615271492942522,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 301225714012278,
                 1094837270268560,
                 1202288391010439,
@@ -1241,21 +1242,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1210746697896459,
                 1416608304244708,
                 2938287290903104,
                 3496931005119382,
                 3303038150540984,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1135604073198207,
                 1683322080485474,
                 769147804376683,
                 2086688130589414,
                 900445683120379,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1971518477615628,
                 401909519527336,
                 448627091057375,
@@ -1266,21 +1267,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1364039144731711,
                 1897497433586190,
                 2203097701135459,
                 2397261210496499,
                 1349844460790698,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1045230323257973,
                 818206601145807,
                 630513189076103,
                 1672046528998132,
                 807204017562437,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 439961968385997,
                 386362664488986,
                 1382706320807688,
@@ -1289,21 +1290,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3480804500082836,
                 3172443782216110,
                 2375775707596425,
                 2933223806901024,
                 1400559197080972,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 2003766096898049,
                 170074059235165,
                 1141124258967971,
                 1485419893480973,
                 1573762821028725,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 729905708611432,
                 1270323270673202,
                 123353058984288,
@@ -1312,21 +1313,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1271140255321216,
                 2044363183174497,
                 2303925201319937,
                 3696920060379952,
                 3194341800024331,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1761608437466135,
                 583360847526804,
                 1586706389685493,
                 2157056599579261,
                 1170692369685772,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 871476219910823,
                 1878769545097794,
                 2241832391238412,
@@ -1335,21 +1336,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2548994545820755,
                 1366347803776819,
                 3552985325930849,
                 561849853336293,
                 1533554921345731,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 999628998628371,
                 1132836708493400,
                 2084741674517453,
                 469343353015612,
                 678782988708035,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 2189427607417022,
                 699801937082607,
                 412764402319267,
@@ -1358,21 +1359,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3964091869651792,
                 2456213404310121,
                 3657538451018088,
                 2660781114515010,
                 3112882032961968,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 508561155940631,
                 966928475686665,
                 2236717801150132,
                 424543858577297,
                 2089272956986143,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 221245220129925,
                 1156020201681217,
                 491145634799213,
@@ -1381,21 +1382,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2405556784925632,
                 1299874139923976,
                 2644898978945750,
                 1058234455773021,
                 996989038681183,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 559086812798481,
                 573177704212711,
                 1629737083816402,
                 1399819713462595,
                 1646954378266038,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1887963056288059,
                 228507035730124,
                 1468368348640282,
@@ -1404,21 +1405,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1224529808187534,
                 1577022856702685,
                 2206946542980843,
                 625883007765001,
                 2531730607197406,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1076287717051609,
                 1114455570543035,
                 187297059715481,
                 250446884292121,
                 1885187512550540,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 902497362940219,
                 76749815795675,
                 1657927525633846,
@@ -1427,21 +1428,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1129576631190765,
                 3533793823712575,
                 996844254743017,
                 2509676177174497,
                 3402650555740265,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 628740660038789,
                 1943038498527841,
                 467786347793886,
                 1093341428303375,
                 235413859513003,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 237425418909360,
                 469614029179605,
                 1512389769174935,
@@ -1452,21 +1453,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3988217766743784,
                 726531315520507,
                 1833335034432527,
                 1629442561574747,
                 2876218732971333,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1960754663920689,
                 497040957888962,
                 1909832851283095,
                 1271432136996826,
                 2219780368020940,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1537037379417136,
                 1358865369268262,
                 2130838645654099,
@@ -1475,21 +1476,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 629042105241795,
                 1098854999137608,
                 887281544569320,
                 3674901833560025,
                 2259711072636808,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1811562332665373,
                 1501882019007673,
                 2213763501088999,
                 359573079719636,
                 36370565049116,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 218907117361280,
                 1209298913016966,
                 1944312619096112,
@@ -1498,21 +1499,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1369976867854685,
                 1396479602419169,
                 4017456468084104,
                 2203659200586298,
                 3250127649802489,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 2230701885562825,
                 1348173180338974,
                 2172856128624598,
                 1426538746123771,
                 444193481326151,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 784210426627951,
                 918204562375674,
                 1284546780452985,
@@ -1521,21 +1522,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2571438643225542,
                 2848082470493653,
                 2037902696412607,
                 1557219121643918,
                 341938082688094,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1901860206695915,
                 2004489122065736,
                 1625847061568236,
                 973529743399879,
                 2075287685312905,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1371853944110545,
                 1042332820512553,
                 1949855697918254,
@@ -1544,21 +1545,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 687200189577836,
                 1082536651125675,
                 2896024754556794,
                 2592723009743198,
                 2595381160432643,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 2082717129583892,
                 27829425539422,
                 145655066671970,
                 1690527209845512,
                 1865260509673478,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1059729620568824,
                 2163709103470266,
                 1440302280256872,
@@ -1567,21 +1568,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3861316033464273,
                 777277757338816,
                 2101121130363987,
                 550762194946473,
                 1905542338659364,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 2024821921041576,
                 426948675450149,
                 595133284085473,
                 471860860885970,
                 600321679413000,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 598474602406721,
                 1468128276358244,
                 1191923149557635,
@@ -1590,21 +1591,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1721138489890688,
                 1264336102277790,
                 2684864359106535,
                 1359988423149465,
                 3813671107094695,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 719520245587143,
                 393380711632345,
                 132350400863381,
                 1543271270810729,
                 1819543295798660,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 396397949784152,
                 1811354474471839,
                 1362679985304303,
@@ -1613,21 +1614,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1812471844975748,
                 1856491995543149,
                 126579494584102,
                 3288044672967868,
                 1975108050082549,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 650623932407995,
                 1137551288410575,
                 2125223403615539,
                 1725658013221271,
                 2134892965117796,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 522584000310195,
                 1241762481390450,
                 1743702789495384,
@@ -1638,21 +1639,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 427904865186293,
                 1703211129693455,
                 1585368107547509,
                 3688784302429584,
                 3012988348299225,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 318101947455002,
                 248138407995851,
                 1481904195303927,
                 309278454311197,
                 1258516760217879,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1275068538599310,
                 513726919533379,
                 349926553492294,
@@ -1661,21 +1662,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3313663849950481,
                 3213411074010628,
                 2573659446386085,
                 3297400443644764,
                 1985130202504037,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1558816436882417,
                 1962896332636523,
                 1337709822062152,
                 1501413830776938,
                 294436165831932,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 818359826554971,
                 1862173000996177,
                 626821592884859,
@@ -1684,21 +1685,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1988022651432119,
                 3333911312271288,
                 1834020786104820,
                 3706626690108935,
                 692929915223121,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 2146513703733331,
                 584788900394667,
                 464965657279958,
                 2183973639356127,
                 238371159456790,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1129007025494441,
                 2197883144413266,
                 265142755578169,
@@ -1707,21 +1708,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1291366624493056,
                 2633256531874362,
                 1711482489312443,
                 1815233647702022,
                 3144079596677715,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 444548969917454,
                 1452286453853356,
                 2113731441506810,
                 645188273895859,
                 810317625309512,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 2242724082797924,
                 1373354730327868,
                 1006520110883049,
@@ -1730,21 +1731,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3997520014069025,
                 4163522956860564,
                 2056329390702073,
                 2607026987995097,
                 3131032608056347,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 163723479936298,
                 115424889803150,
                 1156016391581227,
                 1894942220753364,
                 1970549419986329,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 681981452362484,
                 267208874112496,
                 1374683991933094,
@@ -1753,21 +1754,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2265178468539480,
                 2358037120714814,
                 1944412051589650,
                 4093776581610705,
                 2482502633520820,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 260683893467075,
                 854060306077237,
                 913639551980112,
                 4704576840123,
                 280254810808712,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 715374893080287,
                 1173334812210491,
                 1806524662079626,
@@ -1776,21 +1777,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2751826223412909,
                 3848231101880618,
                 1420380351989369,
                 3237011375206737,
                 392444930785632,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 2096421546958141,
                 1922523000950363,
                 789831022876840,
                 427295144688779,
                 320923973161730,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1927770723575450,
                 1485792977512719,
                 1850996108474547,
@@ -1799,21 +1800,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2112099158080129,
                 2994370617594963,
                 2258284371762679,
                 1951119898618915,
                 2344890196388664,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 383905201636970,
                 859946997631870,
                 855623867637644,
                 1017125780577795,
                 794250831877809,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 77571826285752,
                 999304298101753,
                 487841111777762,
@@ -1824,21 +1825,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2926794589205781,
                 2517835660016036,
                 826951213393477,
                 1405007746162285,
                 1781791018620876,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1001412661522686,
                 348196197067298,
                 1666614366723946,
                 888424995032760,
                 580747687801357,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1939560076207777,
                 1409892634407635,
                 552574736069277,
@@ -1847,21 +1848,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2177087163428741,
                 1439255351721944,
                 3459870654068041,
                 2230616362004768,
                 1396886392021913,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 676962063230039,
                 1880275537148808,
                 2046721011602706,
                 888463247083003,
                 1318301552024067,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1466980508178206,
                 617045217998949,
                 652303580573628,
@@ -1870,21 +1871,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3762856566592150,
                 2357202940576524,
                 2745234706458093,
                 1091943425335975,
                 1802717338077427,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1853982405405128,
                 1878664056251147,
                 1528011020803992,
                 1019626468153565,
                 1128438412189035,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1963939888391106,
                 293456433791664,
                 697897559513649,
@@ -1893,21 +1894,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2668570812315008,
                 2641455366112301,
                 1314476859406755,
                 1749382513022778,
                 3413705412424739,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1428358296490651,
                 1027115282420478,
                 304840698058337,
                 441410174026628,
                 1819358356278573,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 204943430200135,
                 1554861433819175,
                 216426658514651,
@@ -1916,21 +1917,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1934415182909015,
                 1393285083565062,
                 2768209145458208,
                 3409490548679139,
                 2372839480279515,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 662035583584445,
                 286736105093098,
                 1131773000510616,
                 818494214211439,
                 472943792054479,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 665784778135882,
                 1893179629898606,
                 808313193813106,
@@ -1939,21 +1940,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 945205108984213,
                 2778077376644543,
                 1324180513733565,
                 1666970227868664,
                 2405347422974421,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 2031433403516252,
                 203996615228162,
                 170487168837083,
                 981513604791390,
                 843573964916831,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1476570093962618,
                 838514669399805,
                 1857930577281364,
@@ -1962,21 +1963,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1461557121912823,
                 1600674043318359,
                 2157134900399597,
                 1670641601940616,
                 2379565397488531,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1293543509393474,
                 2143624609202546,
                 1058361566797508,
                 214097127393994,
                 946888515472729,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 357067959932916,
                 1290876214345711,
                 521245575443703,
@@ -1985,21 +1986,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2817916472785262,
                 820247422481739,
                 994464017954148,
                 2578957425371613,
                 2344391131796991,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 617256647603209,
                 1652107761099439,
                 1857213046645471,
                 1085597175214970,
                 817432759830522,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 771808161440705,
                 1323510426395069,
                 680497615846440,
@@ -2010,21 +2011,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1219260086131896,
                 2898968820282063,
                 2331400938444953,
                 2161724213426747,
                 2656661710745446,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1327968293887866,
                 1335500852943256,
                 1401587164534264,
                 558137311952440,
                 1551360549268902,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 417621685193956,
                 1429953819744454,
                 396157358457099,
@@ -2033,21 +2034,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1268047918491954,
                 2172375426948536,
                 1533916099229249,
                 1761293575457130,
                 3842422480712013,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1627072914981959,
                 2211603081280073,
                 1912369601616504,
                 1191770436221309,
                 2187309757525860,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1149147819689533,
                 378692712667677,
                 828475842424202,
@@ -2056,21 +2057,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3551539230764990,
                 3690416477138006,
                 3788528892189659,
                 2053896748919837,
                 3260220846276494,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 2040723824657366,
                 399555637875075,
                 632543375452995,
                 872649937008051,
                 1235394727030233,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 2211311599327900,
                 2139787259888175,
                 938706616835350,
@@ -2079,21 +2080,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1324994503390431,
                 2588782144267879,
                 1183998925654176,
                 3343454479598522,
                 2300527487656566,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1845522914617879,
                 1222198248335542,
                 150841072760134,
                 1927029069940982,
                 1189913404498011,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1079559557592645,
                 2215338383666441,
                 1903569501302605,
@@ -2102,21 +2103,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2346453219102138,
                 3637921163538246,
                 3313930291577009,
                 2288353761164521,
                 3085469462634093,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1432015813136298,
                 440364795295369,
                 1395647062821501,
                 1976874522764578,
                 934452372723352,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1296625309219774,
                 2068273464883862,
                 1858621048097805,
@@ -2125,21 +2126,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1490330266465551,
                 1858795661361448,
                 3688040948655011,
                 2546373032584894,
                 3459939824714180,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1282462923712748,
                 741885683986255,
                 2027754642827561,
                 518989529541027,
                 1826610009555945,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1525827120027511,
                 723686461809551,
                 1597702369236987,
@@ -2148,21 +2149,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2365421849929742,
                 3485539881431101,
                 2925909765963743,
                 2114345180342964,
                 2418564326541511,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 2041668749310338,
                 2184405322203901,
                 1633400637611036,
                 2110682505536899,
                 2048144390084644,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 503058759232932,
                 760293024620937,
                 2027152777219493,
@@ -2171,21 +2172,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1916168475367211,
                 3167426246226591,
                 883217071712574,
                 363427871374304,
                 1976029821251593,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 678039535434506,
                 570587290189340,
                 1605302676614120,
                 2147762562875701,
                 1706063797091704,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1439489648586438,
                 2194580753290951,
                 832380563557396,
@@ -2196,21 +2197,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2439789269177838,
                 681223515948274,
                 1933493571072456,
                 1872921007304880,
                 2739962177820919,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1413466089534451,
                 410844090765630,
                 1397263346404072,
                 408227143123410,
                 1594561803147811,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 2102170800973153,
                 719462588665004,
                 1479649438510153,
@@ -2219,21 +2220,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3193865531532443,
                 3321113493038208,
                 2007341951411050,
                 2322773230131539,
                 1419433790163705,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1146565545556377,
                 1661971299445212,
                 406681704748893,
                 564452436406089,
                 1109109865829139,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 2214421081775077,
                 1165671861210569,
                 1890453018796184,
@@ -2242,21 +2243,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3005630360306059,
                 1666955059895018,
                 1530775289309243,
                 3371786842789394,
                 2164156153857579,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 615171919212796,
                 1523849404854568,
                 854560460547503,
                 2067097370290715,
                 1765325848586042,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1094538949313667,
                 1796592198908825,
                 870221004284388,
@@ -2265,21 +2266,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1951351290725195,
                 1916457206844795,
                 2449824998123274,
                 1909076887557594,
                 1938542290318919,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1014323197538413,
                 869150639940606,
                 1756009942696599,
                 1334952557375672,
                 1544945379082874,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 764055910920305,
                 1603590757375439,
                 146805246592357,
@@ -2288,21 +2289,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 80113526615731,
                 764536758732259,
                 3306939158785481,
                 2721052465444637,
                 2869697326116762,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 74497112547268,
                 740094153192149,
                 1745254631717581,
                 727713886503130,
                 1283034364416928,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 525892105991110,
                 1723776830270342,
                 1476444848991936,
@@ -2311,21 +2312,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2794411533877810,
                 1986812262899320,
                 1162535242465837,
                 2733298779828712,
                 2796400347268869,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 64123227344372,
                 1239927720647794,
                 1360722983445904,
                 222610813654661,
                 62429487187991,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1793193323953132,
                 91096687857833,
                 70945970938921,
@@ -2334,21 +2335,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1895854577604590,
                 3646695522634664,
                 1728548428495943,
                 3392664713925397,
                 2815445147288308,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 141358280486863,
                 91435889572504,
                 1087208572552643,
                 1829599652522921,
                 1193307020643647,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1611230858525381,
                 950720175540785,
                 499589887488610,
@@ -2357,21 +2358,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3440880315164906,
                 2184348804772596,
                 3292618539427567,
                 2018318290311833,
                 1712060030915354,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 873966876953756,
                 1090638350350440,
                 1708559325189137,
                 672344594801910,
                 1320437969700239,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1508590048271766,
                 1131769479776094,
                 101550868699323,
@@ -2382,21 +2383,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3008217384184691,
                 2489682092917849,
                 2136263418594015,
                 1701968045454886,
                 2955512998822720,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1781187809325462,
                 1697624151492346,
                 1381393690939988,
                 175194132284669,
                 1483054666415238,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 2175517777364616,
                 708781536456029,
                 955668231122942,
@@ -2405,21 +2406,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3366935780292116,
                 2476017186636029,
                 915967306279221,
                 593866251291540,
                 2813546907893254,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1443163092879439,
                 391875531646162,
                 2180847134654632,
                 464538543018753,
                 1594098196837178,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 850858855888869,
                 319436476624586,
                 327807784938441,
@@ -2428,21 +2429,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2132756334090048,
                 2788047633840893,
                 2300706964962114,
                 2860273011285942,
                 3513489358708031,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1525176236978354,
                 974205476721062,
                 293436255662638,
                 148269621098039,
                 137961998433963,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1121075518299410,
                 2071745529082111,
                 1265567917414828,
@@ -2451,21 +2452,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2374121042985030,
                 3274721891178932,
                 2001275453369483,
                 2017441881607947,
                 3245005694463250,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 654925550560074,
                 1168810995576858,
                 575655959430926,
                 905758704861388,
                 496774564663534,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1954109525779738,
                 2117022646152485,
                 338102630417180,
@@ -2474,21 +2475,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1714785840001267,
                 4288299832366837,
                 1876380234251965,
                 2056717182974196,
                 1645855254384642,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 106431476499341,
                 62482972120563,
                 1513446655109411,
                 807258751769522,
                 538491469114,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 2002850762893643,
                 1243624520538135,
                 1486040410574605,
@@ -2497,21 +2498,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 922510868424903,
                 1089502620807680,
                 402544072617374,
                 1131446598479839,
                 1290278588136533,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1867998812076769,
                 715425053580701,
                 39968586461416,
                 2173068014586163,
                 653822651801304,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 162892278589453,
                 182585796682149,
                 75093073137630,
@@ -2520,21 +2521,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 4166396390264918,
                 1608999621851577,
                 1987629837704609,
                 1519655314857977,
                 1819193753409464,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1949315551096831,
                 1069003344994464,
                 1939165033499916,
                 1548227205730856,
                 1933767655861407,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1730519386931635,
                 1393284965610134,
                 1597143735726030,
@@ -2543,21 +2544,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 360275475604546,
                 2799635544748326,
                 2467160717872776,
                 2848446553564254,
                 2584509464110332,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 47602113726801,
                 1522314509708010,
                 437706261372925,
                 814035330438027,
                 335930650933545,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1291597595523886,
                 1058020588994081,
                 402837842324045,
@@ -2568,21 +2569,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2361321796251793,
                 3967057562270386,
                 1112231216891515,
                 2046641005101484,
                 2386048970842261,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 2156991030936798,
                 2227544497153325,
                 1869050094431622,
                 754875860479115,
                 1754242344267058,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1846089562873800,
                 98894784984326,
                 1412430299204844,
@@ -2591,21 +2592,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2335972195815721,
                 2751510784385293,
                 425749630620777,
                 1762872794206857,
                 2864642415813208,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 868309334532756,
                 1703010512741873,
                 1952690008738057,
                 4325269926064,
                 2071083554962116,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 523094549451158,
                 401938899487815,
                 1407690589076010,
@@ -2614,21 +2615,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 612867287630009,
                 2700012425789062,
                 2823428891104443,
                 1466796750919375,
                 1728478129663858,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1723848973783452,
                 2208822520534681,
                 1718748322776940,
                 1974268454121942,
                 1194212502258141,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1254114807944608,
                 977770684047110,
                 2010756238954993,
@@ -2637,21 +2638,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2484263871921055,
                 1948628555342433,
                 1835348780427694,
                 1031609499437291,
                 2316271920603621,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 767338676040683,
                 754089548318405,
                 1523192045639075,
                 435746025122062,
                 512692508440385,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1255955808701983,
                 1700487367990941,
                 1166401238800299,
@@ -2660,21 +2661,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2600943821853521,
                 1337012557669161,
                 1475912332999108,
                 3573418268585706,
                 2299411105589567,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 877519947135419,
                 2172838026132651,
                 272304391224129,
                 1655143327559984,
                 886229406429814,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 375806028254706,
                 214463229793940,
                 572906353144089,
@@ -2683,21 +2684,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1168827102357825,
                 823864273033637,
                 4323338565789945,
                 788062026895923,
                 2851378154428610,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1948116082078088,
                 2054898304487796,
                 2204939184983900,
                 210526805152138,
                 786593586607626,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1915320147894736,
                 156481169009469,
                 655050471180417,
@@ -2706,21 +2707,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1726336468579724,
                 1119932070398949,
                 1929199510967666,
                 2285718602008207,
                 1836837863503149,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 829996854845988,
                 217061778005138,
                 1686565909803640,
                 1346948817219846,
                 1723823550730181,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 384301494966394,
                 687038900403062,
                 2211195391021739,
@@ -2729,21 +2730,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1247567493562669,
                 4229981908141095,
                 2435671288478202,
                 806570235643434,
                 2540261331753164,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1449077384734201,
                 38285445457996,
                 2136537659177832,
                 2146493000841573,
                 725161151123125,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1201928866368855,
                 800415690605445,
                 1703146756828343,
@@ -2754,21 +2755,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2608268623334125,
                 3034173730618399,
                 1718002439402869,
                 3644022065904502,
                 663171266061950,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 759628738230460,
                 1012693474275852,
                 353780233086498,
                 246080061387552,
                 2030378857679162,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 2040672435071076,
                 888593182036908,
                 1298443657189359,
@@ -2777,21 +2778,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1894938527423184,
                 3715012855162525,
                 2726210319182898,
                 2499094776718546,
                 877975941029127,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 207937160991127,
                 12966911039119,
                 820997788283092,
                 1010440472205286,
                 1701372890140810,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 218882774543183,
                 533427444716285,
                 1233243976733245,
@@ -2800,21 +2801,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 4140638349397055,
                 3303977572025869,
                 3465353617009382,
                 2420981822812579,
                 2715174081801119,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 299137589460312,
                 1594371588983567,
                 868058494039073,
                 257771590636681,
                 1805012993142921,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1806842755664364,
                 2098896946025095,
                 1356630998422878,
@@ -2823,21 +2824,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1402334161391744,
                 3811883484731547,
                 1008585416617746,
                 1147797150908892,
                 1420416683642459,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 665506704253369,
                 273770475169863,
                 799236974202630,
                 848328990077558,
                 1811448782807931,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1468412523962641,
                 771866649897997,
                 1931766110147832,
@@ -2846,21 +2847,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2223212657821831,
                 2882216061048914,
                 2144451165500327,
                 3068710944633039,
                 3276150872095279,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1266603897524861,
                 156378408858100,
                 1275649024228779,
                 447738405888420,
                 253186462063095,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 2022215964509735,
                 136144366993649,
                 1800716593296582,
@@ -2869,21 +2870,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1862751661970309,
                 851596246739884,
                 1519315554814041,
                 3794598280232697,
                 3669775149586767,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1228168094547481,
                 334133883362894,
                 587567568420081,
                 433612590281181,
                 603390400373205,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 121893973206505,
                 1843345804916664,
                 1703118377384911,
@@ -2892,21 +2893,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2710146069631716,
                 2542709749304591,
                 1452768413850678,
                 2802722688939463,
                 1537286854336537,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 584322311184395,
                 380661238802118,
                 114839394528060,
                 655082270500073,
                 2111856026034852,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 996965581008991,
                 2148998626477022,
                 1012273164934654,
@@ -2915,21 +2916,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3175286832534829,
                 2085106799623354,
                 2779882615305384,
                 1606206360876187,
                 2987706905397772,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1697697887804317,
                 1335343703828273,
                 831288615207040,
                 949416685250051,
                 288760277392022,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1419122478109648,
                 1325574567803701,
                 602393874111094,
@@ -2940,21 +2941,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2201150872731785,
                 2180241023425241,
                 2349463270108411,
                 1633405770247823,
                 3100744856129234,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1173339555550611,
                 818605084277583,
                 47521504364289,
                 924108720564965,
                 735423405754506,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 830104860549448,
                 1886653193241086,
                 1600929509383773,
@@ -2963,21 +2964,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3828911108518224,
                 3282698983453994,
                 2396700729978777,
                 4216472406664814,
                 2820189914640497,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 278388655910247,
                 487143369099838,
                 927762205508727,
                 181017540174210,
                 1616886700741287,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1191033906638969,
                 940823957346562,
                 1606870843663445,
@@ -2986,21 +2987,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1875032594195527,
                 1427106132796197,
                 2976536204647406,
                 3153660325729987,
                 2887068310954007,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 622869792298357,
                 1903919278950367,
                 1922588621661629,
                 1520574711600434,
                 1087100760174640,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 25465949416618,
                 1693639527318811,
                 1526153382657203,
@@ -3009,21 +3010,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2466539671654587,
                 920212862967914,
                 4191701364657517,
                 3463662605460468,
                 2336897329405367,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 2006245852772938,
                 734762734836159,
                 254642929763427,
                 1406213292755966,
                 239303749517686,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1619678837192149,
                 1919424032779215,
                 1357391272956794,
@@ -3032,21 +3033,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3292563523447371,
                 1704449869235351,
                 2857062884141577,
                 1998838089036354,
                 1312142911487502,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1996723311435669,
                 1844342766567060,
                 985455700466044,
                 1165924681400960,
                 311508689870129,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 43173156290518,
                 2202883069785309,
                 1137787467085917,
@@ -3055,21 +3056,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 670078326344559,
                 2807454838744604,
                 2723759199967685,
                 2141455487356408,
                 849015953823125,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 2197214573372804,
                 794254097241315,
                 1030190060513737,
                 267632515541902,
                 2040478049202624,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1812516004670529,
                 1609256702920783,
                 1706897079364493,
@@ -3078,21 +3079,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1540374301420565,
                 1764656898914615,
                 1810104162020396,
                 3175608592848336,
                 2916189887881826,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1323460699404750,
                 1262690757880991,
                 871777133477900,
                 1060078894988977,
                 1712236889662886,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1696163952057966,
                 1391710137550823,
                 608793846867416,
@@ -3101,21 +3102,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1367603834210822,
                 4383788460268472,
                 890353773628143,
                 1908908219165595,
                 2522636708938139,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 597536315471731,
                 40375058742586,
                 1942256403956049,
                 1185484645495932,
                 312666282024145,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1919411405316294,
                 1234508526402192,
                 1066863051997083,
@@ -3126,21 +3127,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2102881477513865,
                 3822074379630609,
                 1573617900503707,
                 2270462449417831,
                 2232324307922097,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1853931367696942,
                 8107973870707,
                 350214504129299,
                 775206934582587,
                 1752317649166792,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1417148368003523,
                 721357181628282,
                 505725498207811,
@@ -3149,21 +3150,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2186733281493248,
                 2250694917008620,
                 1014829812957440,
                 2731797975137637,
                 2335366007561721,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1268116367301224,
                 560157088142809,
                 802626839600444,
                 2210189936605713,
                 1129993785579988,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 615183387352312,
                 917611676109240,
                 878893615973325,
@@ -3172,21 +3173,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 522024729211672,
                 3296859129001056,
                 1892245413707789,
                 1907891107684253,
                 2059998109500714,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1799679152208884,
                 912132775900387,
                 25967768040979,
                 432130448590461,
                 274568990261996,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 98698809797682,
                 2144627600856209,
                 1907959298569602,
@@ -3195,21 +3196,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1791451399743152,
                 1713538728337276,
                 2370149810942738,
                 1882306388849953,
                 158235232210248,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1217809823321928,
                 2173947284933160,
                 1986927836272325,
                 1388114931125539,
                 12686131160169,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1650875518872272,
                 1136263858253897,
                 1732115601395988,
@@ -3218,21 +3219,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2624786269799113,
                 2777230729143418,
                 2116279931702134,
                 2753222527273063,
                 1907002872974924,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 803147181835288,
                 868941437997146,
                 316299302989663,
                 943495589630550,
                 571224287904572,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 227742695588364,
                 1776969298667369,
                 628602552821802,
@@ -3241,21 +3242,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 815000523470260,
                 3164885502413555,
                 3303859931956420,
                 1345536665214222,
                 541623413135555,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1580216071604333,
                 1877997504342444,
                 857147161260913,
                 703522726778478,
                 2182763974211603,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1870080310923419,
                 71988220958492,
                 1783225432016732,
@@ -3264,21 +3265,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2982787564515398,
                 857613889540279,
                 1083813157271766,
                 1002817255970169,
                 1719228484436074,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 377616581647602,
                 1581980403078513,
                 804044118130621,
                 2034382823044191,
                 643844048472185,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 176957326463017,
                 1573744060478586,
                 528642225008045,
@@ -3287,21 +3288,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1888911448245718,
                 3638910709296328,
                 4176303607751676,
                 1731539523700948,
                 2230378382645454,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 443392177002051,
                 233793396845137,
                 2199506622312416,
                 1011858706515937,
                 974676837063129,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1846351103143623,
                 1949984838808427,
                 671247021915253,
@@ -3312,21 +3313,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 849646212451983,
                 1410198775302919,
                 2325567699868943,
                 1641663456615811,
                 3014056086137659,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 692017667358279,
                 723305578826727,
                 1638042139863265,
                 748219305990306,
                 334589200523901,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 22893968530686,
                 2235758574399251,
                 1661465835630252,
@@ -3335,21 +3336,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3053098849470395,
                 3985092410411378,
                 1664508947088595,
                 2719548934677170,
                 3899298398220870,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 903105258014366,
                 427141894933047,
                 561187017169777,
                 1884330244401954,
                 1914145708422219,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1344191060517578,
                 1960935031767890,
                 1518838929955259,
@@ -3358,21 +3359,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2925523165433334,
                 1979969272514922,
                 3427087126180756,
                 1187589090978665,
                 1881897672213940,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1917185587363432,
                 1098342571752737,
                 5935801044414,
                 2000527662351839,
                 1538640296181569,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 2495540013192,
                 678856913479236,
                 224998292422872,
@@ -3381,21 +3382,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 271413961212179,
                 3604851875156899,
                 2596511104968730,
                 2014925838520661,
                 2006221033113941,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 194583029968109,
                 514316781467765,
                 829677956235672,
                 1676415686873082,
                 810104584395840,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1980510813313589,
                 1948645276483975,
                 152063780665900,
@@ -3404,21 +3405,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1860190562533083,
                 1936576191345085,
                 2712900106391212,
                 1811043097042829,
                 3209286562992083,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 796664815624365,
                 1543160838872951,
                 1500897791837765,
                 1667315977988401,
                 599303877030711,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1151480509533204,
                 2136010406720455,
                 738796060240027,
@@ -3427,21 +3428,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1731069268103131,
                 2987442261301335,
                 1364750481334267,
                 2669032653668119,
                 3178908082812908,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1017222050227968,
                 1987716148359,
                 2234319589635701,
                 621282683093392,
                 2132553131763026,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1567828528453324,
                 1017807205202360,
                 565295260895298,
@@ -3450,21 +3451,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 249079270936229,
                 1501514259790706,
                 3199709537890096,
                 944551802437486,
                 2804458577667728,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 2089966982947227,
                 1854140343916181,
                 2151980759220007,
                 2139781292261749,
                 158070445864917,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1338766321464554,
                 1906702607371284,
                 1519569445519894,
@@ -3473,21 +3474,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3616421371950629,
                 3764188048593604,
                 1926731583198685,
                 2041482526432505,
                 3172200936019022,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1884844597333588,
                 601480070269079,
                 620203503079537,
                 1079527400117915,
                 1202076693132015,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 840922919763324,
                 727955812569642,
                 1303406629750194,
@@ -3498,21 +3499,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2605560604520539,
                 1598361541848742,
                 3374705511887547,
                 4174333403844152,
                 2670907514351827,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 359856369838236,
                 180914355488683,
                 861726472646627,
                 218807937262986,
                 575626773232501,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 755467689082474,
                 909202735047934,
                 730078068932500,
@@ -3521,21 +3522,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1609384177904054,
                 2614544999293875,
                 1335318541768200,
                 3052765584121496,
                 2799677792952659,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 984339177776787,
                 815727786505884,
                 1645154585713747,
                 1659074964378553,
                 1686601651984156,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1697863093781930,
                 599794399429786,
                 1104556219769607,
@@ -3544,21 +3545,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1168737550514982,
                 897832437380552,
                 463140296333799,
                 2554364413707795,
                 2008360505135500,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1856930662813910,
                 678090852002597,
                 1920179140755167,
                 1259527833759868,
                 55540971895511,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1158643631044921,
                 476554103621892,
                 178447851439725,
@@ -3567,21 +3568,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2176793111709008,
                 3828525530035639,
                 2009350167273522,
                 2012390194631546,
                 2125297410909580,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 825403285195098,
                 2144208587560784,
                 1925552004644643,
                 1915177840006985,
                 1015952128947864,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1807108316634472,
                 1534392066433717,
                 347342975407218,
@@ -3590,21 +3591,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3234860815484973,
                 2683011703586488,
                 2201903782961092,
                 3069193724749589,
                 2214616493042166,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 228567918409756,
                 865093958780220,
                 358083886450556,
                 159617889659320,
                 1360637926292598,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 234147501399755,
                 2229469128637390,
                 2175289352258889,
@@ -3613,21 +3614,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3363562226636810,
                 2504649386192636,
                 3300514047508588,
                 2397910909286693,
                 1237505378776769,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1113790697840279,
                 1051167139966244,
                 1045930658550944,
                 2011366241542643,
                 1686166824620755,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1054097349305049,
                 1872495070333352,
                 182121071220717,
@@ -3636,21 +3637,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3558210666856834,
                 1627717417672446,
                 2302783034773665,
                 1109249951172249,
                 3122001602766640,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 104233794644221,
                 1548919791188248,
                 2224541913267306,
                 2054909377116478,
                 1043803389015153,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 216762189468802,
                 707284285441622,
                 190678557969733,
@@ -3659,21 +3660,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3530824104723725,
                 2596576648903557,
                 2525521909702446,
                 4086000250496689,
                 634517197663803,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 343805853118335,
                 1302216857414201,
                 566872543223541,
                 2051138939539004,
                 321428858384280,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 470067171324852,
                 1618629234173951,
                 2000092177515639,
@@ -3684,21 +3685,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2529951391976704,
                 1810282338562946,
                 1771599529530998,
                 3635459223356879,
                 2937173228157088,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 577009397403102,
                 1791440261786291,
                 2177643735971638,
                 174546149911960,
                 1412505077782326,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 893719721537457,
                 1201282458018197,
                 1522349501711173,
@@ -3707,21 +3708,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 412607348255434,
                 1280455764199780,
                 2233277987330768,
                 2265979894086913,
                 2583384512102412,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 262483770854550,
                 990511055108216,
                 526885552771698,
                 571664396646158,
                 354086190278723,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1820352417585487,
                 24495617171480,
                 1547899057533253,
@@ -3730,21 +3731,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2023310314989233,
                 2889705151211129,
                 2106474638900686,
                 2809620524769320,
                 1687858215057825,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1144168702609745,
                 604444390410187,
                 1544541121756138,
                 1925315550126027,
                 626401428894002,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1922168257351784,
                 2018674099908659,
                 1776454117494445,
@@ -3753,21 +3754,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2796444352433270,
                 1039872944430373,
                 3128550222815858,
                 2962457525011798,
                 3468752501170219,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 58242421545916,
                 2035812695641843,
                 2118491866122923,
                 1191684463816273,
                 46921517454099,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 272268252444639,
                 1374166457774292,
                 2230115177009552,
@@ -3776,21 +3777,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1857910905368338,
                 1754729879288912,
                 3137745277795125,
                 1516096106802165,
                 1602902393369811,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1193437069800958,
                 901107149704790,
                 999672920611411,
                 477584824802207,
                 364239578697845,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 886299989548838,
                 1538292895758047,
                 1590564179491896,
@@ -3799,21 +3800,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3006358179063534,
                 1712186480903617,
                 3955456640022779,
                 3002110732175033,
                 2770795853936147,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1309847803895382,
                 1462151862813074,
                 211370866671570,
                 1544595152703681,
                 1027691798954090,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 803217563745370,
                 1884799722343599,
                 1357706345069218,
@@ -3822,21 +3823,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2941099284981214,
                 1831210565161070,
                 3626987155270686,
                 3358084791231418,
                 1893781834054268,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 696351368613042,
                 1494385251239250,
                 738037133616932,
                 636385507851544,
                 927483222611406,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1949114198209333,
                 1104419699537997,
                 783495707664463,
@@ -3845,21 +3846,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1607325776830197,
                 2782683755100581,
                 1451089452727894,
                 3833490970768671,
                 496100432831153,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1068900648804224,
                 2006891997072550,
                 1134049269345549,
                 1638760646180091,
                 2055396084625778,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 2222475519314561,
                 1870703901472013,
                 1884051508440561,
@@ -3870,21 +3871,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 155711679280637,
                 681100400509288,
                 389811735211209,
                 2135723811340709,
                 2660533024889373,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 7813206966729,
                 194444201427550,
                 2071405409526507,
                 1065605076176312,
                 1645486789731291,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 16625790644959,
                 1647648827778410,
                 1579910185572704,
@@ -3893,21 +3894,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3289062842237779,
                 2820185594063076,
                 2549752917829677,
                 3810384325616458,
                 2238221839292470,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 190565267697443,
                 672855706028058,
                 338796554369226,
                 337687268493904,
                 853246848691734,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1763863028400139,
                 766498079432444,
                 1321118624818005,
@@ -3916,21 +3917,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3543856582248253,
                 1456632109855637,
                 3352431060735432,
                 1386133165675320,
                 3484698163879000,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 366253102478259,
                 525676242508811,
                 1449610995265438,
                 1183300845322183,
                 185960306491545,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 28315355815982,
                 460422265558930,
                 1799675876678724,
@@ -3939,21 +3940,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2408714813047231,
                 3857948219405196,
                 1665208410108429,
                 2569443092377519,
                 1383783705665319,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 54684536365732,
                 2210010038536222,
                 1194984798155308,
                 535239027773705,
                 1516355079301361,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1484387703771650,
                 198537510937949,
                 2186282186359116,
@@ -3962,21 +3963,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2147715541830533,
                 2751832352131065,
                 2898179830570073,
                 2604027669016369,
                 1488268620408051,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 159386186465542,
                 1877626593362941,
                 618737197060512,
                 1026674284330807,
                 1158121760792685,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1744544377739822,
                 1964054180355661,
                 1685781755873170,
@@ -3985,21 +3986,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2333777063470241,
                 3919742931398333,
                 3920783633320113,
                 1605016835177614,
                 1353960708075544,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1602253788689063,
                 439542044889886,
                 2220348297664483,
                 657877410752869,
                 157451572512238,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1029287186166717,
                 65860128430192,
                 525298368814832,
@@ -4008,21 +4009,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2660016802414475,
                 2121095722306988,
                 913562102267595,
                 1879708920318308,
                 2492861262121979,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1185483484383269,
                 1356339572588553,
                 584932367316448,
                 102132779946470,
                 1792922621116791,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1966196870701923,
                 2230044620318636,
                 1425982460745905,
@@ -4031,21 +4032,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2358877405280588,
                 3136759755857592,
                 2279106683482647,
                 2224911448949389,
                 3216151871930471,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1730194207717538,
                 431790042319772,
                 1831515233279467,
                 1372080552768581,
                 1074513929381760,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1450880638731607,
                 1019861580989005,
                 1229729455116861,
@@ -4056,21 +4057,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1899935429242705,
                 1602068751520477,
                 940583196550370,
                 2334230882739107,
                 1540863155745695,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 2136688454840028,
                 2099509000964294,
                 1690800495246475,
                 1217643678575476,
                 828720645084218,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 765548025667841,
                 462473984016099,
                 998061409979798,
@@ -4079,21 +4080,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2298375097456408,
                 3144370785258318,
                 1281983193144089,
                 1491520128287375,
                 75847005908304,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1801436127943107,
                 1734436817907890,
                 1268728090345068,
                 167003097070711,
                 2233597765834956,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1997562060465113,
                 1048700225534011,
                 7615603985628,
@@ -4102,21 +4103,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1161017320376250,
                 2744424393854291,
                 2169815802355236,
                 3228296595417790,
                 1770879511019628,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1357044908364776,
                 729130645262438,
                 1762469072918979,
                 1365633616878458,
                 181282906404941,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1080413443139865,
                 1155205815510486,
                 1848782073549786,
@@ -4125,21 +4126,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1184526762066993,
                 247622751762817,
                 2943928830891604,
                 3071818503097743,
                 2188697339828084,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 2020536369003019,
                 202261491735136,
                 1053169669150884,
                 2056531979272544,
                 778165514694311,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 237404399610207,
                 1308324858405118,
                 1229680749538400,
@@ -4148,21 +4149,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2767383321724075,
                 2269456792542436,
                 1717918437373988,
                 1568052070792483,
                 2298775616809171,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 281527309158085,
                 36970532401524,
                 866906920877543,
                 2222282602952734,
                 1289598729589882,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1278207464902042,
                 494742455008756,
                 1262082121427081,
@@ -4171,21 +4172,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 353042527954210,
                 1830056151907359,
                 1111731275799225,
                 2426760769524072,
                 404312815582674,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 2064251142068628,
                 1666421603389706,
                 1419271365315441,
                 468767774902855,
                 191535130366583,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1716987058588002,
                 1859366439773457,
                 1767194234188234,
@@ -4194,21 +4195,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3236091949205521,
                 2386938060636506,
                 2220652137473166,
                 1722843421165029,
                 2442282371698157,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 298845952651262,
                 1166086588952562,
                 1179896526238434,
                 1347812759398693,
                 1412945390096208,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1143239552672925,
                 906436640714209,
                 2177000572812152,
@@ -4217,21 +4218,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2972824668060020,
                 2936287674948563,
                 3625238557779406,
                 2193186935276994,
                 1387043709851261,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 418098668140962,
                 715065997721283,
                 1471916138376055,
                 2168570337288357,
                 937812682637044,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1043584187226485,
                 2143395746619356,
                 2209558562919611,
@@ -4242,21 +4243,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1248731221520740,
                 1465200936117687,
                 2792603306395388,
                 2304778448366139,
                 2513234303861356,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1057329623869501,
                 620334067429122,
                 461700859268034,
                 2012481616501857,
                 297268569108938,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1055352180870759,
                 1553151421852298,
                 1510903185371259,
@@ -4265,21 +4266,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3744788603986897,
                 3042126439258578,
                 3441906842094992,
                 3641194565844440,
                 3872208010289441,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 47000654413729,
                 1004754424173864,
                 1868044813557703,
                 173236934059409,
                 588771199737015,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 30498470091663,
                 1082245510489825,
                 576771653181956,
@@ -4288,21 +4289,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2672107869436803,
                 3745154677001249,
                 2417006535213335,
                 4136645508605033,
                 2065456951573058,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1115636332012334,
                 1854340990964155,
                 83792697369514,
                 1972177451994021,
                 457455116057587,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1698968457310898,
                 1435137169051090,
                 1083661677032510,
@@ -4311,21 +4312,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1995325341336555,
                 911500251774648,
                 2415810569088940,
                 855378419194761,
                 3825401211214090,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 241719380661528,
                 310028521317150,
                 1215881323380194,
                 1408214976493624,
                 2141142156467363,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1315157046163473,
                 727368447885818,
                 1363466668108618,
@@ -4334,21 +4335,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2326829491984875,
                 3267188020145720,
                 1849729037055211,
                 4191614430138232,
                 2696204044080201,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 2053597130993710,
                 2024431685856332,
                 2233550957004860,
                 2012407275509545,
                 872546993104440,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1217269667678610,
                 599909351968693,
                 1390077048548598,
@@ -4357,21 +4358,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3970118453066023,
                 1560510726633957,
                 3156262694845170,
                 1418028351780051,
                 2346204163137185,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 2132502667405250,
                 214379346175414,
                 1502748313768060,
                 1960071701057800,
                 1353971822643138,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 319394212043702,
                 2127459436033571,
                 717646691535162,
@@ -4380,21 +4381,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2657789238608841,
                 1960452633787082,
                 2919148848086913,
                 3744474074452359,
                 1451061489880786,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 947085906234007,
                 323284730494107,
                 1485778563977200,
                 728576821512394,
                 901584347702286,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1575783124125742,
                 2126210792434375,
                 1569430791264065,
@@ -4403,21 +4404,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3090232019245924,
                 4249503325136911,
                 3270591693593114,
                 1662001808174330,
                 2330127946643001,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 739152638255629,
                 2074935399403557,
                 505483666745895,
                 1611883356514088,
                 628654635394878,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1822054032121349,
                 643057948186973,
                 7306757352712,
@@ -4428,21 +4429,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3618358370049178,
                 1448606567552085,
                 3730680834630016,
                 2417602993041145,
                 1115718458123497,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 204146226972102,
                 1630511199034723,
                 2215235214174763,
                 174665910283542,
                 956127674017216,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1562934578796716,
                 1070893489712745,
                 11324610642270,
@@ -4451,21 +4452,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1770564423056008,
                 2987323445349813,
                 1326060113795288,
                 1509650369341127,
                 2317692235267932,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 623682558650637,
                 1337866509471512,
                 990313350206649,
                 1314236615762469,
                 1164772974270275,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 223256821462517,
                 723690150104139,
                 1000261663630601,
@@ -4474,21 +4475,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1969087237026022,
                 2876595539132372,
                 1335555107635968,
                 2069986355593023,
                 3963899963027150,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1236103475266979,
                 1837885883267218,
                 1026072585230455,
                 1025865513954973,
                 1801964901432134,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1115241013365517,
                 1712251818829143,
                 2148864332502771,
@@ -4497,21 +4498,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3551068012286861,
                 2047148477845620,
                 2165648650132450,
                 1612539282026145,
                 2765997725314138,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 118352772338543,
                 1067608711804704,
                 1434796676193498,
                 1683240170548391,
                 230866769907437,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1850689576796636,
                 1601590730430274,
                 1139674615958142,
@@ -4520,21 +4521,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1723387471374172,
                 3249101280723658,
                 2785727448808904,
                 2272728458379212,
                 1756575222802512,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 2146711623855116,
                 503278928021499,
                 625853062251406,
                 1109121378393107,
                 1033853809911861,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 571005965509422,
                 2005213373292546,
                 1016697270349626,
@@ -4543,21 +4544,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1346698876211176,
                 2076651707527589,
                 3336561384795453,
                 2517134292513653,
                 1068954492309670,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1769967932677654,
                 1695893319756416,
                 1151863389675920,
                 1781042784397689,
                 400287774418285,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1851867764003121,
                 403841933237558,
                 820549523771987,
@@ -4566,21 +4567,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 410915148140008,
                 2107072311871739,
                 3256167275561751,
                 2351484709082008,
                 1180818713503223,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 285945406881439,
                 648174397347453,
                 1098403762631981,
                 1366547441102991,
                 1505876883139217,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 672095903120153,
                 1675918957959872,
                 636236529315028,
@@ -4589,21 +4590,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1902708175321798,
                 3287143344600686,
                 1178560808893262,
                 2552895497743394,
                 1280977479761117,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1615357281742403,
                 404257611616381,
                 2160201349780978,
                 1160947379188955,
                 1578038619549541,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 2013087639791217,
                 822734930507457,
                 1785668418619014,
@@ -4614,21 +4615,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2705718263383616,
                 2358206633614248,
                 2072540975937134,
                 308588860670238,
                 1304394580755385,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1295082798350326,
                 2091844511495996,
                 1851348972587817,
                 3375039684596,
                 789440738712837,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 2083069137186154,
                 848523102004566,
                 993982213589257,
@@ -4637,21 +4638,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3747761112537659,
                 1397203457344778,
                 4026750030752190,
                 2391102557240943,
                 2318403398028034,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1782411379088302,
                 1096724939964781,
                 27593390721418,
                 542241850291353,
                 1540337798439873,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 693543956581437,
                 171507720360750,
                 1557908942697227,
@@ -4660,21 +4661,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 345288228393400,
                 3351443383432420,
                 2386681722088990,
                 1740551994106739,
                 2500011992985018,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 231429562203065,
                 1526290236421172,
                 2021375064026423,
                 1520954495658041,
                 806337791525116,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1079623667189886,
                 872403650198613,
                 766894200588288,
@@ -4683,21 +4684,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 854645372543796,
                 1936406001954827,
                 2403260476226501,
                 3077125552956802,
                 1554306377287555,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1497138821904622,
                 1044820250515590,
                 1742593886423484,
                 1237204112746837,
                 849047450816987,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 667962773375330,
                 1897271816877105,
                 1399712621683474,
@@ -4706,21 +4707,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2378947665252234,
                 1936114012888109,
                 1704424366552046,
                 3108474694401560,
                 2968403435020606,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1072409664800960,
                 2146937497077528,
                 1508780108920651,
                 935767602384853,
                 1112800433544068,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 333549023751292,
                 280219272863308,
                 2104176666454852,
@@ -4729,21 +4730,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2625466093568366,
                 2398257055215356,
                 2555916080813104,
                 2667888562832962,
                 3510376944868638,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1186115062588401,
                 2251609796968486,
                 1098944457878953,
                 1153112761201374,
                 1791625503417267,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1870078460219737,
                 2129630962183380,
                 852283639691142,
@@ -4752,21 +4753,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1361070124828016,
                 815664541425524,
                 3278598711049919,
                 1951790935390646,
                 2807674705520038,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1546301003424277,
                 459094500062839,
                 1097668518375311,
                 1780297770129643,
                 720763293687608,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1212405311403990,
                 1536693382542438,
                 61028431067459,
@@ -4775,21 +4776,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1294303766540260,
                 3435357279640341,
                 3134071170918340,
                 2315654383110622,
                 2213283684565086,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 339050984211414,
                 601386726509773,
                 413735232134068,
                 966191255137228,
                 1839475899458159,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 235605972169408,
                 2174055643032978,
                 1538335001838863,
@@ -4800,21 +4801,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1632352921721536,
                 1833328609514701,
                 2092779091951987,
                 4175756015558474,
                 2210068022482918,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 35271216625062,
                 1712350667021807,
                 983664255668860,
                 98571260373038,
                 1232645608559836,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1998172393429622,
                 1798947921427073,
                 784387737563581,
@@ -4823,21 +4824,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1733739258725305,
                 2283515530744786,
                 2453769758904107,
                 3243892858242237,
                 1194308773174555,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 846415389605137,
                 746163495539180,
                 829658752826080,
                 592067705956946,
                 957242537821393,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1758148849754419,
                 619249044817679,
                 168089007997045,
@@ -4846,21 +4847,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2578433797894864,
                 2513559319756263,
                 1700682323676192,
                 1577907266349064,
                 3469447477068264,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1714182387328607,
                 1477856482074168,
                 574895689942184,
                 2159118410227270,
                 1555532449716575,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 853828206885131,
                 998498946036955,
                 1835887550391235,
@@ -4869,21 +4870,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2392941288336925,
                 3488528558590503,
                 2894901233585134,
                 1646615130509172,
                 1208239602291765,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1501663228068911,
                 1354879465566912,
                 1444432675498247,
                 897812463852601,
                 855062598754348,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 714380763546606,
                 1032824444965790,
                 1774073483745338,
@@ -4892,21 +4893,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1640635546696233,
                 2884968766877360,
                 2212651044092395,
                 2282390772269100,
                 2620315074574625,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1171650314802029,
                 1567085444565577,
                 1453660792008405,
                 757914533009261,
                 1619511342778196,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 420958967093237,
                 971103481109486,
                 2169549185607107,
@@ -4915,21 +4916,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3158923465503550,
                 1332556122804145,
                 4075855067109735,
                 3619414031128206,
                 1982558335973171,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1121533090144639,
                 1021251337022187,
                 110469995947421,
                 1511059774758394,
                 2110035908131662,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 303213233384524,
                 2061932261128138,
                 352862124777736,
@@ -4938,21 +4939,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 856559257852200,
                 2760317478634258,
                 3629993581580163,
                 3975258940632376,
                 1962275756614520,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1445691340537320,
                 40614383122127,
                 402104303144865,
                 485134269878232,
                 1659439323587426,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 20057458979482,
                 1183363722525800,
                 2140003847237215,
@@ -4961,21 +4962,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2228654250927986,
                 3735391177100515,
                 1368661293910955,
                 3328311098862539,
                 526650682059607,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 709481497028540,
                 531682216165724,
                 316963769431931,
                 1814315888453765,
                 258560242424104,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1053447823660455,
                 1955135194248683,
                 1010900954918985,
@@ -4986,21 +4987,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1957943897155478,
                 1788667368028035,
                 2389492723714354,
                 2252839333292309,
                 3078204576998275,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1848942433095597,
                 1582009882530495,
                 1849292741020143,
                 1068498323302788,
                 2001402229799484,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1528282417624269,
                 2142492439828191,
                 2179662545816034,
@@ -5009,21 +5010,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2411826493119617,
                 2484141002903963,
                 2149181472355544,
                 598041771119831,
                 2435658815595421,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 2013278155187349,
                 662660471354454,
                 793981225706267,
                 411706605985744,
                 804490933124791,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 2051892037280204,
                 488391251096321,
                 2230187337030708,
@@ -5032,21 +5033,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1530723630438670,
                 875873929577927,
                 2593359947955236,
                 2701702933216000,
                 1055551308214178,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1461835919309432,
                 1955256480136428,
                 180866187813063,
                 1551979252664528,
                 557743861963950,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 359179641731115,
                 1324915145732949,
                 902828372691474,
@@ -5055,21 +5056,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 4295071423139571,
                 2038225437857463,
                 1317528426475850,
                 1398989128982787,
                 2027639881006861,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 2072902725256516,
                 312132452743412,
                 309930885642209,
                 996244312618453,
                 1590501300352303,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1397254305160710,
                 695734355138021,
                 2233992044438756,
@@ -5078,21 +5079,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2692366865016258,
                 2506694600041928,
                 2745669038615469,
                 1556322069683365,
                 3819256354004466,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1950722461391320,
                 1907845598854797,
                 1822757481635527,
                 2121567704750244,
                 73811931471221,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 387139307395758,
                 2058036430315676,
                 1220915649965325,
@@ -5101,21 +5102,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1765973779329498,
                 2911143873132225,
                 2271621715291913,
                 3553728154996461,
                 3368065817761132,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1127572801181483,
                 1224743760571696,
                 1276219889847274,
                 1529738721702581,
                 1589819666871853,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 2181229378964934,
                 2190885205260020,
                 1511536077659137,
@@ -5124,21 +5125,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2689666469258543,
                 2920826224880015,
                 2333696811665585,
                 523874406393177,
                 2496851874620484,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1975438052228868,
                 1071801519999806,
                 594652299224319,
                 1877697652668809,
                 1489635366987285,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 958592545673770,
                 233048016518599,
                 851568750216589,
@@ -5147,21 +5148,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2014540178270324,
                 192672779514432,
                 2465676996326778,
                 2194819933853410,
                 1716422829364835,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1540769606609725,
                 2148289943846077,
                 1597804156127445,
                 1230603716683868,
                 815423458809453,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1738560251245018,
                 1779576754536888,
                 1783765347671392,
@@ -5172,21 +5173,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2911103727614740,
                 1956447718227572,
                 1830568515922666,
                 3092868863429656,
                 1669607124206367,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1143465490433355,
                 1532194726196059,
                 1093276745494697,
                 481041706116088,
                 2121405433561163,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1686424298744462,
                 1451806974487153,
                 266296068846582,
@@ -5195,21 +5196,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3141016840074207,
                 3295090436969907,
                 3107924901237156,
                 1669272323124635,
                 1603340330827879,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1206396181488998,
                 333158148435054,
                 1402633492821422,
                 1120091191722026,
                 1945474114550509,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 766720088232571,
                 1512222781191002,
                 1189719893490790,
@@ -5218,21 +5219,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2671463460991841,
                 1998875112167986,
                 3678399683938955,
                 3406728169064757,
                 2738338345823434,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 938160078005954,
                 1421776319053174,
                 1941643234741774,
                 180002183320818,
                 1414380336750546,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 398001940109652,
                 1577721237663248,
                 1012748649830402,
@@ -5241,21 +5242,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1653276489969611,
                 2257881638852872,
                 1921777941170835,
                 1604139841794531,
                 3113010867325889,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 996661541407379,
                 1455877387952927,
                 744312806857277,
                 139213896196746,
                 1000282908547789,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1450817495603008,
                 1476865707053229,
                 1030490562252053,
@@ -5264,21 +5265,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2811528223687828,
                 2288856475326432,
                 2038622963352005,
                 1637244893271723,
                 3278365165924196,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 962165956135846,
                 1116599660248791,
                 182090178006815,
                 1455605467021751,
                 196053588803284,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 796863823080135,
                 1897365583584155,
                 420466939481601,
@@ -5287,21 +5288,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 877047233620613,
                 1375632631944375,
                 2895573425567369,
                 2911822552533124,
                 2271153746017078,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 2216943882299338,
                 394841323190322,
                 2222656898319671,
                 558186553950529,
                 1077236877025190,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 801118384953213,
                 1914330175515892,
                 574541023311511,
@@ -5310,21 +5311,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3201417702772463,
                 2207116611267330,
                 3164719852826535,
                 2752958352884036,
                 2314162374456719,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1474518386765335,
                 1760793622169197,
                 1157399790472736,
                 1622864308058898,
                 165428294422792,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1961673048027128,
                 102619413083113,
                 1051982726768458,
@@ -5333,21 +5334,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1401939116319247,
                 2587106153588320,
                 2323846009771033,
                 862423201496005,
                 3102318568216632,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1234706593321979,
                 1083343891215917,
                 898273974314935,
                 1640859118399498,
                 157578398571149,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1143483057726416,
                 1992614991758919,
                 674268662140796,
@@ -5358,21 +5359,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1835401379538542,
                 173900035308392,
                 818247630716732,
                 4013900225838034,
                 1021506399448290,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1506632088156630,
                 2127481795522179,
                 513812919490255,
                 140643715928370,
                 442476620300318,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 2056683376856736,
                 219094741662735,
                 2193541883188309,
@@ -5381,21 +5382,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3566819241596075,
                 1049075855992602,
                 4318372866671791,
                 2518704280870781,
                 2040482348591519,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 94096246544434,
                 922482381166992,
                 24517828745563,
                 2139430508542503,
                 2097139044231004,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 537697207950515,
                 1399352016347350,
                 1563663552106345,
@@ -5404,21 +5405,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1747985413252415,
                 680511052635695,
                 1809559829982725,
                 2846074064615302,
                 2453472984431229,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 323583936109569,
                 1973572998577657,
                 1192219029966558,
                 79354804385273,
                 1374043025560347,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 213277331329947,
                 416202017849623,
                 1950535221091783,
@@ -5427,21 +5428,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2440888617915079,
                 993969372859109,
                 3147669935222235,
                 3799101348983503,
                 1477373024911349,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1620578418245010,
                 541035331188469,
                 2235785724453865,
                 2154865809088198,
                 1974627268751826,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1346805451740245,
                 1350981335690626,
                 942744349501813,
@@ -5450,21 +5451,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2107080134091762,
                 1132567062788208,
                 1824935377687210,
                 769194804343737,
                 1857941799971888,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1074666112436467,
                 249279386739593,
                 1174337926625354,
                 1559013532006480,
                 1472287775519121,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1872620123779532,
                 1892932666768992,
                 1921559078394978,
@@ -5473,21 +5474,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3089190001333428,
                 3264053113908846,
                 989780015893986,
                 1351393287739814,
                 2580427560230798,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1028328827183114,
                 1711043289969857,
                 1350832470374933,
                 1923164689604327,
                 1495656368846911,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1900828492104143,
                 430212361082163,
                 687437570852799,
@@ -5496,21 +5497,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3094432661621646,
                 605670026766215,
                 290836444839585,
                 2415010588577604,
                 2213815011799644,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1176336383453996,
                 1725477294339771,
                 12700622672454,
                 678015708818208,
                 162724078519879,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1448049969043497,
                 1789411762943521,
                 385587766217753,
@@ -5519,21 +5520,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2767886146978542,
                 2240508292484615,
                 3603469341851756,
                 3475055379001735,
                 3002035638112385,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1263624896582495,
                 1102602401673328,
                 526302183714372,
                 2152015839128799,
                 1483839308490010,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 442991718646863,
                 1599275157036458,
                 1925389027579192,
@@ -5544,21 +5545,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1689713572022124,
                 2845654372939621,
                 3229894858477217,
                 1985127338729498,
                 3927868934032873,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1557207018622683,
                 340631692799603,
                 1477725909476187,
                 614735951619419,
                 2033237123746766,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 968764929340557,
                 1225534776710944,
                 662967304013036,
@@ -5567,21 +5568,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1487081286167458,
                 3244839255500182,
                 1792378982844639,
                 2950452258685122,
                 2153908693179753,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1123181311102823,
                 685575944875442,
                 507605465509927,
                 1412590462117473,
                 568017325228626,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 560258797465417,
                 2193971151466401,
                 1824086900849026,
@@ -5590,21 +5591,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1918407319222397,
                 2605567366745211,
                 1930426334528098,
                 1564816146005724,
                 4113142195393344,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 2131325168777276,
                 1176636658428908,
                 1756922641512981,
                 1390243617176012,
                 1966325177038383,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 2063958120364491,
                 2140267332393533,
                 699896251574968,
@@ -5613,21 +5614,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2024297515263178,
                 2668759143407935,
                 3330814048702549,
                 2423412039258430,
                 1031677520051052,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 2033900009388450,
                 1744902869870788,
                 2190580087917640,
                 1949474984254121,
                 231049754293748,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 343868674606581,
                 550155864008088,
                 1450580864229630,
@@ -5636,21 +5637,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2151139328380127,
                 2566545695770176,
                 2311556639460451,
                 1676664391494650,
                 2048348075599360,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1528930066340597,
                 1605003907059576,
                 1055061081337675,
                 1458319101947665,
                 1234195845213142,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 830430507734812,
                 1780282976102377,
                 1425386760709037,
@@ -5659,21 +5660,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3407562046415562,
                 980662895504005,
                 2053766700883521,
                 2742766027762854,
                 2762205690726604,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1683750316716132,
                 652278688286128,
                 1221798761193539,
                 1897360681476669,
                 319658166027343,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 618808732869972,
                 72755186759744,
                 2060379135624181,
@@ -5682,21 +5683,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3714971784278753,
                 3394840525452699,
                 614590986558882,
                 1409210575145591,
                 1882816996436803,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 2230133264691131,
                 563950955091024,
                 2042915975426398,
                 827314356293472,
                 672028980152815,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 264204366029760,
                 1654686424479449,
                 2185050199932931,
@@ -5705,21 +5706,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1784446333136550,
                 1973746527984364,
                 334856327359575,
                 3408569589569858,
                 3275749938360725,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 2065270940578383,
                 31477096270353,
                 306421879113491,
                 181958643936686,
                 1907105536686083,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1496516440779464,
                 1748485652986458,
                 872778352227340,
@@ -5730,21 +5731,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2723435829455580,
                 2924255216478824,
                 1804995246884102,
                 1842309243470804,
                 3753662318666930,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1013216974933691,
                 538921919682598,
                 1915776722521558,
                 1742822441583877,
                 1886550687916656,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 2094270000643336,
                 303971879192276,
                 40801275554748,
@@ -5753,21 +5754,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2241737709499146,
                 549397817447461,
                 838180519319392,
                 1725686958520781,
                 3957438894582995,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1216074541925116,
                 50120933933509,
                 1565829004133810,
                 721728156134580,
                 349206064666188,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 948617110470858,
                 346222547451945,
                 1126511960599975,
@@ -5776,21 +5777,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1454933046815146,
                 3126495827951610,
                 1467170975468587,
                 1432316382418897,
                 2111710746366763,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 2105387117364450,
                 1996463405126433,
                 1303008614294500,
                 851908115948209,
                 1353742049788635,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 750300956351719,
                 1487736556065813,
                 15158817002104,
@@ -5799,21 +5800,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1874648163531674,
                 2124487685930551,
                 1810030029384882,
                 918400043048335,
                 2838148440985898,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1235084464747900,
                 1166111146432082,
                 1745394857881591,
                 1405516473883040,
                 4463504151617,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1663810156463827,
                 327797390285791,
                 1341846161759410,
@@ -5822,21 +5823,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 660005247548214,
                 2071860029952887,
                 3610548013635355,
                 911703252219106,
                 3266179736709079,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 2206641276178231,
                 1690587809721504,
                 1600173622825126,
                 2156096097634421,
                 1106822408548216,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1344788193552206,
                 1949552134239140,
                 1735915881729557,
@@ -5845,21 +5846,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1920949492387945,
                 2410685102072778,
                 2322108077349280,
                 2877838278583064,
                 3719881539786256,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 622221042073383,
                 1210146474039168,
                 1742246422343683,
                 1403839361379025,
                 417189490895736,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 22727256592983,
                 168471543384997,
                 1324340989803650,
@@ -5868,21 +5869,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3565040332441556,
                 1721896294296941,
                 2304063388272514,
                 2065069734239231,
                 3056710287109878,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1337466662091884,
                 1287645354669772,
                 2018019646776184,
                 652181229374245,
                 898011753211715,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1969792547910734,
                 779969968247557,
                 2011350094423418,
@@ -5891,21 +5892,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2459143550747250,
                 1118176942430252,
                 3010694408233412,
                 806764629546265,
                 1157700123092949,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1273565321399022,
                 1638509681964574,
                 759235866488935,
                 666015124346707,
                 897983460943405,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1717263794012298,
                 1059601762860786,
                 1837819172257618,
@@ -5916,21 +5917,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2237039662793603,
                 2249022333361206,
                 2058613546633703,
                 2401253908530527,
                 2215176649164581,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 79472182719605,
                 1851130257050174,
                 1825744808933107,
                 821667333481068,
                 781795293511946,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 755822026485370,
                 152464789723500,
                 1178207602290608,
@@ -5939,21 +5940,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3669985309815545,
                 2736319981413860,
                 3898537095128197,
                 3653287498355512,
                 1349185550126960,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1495380034400429,
                 325049476417173,
                 46346894893933,
                 1553408840354856,
                 828980101835683,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1280337889310282,
                 2070832742866672,
                 1640940617225222,
@@ -5962,21 +5963,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2659503167684029,
                 2378371955168899,
                 2537839641198868,
                 1999255076709337,
                 2030511179441770,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1254958221100483,
                 1153235960999843,
                 942907704968834,
                 637105404087392,
                 1149293270147267,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 894249020470196,
                 400291701616810,
                 406878712230981,
@@ -5985,21 +5986,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3749755063888563,
                 2361916158338507,
                 1128535642171975,
                 1900106496009660,
                 2381592531146157,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 452487513298665,
                 1352120549024569,
                 1173495883910956,
                 1999111705922009,
                 367328130454226,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1717539401269642,
                 1475188995688487,
                 891921989653942,
@@ -6008,21 +6009,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3493583935107776,
                 2439136865632830,
                 3370281625921440,
                 2680547565621609,
                 2282158712612572,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 2022432361201842,
                 1088816090685051,
                 1977843398539868,
                 1854834215890724,
                 564238862029357,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 938868489100585,
                 1100285072929025,
                 1017806255688848,
@@ -6031,21 +6032,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3119119231364171,
                 2872271776627789,
                 2477832016990963,
                 2593801257642876,
                 1761675818237335,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1295072362439987,
                 931227904689414,
                 1355731432641687,
                 922235735834035,
                 892227229410209,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1680989767906154,
                 535362787031440,
                 2136691276706570,
@@ -6054,21 +6055,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2617818047455756,
                 2684460443440843,
                 2378209521329782,
                 1973842949591661,
                 2897427157127624,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 535509430575217,
                 546885533737322,
                 1524675609547799,
                 2138095752851703,
                 1260738089896827,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1159906385590467,
                 2198530004321610,
                 714559485023225,
@@ -6077,21 +6078,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1377485731340769,
                 2046328105512000,
                 1802058637158797,
                 2313945950453421,
                 1356993908853900,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 2013612215646735,
                 1830770575920375,
                 536135310219832,
                 609272325580394,
                 270684344495013,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1237542585982777,
                 2228682050256790,
                 1385281931622824,
@@ -6102,21 +6103,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
     ]),
     LookupTable([
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2299141301692989,
                 1891414891220256,
                 983894663308928,
                 2427961581972066,
                 3378060928864955,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1694030170963455,
                 502038567066200,
                 1691160065225467,
                 949628319562187,
                 275110186693066,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1124515748676336,
                 1661673816593408,
                 1499640319059718,
@@ -6125,21 +6126,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1784525599998356,
                 1619698033617383,
                 2097300287550715,
                 2510065271789004,
                 1905684794832757,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1288941072872766,
                 931787902039402,
                 190731008859042,
                 2006859954667190,
                 1005931482221702,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1465551264822703,
                 152905080555927,
                 680334307368453,
@@ -6148,21 +6149,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2111017076203943,
                 3630560299479595,
                 1248583954016455,
                 3604089008549670,
                 1895180776543895,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 171348223915638,
                 662766099800389,
                 462338943760497,
                 466917763340314,
                 656911292869115,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 488623681976577,
                 866497561541722,
                 1708105560937768,
@@ -6171,21 +6172,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2412225278142205,
                 950394373239688,
                 2682296937026182,
                 711676555398831,
                 320964687779005,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 988979367990485,
                 1359729327576302,
                 1301834257246029,
                 294141160829308,
                 29348272277475,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1434382743317910,
                 100082049942065,
                 221102347892623,
@@ -6194,21 +6195,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2205916462268190,
                 2751663643476068,
                 961960554686615,
                 2409862576442233,
                 1841471168298304,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1191737341426592,
                 1847042034978363,
                 1382213545049056,
                 1039952395710448,
                 788812858896859,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1346965964571152,
                 1291881610839830,
                 2142916164336056,
@@ -6217,21 +6218,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 787164375951248,
                 2454669019058437,
                 3608390234717387,
                 1431233331032509,
                 786341368775957,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 492448143532951,
                 304105152670757,
                 1761767168301056,
                 233782684697790,
                 1981295323106089,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 665807507761866,
                 1343384868355425,
                 895831046139653,
@@ -6240,21 +6241,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3007896024559801,
                 1721699973539148,
                 2510565115413133,
                 1390588532210644,
                 1212530909934781,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 852891097972275,
                 1816988871354562,
                 1543772755726524,
                 1174710635522444,
                 202129090724628,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1205281565824323,
                 22430498399418,
                 992947814485516,
@@ -6263,21 +6264,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3302427242100220,
                 1955849529137134,
                 2171162376368357,
                 2343545681983462,
                 447733118757825,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1287181461435438,
                 622722465530711,
                 880952150571872,
                 741035693459198,
                 311565274989772,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1003649078149734,
                 545233927396469,
                 1849786171789880,
@@ -6294,21 +6295,21 @@ static ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN: EdwardsBasepointTable = Edwards
 pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsPoint> =
     NafLookupTable8([
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3540182452943730,
                 2497478415033846,
                 2521227595762870,
                 1462984067271729,
                 2389212253076811,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 62697248952638,
                 204681361388450,
                 631292143396476,
                 338455783676468,
                 1213667448819585,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 301289933810280,
                 1259582250014073,
                 1422107436869536,
@@ -6317,21 +6318,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1601611775252272,
                 1720807796594148,
                 1132070835939856,
                 3512254832574799,
                 2147779492816910,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 316559037616741,
                 2177824224946892,
                 1459442586438991,
                 1461528397712656,
                 751590696113597,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1850748884277385,
                 1200145853858453,
                 1068094770532492,
@@ -6340,21 +6341,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 769950342298400,
                 2384754244604994,
                 3095885746880802,
                 3225892188161580,
                 2977876099231263,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 425251763115706,
                 608463272472562,
                 442562545713235,
                 837766094556764,
                 374555092627893,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1086255230780037,
                 274979815921559,
                 1960002765731872,
@@ -6363,21 +6364,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2916800678241215,
                 2065379846933858,
                 2622030924071124,
                 2602788184473875,
                 1233371373142984,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 2019367628972465,
                 676711900706637,
                 110710997811333,
                 1108646842542025,
                 517791959672113,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 965130719900578,
                 247011430587952,
                 526356006571389,
@@ -6386,21 +6387,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1802695059464988,
                 1664899123557221,
                 2845359304426105,
                 2160434469266658,
                 3179370264440279,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1725674970513508,
                 1933645953859181,
                 1542344539275782,
                 1767788773573747,
                 1297447965928905,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1381809363726107,
                 1430341051343062,
                 2061843536018959,
@@ -6409,21 +6410,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 4222693909998302,
                 2779866139518454,
                 1619374932191226,
                 2207306624415883,
                 1169170329061080,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 2070390218572616,
                 1458919061857835,
                 624171843017421,
                 1055332792707765,
                 433987520732508,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 893653801273833,
                 1168026499324677,
                 1242553501121234,
@@ -6432,21 +6433,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2465253816303469,
                 3191571337672685,
                 1159882208056013,
                 2569188183312765,
                 621213314200686,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1971678598905747,
                 338026507889165,
                 762398079972271,
                 655096486107477,
                 42299032696322,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 177130678690680,
                 1754759263300204,
                 1864311296286618,
@@ -6455,21 +6456,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1913163449625248,
                 2712579013977241,
                 2193883288642313,
                 1008900146920800,
                 1721983679009502,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1070401523076875,
                 1272492007800961,
                 1910153608563310,
                 2075579521696771,
                 1191169788841221,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 692896803108118,
                 500174642072499,
                 2068223309439677,
@@ -6478,21 +6479,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1819621230288238,
                 2735700366193240,
                 1755134670739586,
                 3080648199451191,
                 4172807995775876,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 992069868904071,
                 799011518185730,
                 1777586403832768,
                 1134820506145684,
                 1999461475558530,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 425204543703124,
                 2040469794090382,
                 1651690622153809,
@@ -6501,21 +6502,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2105824306960939,
                 1387520302709358,
                 3633176580451016,
                 2211816663841753,
                 1629085891776489,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1485201376284999,
                 1022406647424656,
                 504181009209019,
                 962621520820995,
                 590876713147230,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 265873406365287,
                 1192742653492898,
                 88553098803050,
@@ -6524,21 +6525,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3552316659826612,
                 1254279525791875,
                 1609927932077699,
                 3578654071679972,
                 3750681296069893,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 37186803519861,
                 1404297334376301,
                 578519728836650,
                 1740727951192592,
                 2095534282477028,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 833234263154399,
                 2023862470013762,
                 1854137933982069,
@@ -6547,21 +6548,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3679150557957763,
                 1319179453661745,
                 497496853611112,
                 2665464286942351,
                 1208137952365560,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1654513078530905,
                 907489875842908,
                 126098711296368,
                 1726320004173677,
                 28269495058173,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 114436686957443,
                 532739313025996,
                 115428841215897,
@@ -6570,21 +6571,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1111146849833253,
                 2016430049079759,
                 1860522747477948,
                 3537164738290194,
                 4137142824844184,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 429069864577128,
                 975327637149449,
                 237881983565075,
                 1654761232378630,
                 2122527599091807,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 2093793463548278,
                 754827233241879,
                 1420389751719629,
@@ -6593,21 +6594,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 676293365438898,
                 2850296017886344,
                 1205350322490195,
                 2763699392265669,
                 2133931188538142,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 48340340349120,
                 1299261101494832,
                 1137329686775218,
                 1534848106674340,
                 1351662218216799,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1904520614137939,
                 1590301001714014,
                 215781420985270,
@@ -6616,21 +6617,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2365217962409710,
                 2061307169694064,
                 1887478590157603,
                 2169639621284316,
                 2373810867477200,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1020052624656948,
                 1260412094216707,
                 366721640607121,
                 585331442306596,
                 345876457758061,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 975390299880933,
                 1066555195234642,
                 12651997758352,
@@ -6639,21 +6640,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1431537716602643,
                 2024827957433813,
                 3746434518400495,
                 1087794891033550,
                 2156817571680455,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 929288033346881,
                 255179964546973,
                 711057989588035,
                 208899572612840,
                 185348357387383,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 823689746424808,
                 47266130989546,
                 209403309368097,
@@ -6662,21 +6663,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2311213117823762,
                 3296668540922318,
                 2004276520649823,
                 1861500579441125,
                 3148029033359833,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1563693677475261,
                 1843782073741194,
                 1950700654453170,
                 911540858113949,
                 2085151496302359,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1427880892005482,
                 106216431121745,
                 42608394782284,
@@ -6685,21 +6686,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3544335535746750,
                 2367994491347456,
                 2567261456502612,
                 1854058085060971,
                 2263545563461076,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 787426011300053,
                 2105981035769060,
                 1130476291127206,
                 1748659348100075,
                 53470983013756,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 553548273865386,
                 5927805718390,
                 65184587381926,
@@ -6708,21 +6709,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 993787326657446,
                 3868807161609258,
                 1615796046728943,
                 2514644292681953,
                 2059021068660907,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 251010270518880,
                 1681684095763484,
                 1521949356387564,
                 431593457045116,
                 1855308922422910,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 618490909691959,
                 1257497595618257,
                 202952467594088,
@@ -6731,21 +6732,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1673474571932262,
                 2409784519770613,
                 2636095316260487,
                 2761112584601925,
                 3333713288149876,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1600640202645197,
                 1019569075331823,
                 1041916487915822,
                 1680448171313267,
                 2126903137527901,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 894964745143659,
                 106116880092678,
                 1009869382959477,
@@ -6754,21 +6755,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1765281781276487,
                 2863247187455184,
                 2589075472439062,
                 1386435905543054,
                 2182338478845320,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1144730936996693,
                 2213315231278180,
                 1489676672185125,
                 665039429138074,
                 1131283313040268,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 2004734176670602,
                 1738311085075235,
                 418866995976618,
@@ -6777,21 +6778,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2185209688340293,
                 1309276076461009,
                 2514740038571278,
                 3994889904012999,
                 3018098826231021,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1405936970888515,
                 1754621155316654,
                 1211862168554999,
                 1813045702919083,
                 997853418197172,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 82037622045021,
                 1646398333621944,
                 613095452763466,
@@ -6800,21 +6801,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2389287991277873,
                 403851022333257,
                 1597473361477193,
                 2953351602509212,
                 2135174663049062,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1826548187201150,
                 302299893734126,
                 1475477168615781,
                 842617616347376,
                 1438600873676130,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 663049852468609,
                 1649295727846569,
                 1048009692742781,
@@ -6823,21 +6824,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1795645928096646,
                 306878154408959,
                 2924901319092394,
                 2801261341654799,
                 1653782432983523,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 2077597317438627,
                 212642017882064,
                 674844477518888,
                 875487498687554,
                 2060550250171182,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1420448018683809,
                 1032663994771382,
                 1341927003385267,
@@ -6846,21 +6847,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1082660122598844,
                 2545055705583789,
                 3888919679589007,
                 1670283344995811,
                 3403239134794618,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 90430593339788,
                 1838338032241275,
                 571293238480915,
                 1639938867416883,
                 257378872001111,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1528535658865034,
                 1516636853043960,
                 787000569996728,
@@ -6869,21 +6870,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 811329918113934,
                 2783463529007378,
                 1769095754634835,
                 2970819621866866,
                 881037178164325,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1784566501964517,
                 433890943689325,
                 1186055625589419,
                 1496077405487512,
                 1731807117886548,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 424909811816304,
                 1355993963741797,
                 409606483251841,
@@ -6892,21 +6893,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2478728492077816,
                 2780289048655501,
                 2328687177473769,
                 4107341333582032,
                 1316147724308250,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1617420574301156,
                 1741273341070467,
                 667135503486508,
                 2100436564640123,
                 1032223920000865,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1753947659404033,
                 247279202390193,
                 1819288880178945,
@@ -6915,21 +6916,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1762568490530034,
                 673742465299012,
                 2054571050635888,
                 2040165159255111,
                 3040123733327257,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1627187989987422,
                 1686331580821752,
                 1309895873498183,
                 719718719104086,
                 300063199808722,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 238176707016164,
                 1440454788877048,
                 203336037573144,
@@ -6938,21 +6939,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1895216760098480,
                 1934324337975022,
                 3677350688973167,
                 2536415965456176,
                 714678003308640,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 508185358728815,
                 1691320535341855,
                 2168887448239256,
                 1035124393070661,
                 1936603999698584,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 390562831571647,
                 1390223890708972,
                 1383183990676371,
@@ -6961,21 +6962,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3747620842612921,
                 2081794785291195,
                 3284594056262745,
                 2090090346797895,
                 2581692978935809,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 244144781251265,
                 1290834426417077,
                 1888701171101942,
                 1233922456644870,
                 241117402207491,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1266169390045455,
                 1148042013187970,
                 878921907853942,
@@ -6984,21 +6985,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2521768507305118,
                 953557056811112,
                 2015863732865770,
                 1358382511861315,
                 2835421647899992,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 2239837206240498,
                 330928973149665,
                 422268062913642,
                 1481280019493032,
                 619879520439841,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1360166735366017,
                 1770556573948510,
                 1395061284191031,
@@ -7007,21 +7008,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2611794802645686,
                 707234844948070,
                 1314059396506491,
                 2919250341703934,
                 2161831667832785,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 934831784182383,
                 433734253968318,
                 1660867106725771,
                 1968393082772831,
                 873946300968490,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 26306827827554,
                 430884999378685,
                 1504310424376419,
@@ -7030,21 +7031,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1762131062631725,
                 3123952634417535,
                 3619918390837537,
                 2909990877347294,
                 1411594230004385,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 538272372224622,
                 1425714779586199,
                 588313661410172,
                 1497062084392578,
                 1602174047128512,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 907490361939255,
                 1963620338391363,
                 626927432296975,
@@ -7053,21 +7054,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1335066153744413,
                 2887804660779657,
                 2653073855954038,
                 2765226981667422,
                 938831784476763,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 296699434737224,
                 2047543711075683,
                 2076451038937139,
                 227783599906901,
                 1602062110967627,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1574834773194203,
                 1384279952062839,
                 393652417255803,
@@ -7076,21 +7077,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1619646774410947,
                 1576090644023562,
                 3035228391320965,
                 1735328519940543,
                 2355324535937066,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1024074573633446,
                 957088456885874,
                 1690425531356997,
                 2102187380180052,
                 1082544623222033,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1871906170635853,
                 1719383891167200,
                 1584032250247862,
@@ -7099,21 +7100,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 642147846489775,
                 3334304977145699,
                 305205716788147,
                 2589176626729533,
                 2224680511484174,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1734162377166545,
                 260713621840346,
                 157174591942595,
                 952544272517991,
                 222818702471733,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1213115494182947,
                 286778704335711,
                 2130189536016490,
@@ -7122,21 +7123,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3360052266973635,
                 1843486583624091,
                 1561693837124349,
                 1084041964025479,
                 1866270922024009,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 460705465481210,
                 1968151453817859,
                 497005926994844,
                 625618055866751,
                 2176893440866887,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1655800250476757,
                 2036588542300609,
                 666447448675243,
@@ -7145,21 +7146,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2245948203759141,
                 1058306669699396,
                 1452898014240582,
                 3961024141962768,
                 1633235287338608,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 986647273684279,
                 1507266907811370,
                 1260572633649005,
                 2071672342077446,
                 695976026010857,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1312356620823495,
                 1635278548098567,
                 901946076841033,
@@ -7168,21 +7169,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2313723935779695,
                 1506054666773895,
                 996040223525031,
                 636592914999692,
                 1497801917020297,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 292042016419794,
                 1158932298133044,
                 2062611870323738,
                 1946058478962569,
                 1749165808126286,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 654683942212830,
                 1526897351349087,
                 2006818439922838,
@@ -7191,21 +7192,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3015041017808905,
                 2951823141773809,
                 2584865668253675,
                 2508192032998563,
                 2582137700042019,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1628123495344283,
                 2072923641214546,
                 1647225812023982,
                 855655925244679,
                 1758126430071140,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1615895096489599,
                 275295258643784,
                 937665541219916,
@@ -7214,21 +7215,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1603070202850694,
                 2072127623773242,
                 1692648737212158,
                 2493373404187852,
                 1248948672117105,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 11167836031898,
                 596565174397990,
                 2196351068723859,
                 314744641791907,
                 1102014997250781,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1409047922401191,
                 69960384467966,
                 688103515547600,
@@ -7237,21 +7238,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1986083055103168,
                 691715819340300,
                 1361811659746933,
                 3459052030333434,
                 1063594696046061,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1201987338414749,
                 2198784582460616,
                 1203335513981498,
                 489243077045066,
                 2205278143582433,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 2034744376624534,
                 2077387101466387,
                 148448542974969,
@@ -7260,21 +7261,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 472016956315960,
                 720786972252993,
                 2840633661190043,
                 3150798753357827,
                 2816563335499153,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 253464247569755,
                 168314237403057,
                 511780806170295,
                 1058862316549135,
                 1646858476817137,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 595092995922219,
                 1491311840717691,
                 291581784452778,
@@ -7283,21 +7284,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3483137021572755,
                 1526955102024322,
                 2778006642704458,
                 457549634924205,
                 1097420237736736,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1246991699537710,
                 81367319519439,
                 530844036072196,
                 163656863755855,
                 1950742455979290,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 191532664076407,
                 539378506082089,
                 1021612562876554,
@@ -7306,21 +7307,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 4144620731387879,
                 590179521333342,
                 4034023318016108,
                 2255745030335426,
                 2699746851701250,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 2206599697359952,
                 553895797384417,
                 181689161933786,
                 1153123447919104,
                 778568064152659,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1706307000059211,
                 1885601289314487,
                 889758608505788,
@@ -7329,21 +7330,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3210197754285058,
                 2048500453422630,
                 3403309827888207,
                 927154428508963,
                 4199813798872019,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 992058915374933,
                 476120535358775,
                 1973648780784340,
                 2025282643598818,
                 2182318983793230,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1343440812005821,
                 1316045839091795,
                 1884951299078063,
@@ -7352,21 +7353,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3129247779382818,
                 4415026969054274,
                 1900265885969643,
                 1528796215447059,
                 2172730393748688,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1773355092297603,
                 64654329538271,
                 1332124041660957,
                 748492100858001,
                 895500006200535,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 2000840647851980,
                 546565968824914,
                 420633283457524,
@@ -7375,21 +7376,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 743138980705446,
                 3411117504637167,
                 2591389959690621,
                 2380042066577202,
                 3022267940115114,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 165947002229363,
                 115186103724967,
                 1068573292121517,
                 1842565776920938,
                 1969395681111987,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 553322266190633,
                 234265665613185,
                 484544650202821,
@@ -7398,21 +7399,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2581954631514051,
                 1245093644265357,
                 3537016673825374,
                 1834216551713857,
                 923978372152807,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1855378315339552,
                 890045579230758,
                 1764718173975590,
                 197904186055854,
                 1718129022310327,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1278162928734862,
                 1894118254109862,
                 987503995465517,
@@ -7421,21 +7422,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1996603431230215,
                 1191888797552937,
                 1207440075928499,
                 2765853449051137,
                 2525314961343288,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 808903879370889,
                 990820108751280,
                 1084429472258867,
                 1078562781312589,
                 254514692695625,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 615855140068469,
                 586046731175395,
                 693470779212674,
@@ -7444,21 +7445,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3344544372023708,
                 720386671449874,
                 2480841360702110,
                 2036034126860286,
                 2015744690201389,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1337446193390478,
                 1984110761311871,
                 746489405020285,
                 407347127604128,
                 1740475330360596,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 140840424783613,
                 1063284623568331,
                 1136446106453878,
@@ -7467,21 +7468,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2330781679120937,
                 376801425148230,
                 2032603686676107,
                 1488926293635130,
                 1317278311532959,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1290116731380016,
                 2166899563471713,
                 831997001838078,
                 870954980505220,
                 2108537278055823,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1912719171026343,
                 846194720551034,
                 2043988124740726,
@@ -7490,21 +7491,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2651184584992902,
                 2775702557638963,
                 2539786009779572,
                 2575974880015305,
                 2122619079836732,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1154054290132562,
                 931753998725577,
                 1647742001778052,
                 865765466488226,
                 1083816107290025,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 986341121095108,
                 1522330369638573,
                 1990880546211047,
@@ -7513,21 +7514,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1496414019192687,
                 3991034436173951,
                 3380311659062196,
                 2854747485359158,
                 3346958036643152,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 805612068303425,
                 1891790027761335,
                 1587008567571549,
                 722120737390201,
                 378156757163816,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1588994517921951,
                 977362751042302,
                 1329302387067714,
@@ -7536,21 +7537,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2490539421551682,
                 1985699850375015,
                 2331762317128172,
                 4145097393776678,
                 2521049460190674,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 615817553313996,
                 2245962768078178,
                 482564324326173,
                 2101336843140780,
                 1240914880829407,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1438242482238189,
                 874267817785463,
                 1620810389770625,
@@ -7559,21 +7560,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 2403083624110300,
                 2548561409802975,
                 2492699136535911,
                 2358289519456539,
                 3203964320363148,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1913986535403097,
                 1977163223054199,
                 1972905914623196,
                 1650122133472502,
                 1905849310819035,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 858174816360838,
                 614595356564037,
                 1099584959044836,
@@ -7582,21 +7583,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3666695924830668,
                 3585640662737501,
                 2372994528684236,
                 2628565977288995,
                 3482812783469694,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1994161359147952,
                 2198039369802658,
                 62790022842537,
                 1522306785848169,
                 951223194802833,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 852296621440717,
                 431889737774209,
                 370755457746189,
@@ -7605,21 +7606,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1794955764684156,
                 2586904290013612,
                 1322647643615887,
                 856117964085888,
                 2652432778663153,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 933592377399646,
                 78031722952813,
                 926049890685253,
                 1471649501316246,
                 33789909190376,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1479319468832059,
                 203906207621608,
                 659828362330083,
@@ -7628,21 +7629,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1592342143350813,
                 3227219208247713,
                 2345240352078765,
                 2577750109932929,
                 2933512841197243,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 2184946892642995,
                 1517382324576002,
                 1557940277419806,
                 2170635134813213,
                 747314658627002,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1823193620577742,
                 1135817878516419,
                 1731253819308581,
@@ -7651,21 +7652,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1346190246005805,
                 2052692552023851,
                 1718128041785940,
                 2491557332978474,
                 3474370880388305,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 424776012994573,
                 281050757243423,
                 626466040846420,
                 990194703866532,
                 38571969885982,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 192408346595466,
                 1054889725292349,
                 584097975693004,
@@ -7674,21 +7675,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3169895788615063,
                 3503097743181446,
                 601598510029975,
                 1422812237223371,
                 2121009661378329,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1603348391996783,
                 2066143816131699,
                 1789627290363958,
                 2145705961178118,
                 1985578641438222,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 352633958653380,
                 856927627345554,
                 793925083122702,
@@ -7697,21 +7698,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1756866499986349,
                 911731956999969,
                 2707505543214075,
                 4006920335263786,
                 822501008147910,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1094036422864347,
                 1897208881572508,
                 1503607738246960,
                 1901060196071406,
                 294068411105729,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 587776484399576,
                 1116861711228807,
                 343398777436088,
@@ -7720,21 +7721,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 3477749685790410,
                 267997399528836,
                 2953780922004404,
                 3252368924080907,
                 3787792887348381,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 2042368155872443,
                 41662387210459,
                 1676313264498480,
                 1333968523426810,
                 1765708383352310,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1453394896690938,
                 1585795827439909,
                 1469309456804303,
@@ -7743,21 +7744,21 @@ pub(crate) const AFFINE_ODD_MULTIPLES_OF_BASEPOINT: NafLookupTable8<AffineNielsP
             ]),
         },
         AffineNielsPoint {
-            y_plus_x: FieldElement51([
+            y_plus_x: FieldElement51::from_limbs([
                 1810069207599881,
                 1358344669503239,
                 1989371257548167,
                 2316270051121225,
                 3019675451276507,
             ]),
-            y_minus_x: FieldElement51([
+            y_minus_x: FieldElement51::from_limbs([
                 1866114438287676,
                 1663420339568364,
                 1437691317033088,
                 538298302628038,
                 1212711449614363,
             ]),
-            xy2d: FieldElement51([
+            xy2d: FieldElement51::from_limbs([
                 1769235035677897,
                 1562012115317882,
                 31277513664750,

--- a/curve25519-dalek/src/backend/serial/u64/field.rs
+++ b/curve25519-dalek/src/backend/serial/u64/field.rs
@@ -255,12 +255,16 @@ impl ConditionallySelectable for FieldElement51 {
 }
 
 impl FieldElement51 {
+    pub(crate) const fn from_limbs(limbs: [u64; 5]) -> FieldElement51 {
+        FieldElement51(limbs)
+    }
+
     /// The scalar \\( 0 \\).
-    pub const ZERO: FieldElement51 = FieldElement51([0, 0, 0, 0, 0]);
+    pub const ZERO: FieldElement51 = FieldElement51::from_limbs([0, 0, 0, 0, 0]);
     /// The scalar \\( 1 \\).
-    pub const ONE: FieldElement51 = FieldElement51([1, 0, 0, 0, 0]);
+    pub const ONE: FieldElement51 = FieldElement51::from_limbs([1, 0, 0, 0, 0]);
     /// The scalar \\( -1 \\).
-    pub const MINUS_ONE: FieldElement51 = FieldElement51([
+    pub const MINUS_ONE: FieldElement51 = FieldElement51::from_limbs([
         2251799813685228,
         2251799813685247,
         2251799813685247,


### PR DESCRIPTION
I have an outstanding PR that proposes some breaking changes to fiat-crypto, see mit-plv/fiat-crypto#1623. Briefly, it introduces new structures to replace different type aliases for each field element representation. Encoding this in the type system is intended to prevent misuse of functions that require "tight" preconditions on their inputs' ranges. I'm opening this PR for a future crate upgrade early, with a `[patch.crates-io]` stanza, to test out the breaking change, and for temporary use in fiat-crypto's integration tests. If this looks good, I can back out the patch stanza when `fiat-crypto` is released and mark it ready for review.