### PR TITLE
curve: add `doc(hidden)` to serial backend modules

### DIFF
--- a/curve25519-dalek/src/backend/serial/mod.rs
+++ b/curve25519-dalek/src/backend/serial/mod.rs
@@ -24,17 +24,21 @@ cfg_if! {
     if #[cfg(curve25519_dalek_backend = "fiat")] {
 
         #[cfg(curve25519_dalek_bits = "32")]
+        #[doc(hidden)]
         pub mod fiat_u32;
 
         #[cfg(curve25519_dalek_bits = "64")]
+        #[doc(hidden)]
         pub mod fiat_u64;
 
     } else {
 
         #[cfg(curve25519_dalek_bits = "32")]
+        #[doc(hidden)]
         pub mod u32;
 
         #[cfg(curve25519_dalek_bits = "64")]
+        #[doc(hidden)]
         pub mod u64;
 
     }


### PR DESCRIPTION
We have a lot of backend types leaking via the public API, including e.g. `FieldElement51`:

https://docs.rs/curve25519-dalek/latest/curve25519_dalek/backend/serial/u64/field/struct.FieldElement51.html

At the very least, these types shouldn't be visible in the rustdoc.

This PR hides them from the docs, but ideally we would hide them completely from the public API (which might technically be considered a breaking change, but IMO leaking them at all is a bug).