### PR TITLE
Add PrimeFieldBits support to Scalar

### DIFF
--- a/curve25519-dalek/CHANGELOG.md
+++ b/curve25519-dalek/CHANGELOG.md
@@ -5,6 +5,10 @@ major series.
 
 ## 4.x series
 
+### Unreleased
+
+* Add implementation for `PrimeFieldBits`, behind the `group-bits` feature flag.
+
 ### 4.1.0
 
 * Add arbitrary integer multiplication with `MontgomeryPoint::mul_bits_be`

--- a/curve25519-dalek/Cargo.toml
+++ b/curve25519-dalek/Cargo.toml
@@ -48,7 +48,7 @@ required-features = ["alloc", "rand_core"]
 
 [dependencies]
 cfg-if = "1"
-group = { version = "0.13", default-features = false, optional = true }
+group = { version = "0.13", default-features = false, features = ["bits"], optional = true }
 rand_core = { version = "0.6.4", default-features = false, optional = true }
 digest = { version = "0.10", default-features = false, optional = true }
 subtle = { version = "2.3.0", default-features = false }

--- a/curve25519-dalek/Cargo.toml
+++ b/curve25519-dalek/Cargo.toml
@@ -27,7 +27,7 @@ rustdoc-args = [
     "--html-in-header", "docs/assets/rustdoc-include-katex-header.html",
     "--cfg", "docsrs",
 ]
-features = ["serde", "rand_core", "digest", "legacy_compatibility", "group"]
+features = ["serde", "rand_core", "digest", "legacy_compatibility", "group-bits"]
 
 [dev-dependencies]
 sha2 = { version = "0.10", default-features = false }
@@ -48,7 +48,7 @@ required-features = ["alloc", "rand_core"]
 
 [dependencies]
 cfg-if = "1"
-ff = { version = "0.13", default-features = false, features = ["bits"], optional = true }
+ff = { version = "0.13", default-features = false, optional = true }
 group = { version = "0.13", default-features = false, optional = true }
 rand_core = { version = "0.6.4", default-features = false, optional = true }
 digest = { version = "0.10", default-features = false, optional = true }
@@ -68,6 +68,7 @@ alloc = ["zeroize?/alloc"]
 precomputed-tables = []
 legacy_compatibility = []
 group = ["dep:group", "rand_core"]
+group-bits = ["group", "ff/bits"]
 
 [target.'cfg(all(not(curve25519_dalek_backend = "fiat"), not(curve25519_dalek_backend = "serial"), target_arch = "x86_64"))'.dependencies]
 curve25519-dalek-derive = { version = "0.1", path = "../curve25519-dalek-derive" }

--- a/curve25519-dalek/Cargo.toml
+++ b/curve25519-dalek/Cargo.toml
@@ -48,7 +48,8 @@ required-features = ["alloc", "rand_core"]
 
 [dependencies]
 cfg-if = "1"
-group = { version = "0.13", default-features = false, features = ["bits"], optional = true }
+ff = { version = "0.13", default-features = false, features = ["bits"], optional = true }
+group = { version = "0.13", default-features = false, optional = true }
 rand_core = { version = "0.6.4", default-features = false, optional = true }
 digest = { version = "0.10", default-features = false, optional = true }
 subtle = { version = "2.3.0", default-features = false }

--- a/curve25519-dalek/src/scalar.rs
+++ b/curve25519-dalek/src/scalar.rs
@@ -1330,10 +1330,7 @@ impl PrimeFieldBits for Scalar {
   }
 
   fn char_le_bits() -> FieldBits<Self::ReprBits> {
-    let mut bytes = (Scalar::ZERO - Scalar::ONE).to_repr();
-    bytes[0] += 1;
-    debug_assert_eq!(DScalar::from_bytes_mod_order(bytes), DScalar::ZERO);
-    bytes.into()
+    constants::BASEPOINT_ORDER.to_bytes().into()
   }
 }
 

--- a/curve25519-dalek/src/scalar.rs
+++ b/curve25519-dalek/src/scalar.rs
@@ -126,7 +126,7 @@ use cfg_if::cfg_if;
 
 #[cfg(feature = "group")]
 use {
-    group::ff::{Field, FromUniformBytes, PrimeField, PrimeFieldBits},
+    group::ff::{Field, FromUniformBytes, PrimeField, FieldBits, PrimeFieldBits},
     rand_core::RngCore,
 };
 
@@ -1323,15 +1323,15 @@ impl PrimeField for Scalar {
 
 #[cfg(feature = "group")]
 impl PrimeFieldBits for Scalar {
-  type ReprBits = [u8; 32];
+    type ReprBits = [u8; 32];
 
-  fn to_le_bits(&self) -> FieldBits<Self::ReprBits> {
-    self.to_repr().into()
-  }
+    fn to_le_bits(&self) -> FieldBits<Self::ReprBits> {
+        self.to_repr().into()
+    }
 
-  fn char_le_bits() -> FieldBits<Self::ReprBits> {
-    constants::BASEPOINT_ORDER.to_bytes().into()
-  }
+    fn char_le_bits() -> FieldBits<Self::ReprBits> {
+        constants::BASEPOINT_ORDER.to_bytes().into()
+    }
 }
 
 #[cfg(feature = "group")]

--- a/curve25519-dalek/src/scalar.rs
+++ b/curve25519-dalek/src/scalar.rs
@@ -126,7 +126,7 @@ use cfg_if::cfg_if;
 
 #[cfg(feature = "group")]
 use {
-    group::ff::{Field, FromUniformBytes, PrimeField, FieldBits, PrimeFieldBits},
+    group::ff::{Field, FieldBits, FromUniformBytes, PrimeField, PrimeFieldBits},
     rand_core::RngCore,
 };
 

--- a/curve25519-dalek/src/scalar.rs
+++ b/curve25519-dalek/src/scalar.rs
@@ -1332,7 +1332,7 @@ impl PrimeFieldBits for Scalar {
     }
 
     fn char_le_bits() -> FieldBits<Self::ReprBits> {
-        constants::BASEPOINT_ORDER.to_bytes().into()
+        constants::BASEPOINT_ORDER_PRIVATE.to_bytes().into()
     }
 }
 

--- a/curve25519-dalek/src/scalar.rs
+++ b/curve25519-dalek/src/scalar.rs
@@ -126,7 +126,7 @@ use cfg_if::cfg_if;
 
 #[cfg(feature = "group")]
 use {
-    group::ff::{Field, FromUniformBytes, PrimeField},
+    group::ff::{Field, FromUniformBytes, PrimeField, PrimeFieldBits},
     rand_core::RngCore,
 };
 
@@ -1319,6 +1319,22 @@ impl PrimeField for Scalar {
             0, 0, 0,
         ],
     };
+}
+
+#[cfg(feature = "group")]
+impl PrimeFieldBits for Scalar {
+  type ReprBits = [u8; 32];
+
+  fn to_le_bits(&self) -> FieldBits<Self::ReprBits> {
+    self.to_repr().into()
+  }
+
+  fn char_le_bits() -> FieldBits<Self::ReprBits> {
+    let mut bytes = (Scalar::ZERO - Scalar::ONE).to_repr();
+    bytes[0] += 1;
+    debug_assert_eq!(DScalar::from_bytes_mod_order(bytes), DScalar::ZERO);
+    bytes.into()
+  }
 }
 
 #[cfg(feature = "group")]

--- a/curve25519-dalek/src/scalar.rs
+++ b/curve25519-dalek/src/scalar.rs
@@ -124,9 +124,11 @@ use core::ops::{Sub, SubAssign};
 
 use cfg_if::cfg_if;
 
+#[cfg(feature = "group-bits")]
+use group::ff::{FieldBits, PrimeFieldBits};
 #[cfg(feature = "group")]
 use {
-    group::ff::{Field, FieldBits, FromUniformBytes, PrimeField, PrimeFieldBits},
+    group::ff::{Field, FromUniformBytes, PrimeField},
     rand_core::RngCore,
 };
 
@@ -1321,7 +1323,7 @@ impl PrimeField for Scalar {
     };
 }
 
-#[cfg(feature = "group")]
+#[cfg(feature = "group-bits")]
 impl PrimeFieldBits for Scalar {
     type ReprBits = [u8; 32];
 


### PR DESCRIPTION
The char_le_bits function is a hack I don't legitimately recommend. I just felt it'd be better to make a PR, which works, than to solely file an issue requesting it as a feature.