### PR TITLE
ed25519: loosen `signature` crate dependency again

### DIFF
--- a/ed25519-dalek/Cargo.toml
+++ b/ed25519-dalek/Cargo.toml
@@ -28,7 +28,7 @@ features = ["batch", "digest", "hazmat", "pem", "serde"]
 [dependencies]
 curve25519-dalek = { version = "4", path = "../curve25519-dalek", default-features = false, features = ["digest"] }
 ed25519 = { version = ">=2.2, <2.3", default-features = false }
-signature = { version = ">=2.0, <2.2", optional = true, default-features = false }
+signature = { version = ">=2.0, <2.3", optional = true, default-features = false }
 sha2 = { version = "0.10", default-features = false }
 subtle = { version = "2.3.0", default-features = false }
 


### PR DESCRIPTION
Like #582, there is a new release of `signature` ([v2.2.0](https://crates.io/crates/signature/2.2.0)) which contains no breaking changes from ed25519-dalek's perspective. The main notable one is it bumps MSRV to 1.60, which so also happens to also be ed25519-dalek's MSRV.

This commit loosens the version requirement to allow `>=2.0, <2.3` to allow the `signature` 2.2 series.