### PR TITLE
curve: mark `ValidityCheck` trait as `allow(dead_code)`

### DIFF
--- a/curve25519-dalek/src/traits.rs
+++ b/curve25519-dalek/src/traits.rs
@@ -409,6 +409,7 @@ pub trait VartimePrecomputedMultiscalarMul: Sized {
 /// This trait is only for debugging/testing, since it should be
 /// impossible for a `curve25519-dalek` user to construct an invalid
 /// point.
+#[allow(dead_code)]
 pub(crate) trait ValidityCheck {
     /// Checks whether the point is on the curve. Not CT.
     fn is_valid(&self) -> bool;


### PR DESCRIPTION
Recent nightlies have started emitting a dead code lint which is breaking the build: https://github.com/dalek-cryptography/curve25519-dalek/actions/runs/7873600894/job/21481401663?pr=624#step:4:152