### PR TITLE
ed25519: loosen `signature` crate dependency

### DIFF
--- a/ed25519-dalek/Cargo.toml
+++ b/ed25519-dalek/Cargo.toml
@@ -28,7 +28,7 @@ features = ["batch", "digest", "hazmat", "pem", "serde"]
 [dependencies]
 curve25519-dalek = { version = "4", path = "../curve25519-dalek", default-features = false, features = ["digest"] }
 ed25519 = { version = ">=2.2, <2.3", default-features = false }
-signature = { version = ">=2.0, <2.1", optional = true, default-features = false }
+signature = { version = ">=2.0, <2.2", optional = true, default-features = false }
 sha2 = { version = "0.10", default-features = false }
 subtle = { version = "2.3.0", default-features = false }
 


### PR DESCRIPTION
The `signature` crate contains unstable, minor version-gated functionality.

The v2.1 release did not change any of that, and only added new functionality. So it's safe to relax the requirement for `signature` to `>=2.0, <2.2`.