### PR TITLE
Bump digest and sha2 to pre-release versions

### DIFF
--- a/.github/workflows/curve25519-dalek.yml
+++ b/.github/workflows/curve25519-dalek.yml
@@ -130,7 +130,7 @@ jobs:
       run: cargo test --no-default-features --features alloc,precomputed-tables,zeroize,group-bits --target x86_64-unknown-linux-gnu
 
   msrv:
-    name: Current MSRV is 1.60.0
+    name: Current MSRV is 1.71.0
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -139,7 +139,7 @@ jobs:
     - run: cargo update -Z minimal-versions
     # Now check that `cargo build` works with respect to the oldest possible
     # deps and the stated MSRV
-    - uses: dtolnay/rust-toolchain@1.60.0
+    - uses: dtolnay/rust-toolchain@1.71.0
     - run: cargo build --no-default-features --features serde
     # Also make sure the AVX2 build works
     - run: cargo build --target x86_64-unknown-linux-gnu

--- a/.github/workflows/ed25519-dalek.yml
+++ b/.github/workflows/ed25519-dalek.yml
@@ -20,7 +20,7 @@ env:
 jobs:
 
   msrv:
-    name: Current MSRV is 1.60.0
+    name: Current MSRV is 1.72.0
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -29,5 +29,5 @@ jobs:
     - run: cargo update -Z minimal-versions
       # Now check that `cargo build` works with respect to the oldest possible
       # deps and the stated MSRV
-    - uses: dtolnay/rust-toolchain@1.60.0
+    - uses: dtolnay/rust-toolchain@1.72.0
     - run: cargo build

--- a/.github/workflows/x25519-dalek.yml
+++ b/.github/workflows/x25519-dalek.yml
@@ -20,7 +20,7 @@ env:
 jobs:
 
   msrv:
-    name: Current MSRV is 1.60.0
+    name: Current MSRV is 1.71.0
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -29,5 +29,5 @@ jobs:
     - run: cargo update -Z minimal-versions
       # Now check that `cargo build` works with respect to the oldest possible
       # deps and the stated MSRV
-    - uses: dtolnay/rust-toolchain@1.60.0
+    - uses: dtolnay/rust-toolchain@1.71.0
     - run: cargo build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,5 @@ resolver = "2"
 [profile.dev]
 opt-level = 2
 
+[patch.crates-io]
+ed25519 = { git = "https://github.com/RustCrypto/signatures.git" }

--- a/curve25519-dalek/CHANGELOG.md
+++ b/curve25519-dalek/CHANGELOG.md
@@ -3,6 +3,14 @@
 Entries are listed in reverse chronological order per undeprecated
 major series.
 
+# Unreleased
+
+### 4.2.0-pre
+
+* Update the MSRV from 1.60 to 1.71
+* Update `digest` dependency to `0.11`.
+* Update `sha2` dependency to `0.11`.
+
 ## 4.x series
 
 ### 4.1.2

--- a/curve25519-dalek/Cargo.toml
+++ b/curve25519-dalek/Cargo.toml
@@ -30,7 +30,7 @@ rustdoc-args = [
 features = ["serde", "rand_core", "digest", "legacy_compatibility", "group-bits"]
 
 [dev-dependencies]
-sha2 = { version = "0.10", default-features = false }
+sha2 = { version = "=0.11.0-pre.3", default-features = false }
 bincode = "1"
 criterion = { version = "0.5", features = ["html_reports"] }
 hex = "0.4.2"
@@ -50,7 +50,7 @@ cfg-if = "1"
 ff = { version = "0.13", default-features = false, optional = true }
 group = { version = "0.13", default-features = false, optional = true }
 rand_core = { version = "0.6.4", default-features = false, optional = true }
-digest = { version = "0.10", default-features = false, optional = true }
+digest = { version = "=0.11.0-pre.8", default-features = false, optional = true }
 subtle = { version = "2.3.0", default-features = false }
 serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
 zeroize = { version = "1", default-features = false, optional = true }

--- a/curve25519-dalek/Cargo.toml
+++ b/curve25519-dalek/Cargo.toml
@@ -6,7 +6,7 @@ name = "curve25519-dalek"
 # - if README was updated, also update module documentation in src/lib.rs
 version = "4.2.0-pre"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.71.0"
 authors = ["Isis Lovecruft <isis@patternsinthevoid.net>",
            "Henry de Valence <hdevalence@hdevalence.ca>"]
 readme = "README.md"

--- a/curve25519-dalek/Cargo.toml
+++ b/curve25519-dalek/Cargo.toml
@@ -4,7 +4,7 @@ name = "curve25519-dalek"
 # - update CHANGELOG
 # - update README if required by semver
 # - if README was updated, also update module documentation in src/lib.rs
-version = "4.1.2"
+version = "4.2.0-pre"
 edition = "2021"
 rust-version = "1.60.0"
 authors = ["Isis Lovecruft <isis@patternsinthevoid.net>",

--- a/curve25519-dalek/src/edwards.rs
+++ b/curve25519-dalek/src/edwards.rs
@@ -104,7 +104,7 @@ use core::ops::{Mul, MulAssign};
 use cfg_if::cfg_if;
 
 #[cfg(feature = "digest")]
-use digest::{generic_array::typenum::U64, Digest};
+use digest::{typenum::U64, Digest};
 
 #[cfg(feature = "group")]
 use {

--- a/curve25519-dalek/src/ristretto.rs
+++ b/curve25519-dalek/src/ristretto.rs
@@ -173,7 +173,7 @@ use core::ops::{Mul, MulAssign};
 use rand_core::CryptoRngCore;
 
 #[cfg(feature = "digest")]
-use digest::generic_array::typenum::U64;
+use digest::typenum::U64;
 #[cfg(feature = "digest")]
 use digest::Digest;
 

--- a/curve25519-dalek/src/scalar.rs
+++ b/curve25519-dalek/src/scalar.rs
@@ -134,7 +134,7 @@ use rand_core::RngCore;
 use rand_core::CryptoRngCore;
 
 #[cfg(feature = "digest")]
-use digest::generic_array::typenum::U64;
+use digest::typenum::U64;
 #[cfg(feature = "digest")]
 use digest::Digest;
 

--- a/ed25519-dalek/CHANGELOG.md
+++ b/ed25519-dalek/CHANGELOG.md
@@ -8,6 +8,14 @@ Entries are listed in reverse chronological order per undeprecated major series.
 
 # Unreleased
 
+## 2.2.0-pre
+
+* Update the MSRV from 1.60 to 1.72
+* Update `sha2` dependency to `0.11`.
+* Update `signature` dependency to `2.3.0-pre.3`.
+* Update underlying `curve25519_dalek` to `4.2.0-pre`
+* Update underlying `ed25519` to `2.3.0-pre`
+
 # 2.x series
 
 ## 2.1.1

--- a/ed25519-dalek/Cargo.toml
+++ b/ed25519-dalek/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ed25519-dalek"
-version = "2.1.1"
+version = "2.2.0-pre"
 edition = "2021"
 authors = [
     "isis lovecruft <isis@patternsinthevoid.net>",
@@ -26,7 +26,7 @@ rustdoc-args = [
 features = ["batch", "digest", "hazmat", "pem", "serde"]
 
 [dependencies]
-curve25519-dalek = { version = "4", path = "../curve25519-dalek", default-features = false, features = ["digest"] }
+curve25519-dalek = { version = "=4.2.0-pre", path = "../curve25519-dalek", default-features = false, features = ["digest"] }
 ed25519 = { version = "=2.3.0-pre", default-features = false }
 signature = { version = "=2.3.0-pre.3", optional = true, default-features = false }
 sha2 = { version = "=0.11.0-pre.3", default-features = false }
@@ -39,8 +39,8 @@ serde = { version = "1.0", default-features = false, optional = true }
 zeroize = { version = "1.5", default-features = false, optional = true }
 
 [dev-dependencies]
-curve25519-dalek = { version = "4", path = "../curve25519-dalek", default-features = false, features = ["digest", "rand_core"] }
-x25519-dalek = { version = "2", path = "../x25519-dalek", default-features = false, features = ["static_secrets"] }
+curve25519-dalek = { version = "=4.2.0-pre", path = "../curve25519-dalek", default-features = false, features = ["digest", "rand_core"] }
+x25519-dalek = { version = "=2.1.0-pre", path = "../x25519-dalek", default-features = false, features = ["static_secrets"] }
 blake2 = "0.10"
 sha3 = "0.10"
 hex = "0.4"

--- a/ed25519-dalek/Cargo.toml
+++ b/ed25519-dalek/Cargo.toml
@@ -28,7 +28,7 @@ features = ["batch", "digest", "hazmat", "pem", "serde"]
 [dependencies]
 curve25519-dalek = { version = "4", path = "../curve25519-dalek", default-features = false, features = ["digest"] }
 ed25519 = { version = ">=2.2, <2.3", default-features = false }
-signature = { version = ">=2.0, <2.3", optional = true, default-features = false }
+signature = { version = "=2.3.0-pre.3", optional = true, default-features = false }
 sha2 = { version = "=0.11.0-pre.3", default-features = false }
 subtle = { version = "2.3.0", default-features = false }
 

--- a/ed25519-dalek/Cargo.toml
+++ b/ed25519-dalek/Cargo.toml
@@ -27,7 +27,7 @@ features = ["batch", "digest", "hazmat", "pem", "serde"]
 
 [dependencies]
 curve25519-dalek = { version = "4", path = "../curve25519-dalek", default-features = false, features = ["digest"] }
-ed25519 = { version = ">=2.2, <2.3", default-features = false }
+ed25519 = { version = "=2.3.0-pre", default-features = false }
 signature = { version = "=2.3.0-pre.3", optional = true, default-features = false }
 sha2 = { version = "=0.11.0-pre.3", default-features = false }
 subtle = { version = "2.3.0", default-features = false }

--- a/ed25519-dalek/Cargo.toml
+++ b/ed25519-dalek/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["cryptography", "ed25519", "curve25519", "signature", "ECC"]
 categories = ["cryptography", "no-std"]
 description = "Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust."
 exclude = [ ".gitignore", "TESTVECTORS", "VALIDATIONVECTORS", "res/*" ]
-rust-version = "1.60"
+rust-version = "1.72"
 
 [package.metadata.docs.rs]
 rustdoc-args = [

--- a/ed25519-dalek/Cargo.toml
+++ b/ed25519-dalek/Cargo.toml
@@ -29,7 +29,7 @@ features = ["batch", "digest", "hazmat", "pem", "serde"]
 curve25519-dalek = { version = "4", path = "../curve25519-dalek", default-features = false, features = ["digest"] }
 ed25519 = { version = ">=2.2, <2.3", default-features = false }
 signature = { version = ">=2.0, <2.3", optional = true, default-features = false }
-sha2 = { version = "0.10", default-features = false }
+sha2 = { version = "=0.11.0-pre.3", default-features = false }
 subtle = { version = "2.3.0", default-features = false }
 
 # optional features
@@ -63,7 +63,6 @@ default = ["fast", "std", "zeroize"]
 alloc = ["curve25519-dalek/alloc", "ed25519/alloc", "serde?/alloc", "zeroize/alloc"]
 std = ["alloc", "ed25519/std", "serde?/std", "sha2/std"]
 
-asm = ["sha2/asm"]
 batch = ["alloc", "merlin", "rand_core"]
 fast = ["curve25519-dalek/precomputed-tables"]
 digest = ["signature/digest"]

--- a/ed25519-dalek/README.md
+++ b/ed25519-dalek/README.md
@@ -23,7 +23,6 @@ This crate is `#[no_std]` compatible with `default-features = false`.
 | `rand_core`            |          | Enables `SigningKey::generate` |
 | `batch`                |          | Enables `verify_batch` for verifying many signatures quickly. Also enables `rand_core`. |
 | `digest`               |          | Enables `Context`, `SigningKey::{with_context, sign_prehashed}` and `VerifyingKey::{with_context, verify_prehashed, verify_prehashed_strict}` for Ed25519ph prehashed signatures |
-| `asm`                  |          | Enables assembly optimizations in the SHA-512 compression functions |
 | `pkcs8`                |          | Enables [PKCS#8](https://en.wikipedia.org/wiki/PKCS_8) serialization/deserialization for `SigningKey` and `VerifyingKey` |
 | `pem`                  |          | Enables PEM serialization support for PKCS#8 private keys and SPKI public keys. Also enables `alloc`. |
 | `legacy_compatibility` |          | **Unsafe:** Disables certain signature checks. See [below](#malleability-and-the-legacy_compatibility-feature) |

--- a/ed25519-dalek/src/hazmat.rs
+++ b/ed25519-dalek/src/hazmat.rs
@@ -22,7 +22,7 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 
 // These are used in the functions that are made public when the hazmat feature is set
 use crate::{Signature, VerifyingKey};
-use curve25519_dalek::digest::{generic_array::typenum::U64, Digest};
+use curve25519_dalek::digest::{typenum::U64, Digest};
 
 /// Contains the secret scalar and domain separator used for generating signatures.
 ///

--- a/ed25519-dalek/src/signing.rs
+++ b/ed25519-dalek/src/signing.rs
@@ -24,7 +24,7 @@ use sha2::Sha512;
 use subtle::{Choice, ConstantTimeEq};
 
 use curve25519_dalek::{
-    digest::{generic_array::typenum::U64, Digest},
+    digest::{typenum::U64, Digest},
     edwards::{CompressedEdwardsY, EdwardsPoint},
     scalar::Scalar,
 };

--- a/ed25519-dalek/src/verifying.rs
+++ b/ed25519-dalek/src/verifying.rs
@@ -13,7 +13,7 @@ use core::fmt::Debug;
 use core::hash::{Hash, Hasher};
 
 use curve25519_dalek::{
-    digest::{generic_array::typenum::U64, Digest},
+    digest::{typenum::U64, Digest},
     edwards::{CompressedEdwardsY, EdwardsPoint},
     montgomery::MontgomeryPoint,
     scalar::Scalar,

--- a/x25519-dalek/CHANGELOG.md
+++ b/x25519-dalek/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Entries are listed in reverse chronological order.
 
+# Unreleased
+
+## 2.1.0-pre
+
+* Update the MSRV from 1.60 to 1.71
+* Update underlying `curve25519_dalek` to `4.2.0-pre`
+
 # 2.x Series
 
 * Note: All `x255919-dalek` 2.x releases are in sync with the underlying `curve25519-dalek` 4.x releases. 

--- a/x25519-dalek/Cargo.toml
+++ b/x25519-dalek/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # - update html_root_url
 # - update CHANGELOG
 # - if any changes were made to README.md, mirror them in src/lib.rs docs
-version = "2.0.1"
+version = "2.1.0-pre"
 authors = [
     "Isis Lovecruft <isis@patternsinthevoid.net>",
     "DebugSteven <debugsteven@gmail.com>",
@@ -38,7 +38,7 @@ rustdoc-args = [
 features = ["getrandom", "reusable_secrets", "serde", "static_secrets"]
 
 [dependencies]
-curve25519-dalek = { version = "4", path = "../curve25519-dalek", default-features = false }
+curve25519-dalek = { version = "=4.2.0-pre", path = "../curve25519-dalek", default-features = false }
 rand_core = { version = "0.6", default-features = false }
 serde = { version = "1", default-features = false, optional = true, features = ["derive"] }
 zeroize = { version = "1", default-features = false, optional = true, features = ["zeroize_derive"] }

--- a/x25519-dalek/Cargo.toml
+++ b/x25519-dalek/Cargo.toml
@@ -25,7 +25,7 @@ exclude = [
     ".travis.yml",
     "CONTRIBUTING.md",
 ]
-rust-version = "1.60"
+rust-version = "1.71"
 
 [badges]
 travis-ci = { repository = "dalek-cryptography/x25519-dalek", branch = "master"}


### PR DESCRIPTION
Upcoming changes in `digest` and `sha2` crates

Depends:
 - https://github.com/RustCrypto/signatures/pull/807