### PR TITLE
Unpin zeroize version and update MSRV

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -101,14 +101,14 @@ jobs:
         args: --features "nightly"
 
   msrv:
-    name: Current MSRV is 1.41
+    name: Current MSRV is 1.60
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: 1.41
+        toolchain: 1.60
         override: true
     - uses: actions-rs/cargo@v1
       with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ serde = { version = "1.0", default-features = false, optional = true, features =
 # The original packed_simd package was orphaned, see
 # https://github.com/rust-lang/packed_simd/issues/303#issuecomment-701361161
 packed_simd = { version = "0.3.4", package = "packed_simd_2", features = ["into_bits"], optional = true }
-zeroize = { version = ">=1, <1.4", default-features = false }
+zeroize = { version = "1", default-features = false }
 fiat-crypto = { version = "0.1.6", optional = true}
 
 [features]


### PR DESCRIPTION
It’s been nearly 4 years since the release of Rust 1.41 so there’s no
point in point in keeping such a low MSRV.  Issue #362 which was the
reason for pinning is over two years old.

From issue #388 we know that:

> This is now resolved in the release/4.0 branch. Next release (or
> prerelease) will have a laxer zeroize dependency.

however, not everyone has the luxury of migrating to 4.x.  3.x may be
pulled in through third party dependency whose update plan is unknown.

Meanwhile, pinning zeroize causes build failure as pointed in
aforecited issues as well as shown below:

    error: failed to select a version for `zeroize`.
        ... required by package `der v0.7.8`
        ... which satisfies dependency `der = "^0.7"` (locked to 0.7.8) of package `pkcs8 v0.10.2`
        ... which satisfies dependency `pkcs8 = "^0.10"` (locked to 0.10.2) of package `ed25519 v2.2.3`
        ... which satisfies dependency `ed25519 = "^2"` (locked to 2.2.3) of package `tendermint v0.34.0`
        ... which satisfies dependency `tendermint = "^0.34.0"` (locked to 0.34.0) of package `ibc-testkit v0.48.1`
        ... which satisfies dependency `ibc-testkit = "^0.48.1"` (locked to 0.48.1) of package `…`
    versions that meet the requirements `^1.5` are: 1.7.0, 1.6.0, 1.5.7, 1.5.6, 1.5.5, 1.5.4, 1.5.3

Unpin zeroize crate and update MSRV to 1.60 which is current MSRV of
zeroize and a 20 month old Rust release.
