### PR TITLE
Avoid cargo test -p curve25519-dalek-derive failure on ARM

### DIFF
--- a/curve25519-dalek-derive/README.md
+++ b/curve25519-dalek-derive/README.md
@@ -44,6 +44,7 @@ to build out more elaborate abstractions it starts to become painful to use.
     }
 
     struct AVX;
+    # #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     impl Backend for AVX {
         #[target_feature(enable = "avx")]
         unsafe fn sum(xs: &[u32]) -> u32 {
@@ -53,6 +54,7 @@ to build out more elaborate abstractions it starts to become painful to use.
     }
 
     struct AVX2;
+    # #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     impl Backend for AVX2 {
         #[target_feature(enable = "avx2")]
         unsafe fn sum(xs: &[u32]) -> u32 {
@@ -87,6 +89,7 @@ fn func() {}
 
 ```rust
 // It works, but must be `unsafe`
+# #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[target_feature(enable = "avx2")]
 unsafe fn func() {}
 ```
@@ -95,6 +98,7 @@ unsafe fn func() {}
 use curve25519_dalek_derive::unsafe_target_feature;
 
 // No `unsafe` on the function itself!
+# #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[unsafe_target_feature("avx2")]
 fn func() {}
 ```
@@ -119,6 +123,7 @@ use curve25519_dalek_derive::unsafe_target_feature;
 
 struct S;
 
+# #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[unsafe_target_feature("avx2")]
 impl core::ops::Add for S {
     type Output = S;
@@ -135,6 +140,7 @@ impl core::ops::Add for S {
 ```rust
 use curve25519_dalek_derive::unsafe_target_feature_specialize;
 
+# #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[unsafe_target_feature_specialize("sse2", "avx2", conditional("avx512ifma", nightly))]
 mod simd {
     #[for_target_feature("sse2")]
@@ -149,6 +155,7 @@ mod simd {
     pub fn func() { /* ... */ }
 }
 
+# #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn entry_point() {
     #[cfg(nightly)]
     if std::is_x86_feature_detected!("avx512ifma") {


### PR DESCRIPTION
On a MacBook M1, I noticed `cargo test` in the workspace root fails. It fails due to the references to `#[target_feature(enable = "avx2")]` in the `README.md` for `curve25519-dalek-derive`.

This PR avoids the test failure by adding conditional compile statements on the usages of `target_feature`. `cfg` statements are added as hidden lines in the examples and so they will not appear in `cargo doc`. Hidden lines will appear when looking at the README on GitHub.
