### PR TITLE
ed: Prep to release v2.1.0

### DIFF
--- a/ed25519-dalek/CHANGELOG.md
+++ b/ed25519-dalek/CHANGELOG.md
@@ -8,9 +8,12 @@ Entries are listed in reverse chronological order per undeprecated major series.
 
 # Unreleased
 
-* Add `SigningKey::to_scalar_bytes` for getting the unclamped scalar from signing key
-
 # 2.x series
+
+## 2.1.0
+
+* Add `SigningKey::to_scalar_bytes` for getting the unclamped scalar from a signing key
+* Loosened `signature` dependency to allow version 2.2
 
 ##  2.0.0
 

--- a/ed25519-dalek/Cargo.toml
+++ b/ed25519-dalek/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ed25519-dalek"
-version = "2.0.0"
+version = "2.1.0"
 edition = "2021"
 authors = [
     "isis lovecruft <isis@patternsinthevoid.net>",


### PR DESCRIPTION
#598 merits a new release, and #599 added functionality, so we need a minor version bump.