### PR TITLE
Allow viewing secret as byte array

### DIFF
--- a/x25519-dalek/src/x25519.rs
+++ b/x25519-dalek/src/x25519.rs
@@ -103,7 +103,21 @@ impl EphemeralSecret {
     pub fn random() -> Self {
         Self::random_from_rng(rand_core::OsRng)
     }
+
+    /// View this key as a byte array.
+     #[inline]
+     pub fn as_bytes(&self) -> &[u8; 32] {
+         &self.0
+     }
 }
+
+impl AsRef<[u8]> for EphemeralSecret {
+     /// View this private key as a byte array.
+     #[inline]
+     fn as_ref(&self) -> &[u8] {
+         self.as_bytes()
+     }
+ }
 
 impl<'a> From<&'a EphemeralSecret> for PublicKey {
     /// Given an x25519 [`EphemeralSecret`] key, compute its corresponding [`PublicKey`].


### PR DESCRIPTION
This will make it possible to view the secret as byte array which can be handy when printing contents for "debug" purposes via crates such as https://crates.io/crates/pretty-hex