### PR TITLE
Deprecate `BASEPOINT_ORDER` from pub API consts

### DIFF
--- a/curve25519-dalek/CHANGELOG.md
+++ b/curve25519-dalek/CHANGELOG.md
@@ -5,6 +5,10 @@ major series.
 
 ## 4.x series
 
+### Unreleased
+
+* Mark `constants::BASEPOINT_ORDER` deprecated from pub API from 5.0.0
+
 ### 4.1.0
 
 * Add arbitrary integer multiplication with `MontgomeryPoint::mul_bits_be`

--- a/curve25519-dalek/CHANGELOG.md
+++ b/curve25519-dalek/CHANGELOG.md
@@ -5,9 +5,9 @@ major series.
 
 ## 4.x series
 
-### Unreleased
+### 4.1.1
 
-* Mark `constants::BASEPOINT_ORDER` deprecated from pub API from 5.0.0
+* Mark `constants::BASEPOINT_ORDER` deprecated from pub API
 
 ### 4.1.0
 

--- a/curve25519-dalek/src/constants.rs
+++ b/curve25519-dalek/src/constants.rs
@@ -8,24 +8,7 @@
 // Authors:
 // - isis agora lovecruft <isis@patternsinthevoid.net>
 // - Henry de Valence <hdevalence@hdevalence.ca>
-
 //! Various constants, such as the Ristretto and Ed25519 basepoints.
-//!
-//! Most of the constants are given with
-//! `LONG_DESCRIPTIVE_UPPER_CASE_NAMES`, but they can be brought into
-//! scope using a `let` binding:
-//!
-#![cfg_attr(feature = "precomputed-tables", doc = "```")]
-#![cfg_attr(not(feature = "precomputed-tables"), doc = "```ignore")]
-//! use curve25519_dalek::constants;
-//! use curve25519_dalek::traits::IsIdentity;
-//!
-//! let B = constants::RISTRETTO_BASEPOINT_TABLE;
-//! let l = &constants::BASEPOINT_ORDER;
-//!
-//! let A = l * B;
-//! assert!(A.is_identity());
-//! ```
 
 #![allow(non_snake_case)]
 
@@ -86,7 +69,10 @@ pub const RISTRETTO_BASEPOINT_POINT: RistrettoPoint = RistrettoPoint(ED25519_BAS
 /// $$
 /// \ell = 2^\{252\} + 27742317777372353535851937790883648493.
 /// $$
-pub const BASEPOINT_ORDER: Scalar = Scalar {
+#[deprecated(since = "5.0.0", note = "Should not have been in public API")]
+pub const BASEPOINT_ORDER: Scalar = BASEPOINT_ORDER_PRIVATE;
+
+pub(crate) const BASEPOINT_ORDER_PRIVATE: Scalar = Scalar {
     bytes: [
         0xed, 0xd3, 0xf5, 0x5c, 0x1a, 0x63, 0x12, 0x58, 0xd6, 0x9c, 0xf7, 0xa2, 0xde, 0xf9, 0xde,
         0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,

--- a/curve25519-dalek/src/constants.rs
+++ b/curve25519-dalek/src/constants.rs
@@ -69,7 +69,7 @@ pub const RISTRETTO_BASEPOINT_POINT: RistrettoPoint = RistrettoPoint(ED25519_BAS
 /// $$
 /// \ell = 2^\{252\} + 27742317777372353535851937790883648493.
 /// $$
-#[deprecated(since = "5.0.0", note = "Should not have been in public API")]
+#[deprecated(since = "4.1.1", note = "Should not have been in public API")]
 pub const BASEPOINT_ORDER: Scalar = BASEPOINT_ORDER_PRIVATE;
 
 pub(crate) const BASEPOINT_ORDER_PRIVATE: Scalar = Scalar {

--- a/curve25519-dalek/src/edwards.rs
+++ b/curve25519-dalek/src/edwards.rs
@@ -1254,7 +1254,7 @@ impl EdwardsPoint {
     /// assert_eq!((P+Q).is_torsion_free(), false);
     /// ```
     pub fn is_torsion_free(&self) -> bool {
-        (self * constants::BASEPOINT_ORDER).is_identity()
+        (self * constants::BASEPOINT_ORDER_PRIVATE).is_identity()
     }
 }
 
@@ -1580,7 +1580,7 @@ impl CofactorGroup for EdwardsPoint {
     }
 
     fn is_torsion_free(&self) -> Choice {
-        (self * constants::BASEPOINT_ORDER).ct_eq(&Self::identity())
+        (self * constants::BASEPOINT_ORDER_PRIVATE).ct_eq(&Self::identity())
     }
 }
 
@@ -1769,7 +1769,7 @@ mod test {
     /// Test that multiplication by the basepoint order kills the basepoint
     #[test]
     fn basepoint_mult_by_basepoint_order() {
-        let should_be_id = EdwardsPoint::mul_base(&constants::BASEPOINT_ORDER);
+        let should_be_id = EdwardsPoint::mul_base(&constants::BASEPOINT_ORDER_PRIVATE);
         assert!(should_be_id.is_identity());
     }
 


### PR DESCRIPTION
Deprecates `BASEPOINT_ORDER` from pub API constants

Redirect internally to avoid deprecation errors