### PR TITLE
doc: Fix markdown PR reference

### DIFF
--- a/ed25519-dalek/README.md
+++ b/ed25519-dalek/README.md
@@ -43,7 +43,7 @@ See [CHANGELOG.md](CHANGELOG.md) for a list of changes made in past version of t
 * Make `rand_core` an optional dependency
 * Adopt [curve25519-backend selection](https://github.com/dalek-cryptography/curve25519-dalek/#backends) over features
 * Make all batch verification deterministic remove `batch_deterministic` ([#256](https://github.com/dalek-cryptography/ed25519-dalek/pull/256))
-* Remove `ExpandedSecretKey` API ((#205)[https://github.com/dalek-cryptography/ed25519-dalek/pull/205])
+* Remove `ExpandedSecretKey` API ([#205](https://github.com/dalek-cryptography/ed25519-dalek/pull/205))
 * Rename `Keypair` → `SigningKey` and `PublicKey` → `VerifyingKey`
 * Make `hazmat` feature to expose, `ExpandedSecretKey`, `raw_sign()`, `raw_sign_prehashed()`, `raw_verify()`, and `raw_verify_prehashed()`
 


### PR DESCRIPTION
The markdown formatting was a bit broken (`[` and `(` used in wrong order). This tiny PR fixes it.