### PR TITLE
Fix nightly build

### DIFF
--- a/curve25519-dalek/src/lib.rs
+++ b/curve25519-dalek/src/lib.rs
@@ -10,7 +10,10 @@
 // - Henry de Valence <hdevalence@hdevalence.ca>
 
 #![no_std]
-#![cfg_attr(all(curve25519_dalek_backend = "simd", nightly), feature(stdsimd))]
+#![cfg_attr(
+    all(curve25519_dalek_backend = "simd", nightly),
+    feature(stdarch_x86_avx512)
+)]
 #![cfg_attr(
     all(curve25519_dalek_backend = "simd", nightly),
     feature(avx512_target_feature)

--- a/curve25519-dalek/src/lib.rs
+++ b/curve25519-dalek/src/lib.rs
@@ -11,7 +11,7 @@
 
 #![no_std]
 #![cfg_attr(
-    all(curve25519_dalek_backend = "simd", nightly),
+    all(curve25519_dalek_backend = "simd", nightly, any(target_arch = "x86", target_arch = "x86_64")),
     feature(stdarch_x86_avx512)
 )]
 #![cfg_attr(

--- a/curve25519-dalek/src/lib.rs
+++ b/curve25519-dalek/src/lib.rs
@@ -11,7 +11,11 @@
 
 #![no_std]
 #![cfg_attr(
-    all(curve25519_dalek_backend = "simd", nightly, any(target_arch = "x86", target_arch = "x86_64")),
+    all(
+        curve25519_dalek_backend = "simd",
+        nightly,
+        any(target_arch = "x86", target_arch = "x86_64")
+    ),
     feature(stdarch_x86_avx512)
 )]
 #![cfg_attr(


### PR DESCRIPTION
Addresses #618.

This PR fixes the failing build on the latest Rust nightly compiler `rustc 1.78.0-nightly (f067fd608 2024-02-05)`.

The `stdsimd` feature has been split into separate features in the latest Rust nightly compiler and its usage needs to be updated to use `#![feature(stdarch_x86_avx512)]` instead.

See https://github.com/rust-lang/stdarch/pull/1486 and https://github.com/rust-lang/rust/issues/111137.