### PR TITLE
{Signing,Verifying}KeyVisitor: visit_borrowed_bytes -> visit_bytes

### DIFF
--- a/ed25519-dalek/src/signing.rs
+++ b/ed25519-dalek/src/signing.rs
@@ -746,10 +746,7 @@ impl<'d> Deserialize<'d> for SigningKey {
                 write!(formatter, concat!("An ed25519 signing (private) key"))
             }
 
-            fn visit_borrowed_bytes<E: serde::de::Error>(
-                self,
-                bytes: &'de [u8],
-            ) -> Result<Self::Value, E> {
+            fn visit_bytes<E: serde::de::Error>(self, bytes: &[u8]) -> Result<Self::Value, E> {
                 SigningKey::try_from(bytes).map_err(E::custom)
             }
 

--- a/ed25519-dalek/src/verifying.rs
+++ b/ed25519-dalek/src/verifying.rs
@@ -636,10 +636,7 @@ impl<'d> Deserialize<'d> for VerifyingKey {
                 write!(formatter, concat!("An ed25519 verifying (public) key"))
             }
 
-            fn visit_borrowed_bytes<E: serde::de::Error>(
-                self,
-                bytes: &'de [u8],
-            ) -> Result<Self::Value, E> {
+            fn visit_bytes<E: serde::de::Error>(self, bytes: &[u8]) -> Result<Self::Value, E> {
                 VerifyingKey::try_from(bytes).map_err(E::custom)
             }
 


### PR DESCRIPTION
This is a slight improvement to the deserialisation code for `SigningKey` and `VerifyingKey`.

The default implementations of `visit_borrowed_bytes` and `visit_byte_buf` [forward to](https://docs.rs/serde/1.0.192/serde/de/trait.Visitor.html#method.visit_borrowed_bytes) `visit_bytes`, but only `visit_borrowed_bytes` was implemented for the `{Signing,Verifying}KeyVisitor`.  This means that `{Signing,Verifying}Key`s can only be deserialised from borrowed byte arrays, but not from [owned or transient byte arrays](https://serde.rs/data-model.html).  Example:

```rust
let bytes = base16ct::lower::decode_vec(
    "66b1419fae979516fb3807dda1b05026b2570a7ab2190254e524af4f0934ddd2",
)
.unwrap();
    
let d = serde::de::value::BorrowedBytesDeserializer::<serde::de::value::Error>::new(&bytes);
ed25519_dalek::VerifyingKey::deserialize(d).unwrap(); // deserialising from a borrowed byte array works
    
let d = serde::de::value::BytesDeserializer::<serde::de::value::Error>::new(&bytes);
ed25519_dalek::VerifyingKey::deserialize(d).unwrap_err(); // but not from a transient byte array
```

Implementing `visit_bytes` instead of `visit_borrowed_bytes` enables deserialisation from all three byte array types.






