### PR TITLE
CI: fix minimal-versions resolution

### DIFF
--- a/.github/workflows/curve25519-dalek.yml
+++ b/.github/workflows/curve25519-dalek.yml
@@ -134,10 +134,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    # First run `cargo +nightly -Z minimal-verisons check` in order to get a
-    # Cargo.lock with the oldest possible deps
+    # Re-resolve Cargo.lock with minimal versions
     - uses: dtolnay/rust-toolchain@nightly
-    - run: cargo -Z minimal-versions check --no-default-features --features serde
+    - run: cargo update -Z minimal-versions
     # Now check that `cargo build` works with respect to the oldest possible
     # deps and the stated MSRV
     - uses: dtolnay/rust-toolchain@1.60.0

--- a/.github/workflows/ed25519-dalek.yml
+++ b/.github/workflows/ed25519-dalek.yml
@@ -24,10 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-      # Now run `cargo +nightly -Z minimal-verisons check` in order to get a
-      # Cargo.lock with the oldest possible deps
+      # Re-resolve Cargo.lock with minimal versions
     - uses: dtolnay/rust-toolchain@nightly
-    - run: cargo -Z minimal-versions check --no-default-features --features serde
+    - run: cargo update -Z minimal-versions
       # Now check that `cargo build` works with respect to the oldest possible
       # deps and the stated MSRV
     - uses: dtolnay/rust-toolchain@1.60.0

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -85,7 +85,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: dtolnay/rust-toolchain@nightly
+    - uses: dtolnay/rust-toolchain@1.73.0
       with:
         components: clippy
     - run: cargo clippy --target x86_64-unknown-linux-gnu --all-features

--- a/.github/workflows/x25519-dalek.yml
+++ b/.github/workflows/x25519-dalek.yml
@@ -24,10 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-      # Now run `cargo +nightly -Z minimal-verisons check` in order to get a
-      # Cargo.lock with the oldest possible deps
+      # Re-resolve Cargo.lock with minimal versions
     - uses: dtolnay/rust-toolchain@nightly
-    - run: cargo -Z minimal-versions check --no-default-features --features serde
+    - run: cargo update -Z minimal-versions
       # Now check that `cargo build` works with respect to the oldest possible
       # deps and the stated MSRV
     - uses: dtolnay/rust-toolchain@1.60.0


### PR DESCRIPTION
To avoid nightly regressions breaking the build, the CI configuration has been updated to *only* use nightly for resolving Cargo.lock by using `cargo update -Z minimal-versions`.

Previously, it was running `cargo check` which would attempt to compile all of the dependencies and the code, which is why the diagnostic bug was triggered. By avoiding any kind of code compilation using nightly we can avoid such regressions in the future.

Additionally, the clippy job has been changed to run on the latest stable release (1.73.0) rather than nightly, which will prevent future clippy lints from breaking the build. Instead, they can be addressed when clippy is updated.