### PR TITLE
Backport: Relax zeroize version in 3.2

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -101,18 +101,26 @@ jobs:
         args: --features "nightly"
 
   msrv:
-    name: Current MSRV is 1.41
+    name: Current MSRV is 1.56.1
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    # First run `cargo +nightly -Z minimal-verisons check` in order to get a
+    # Cargo.lock with the oldest possible deps
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: 1.41
+        toolchain: nightly
         override: true
-    - uses: actions-rs/cargo@v1
+    - run: cargo -Z minimal-versions check --no-default-features --features "fiat_u64_backend,serde"
+    # Now check that `cargo build` works with respect to the oldest possible
+    # deps and the stated MSRV
+    - uses: actions-rs/toolchain@v1
       with:
-        command: build
+        profile: minimal
+        toolchain: 1.56.1
+        override: true
+    - run: cargo build --no-default-features --features "fiat_u64_backend,serde"
 
   bench:
     name: Check that benchmarks compile
@@ -128,4 +136,4 @@ jobs:
       with:
         command: bench
         # This filter selects no benchmarks, so we don't run any, only build them.
-        args: "DONTRUNBENCHMARKS"
+        args: "nonexistentbenchmark"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ serde = { version = "1.0", default-features = false, optional = true, features =
 # The original packed_simd package was orphaned, see
 # https://github.com/rust-lang/packed_simd/issues/303#issuecomment-701361161
 packed_simd = { version = "0.3.4", package = "packed_simd_2", features = ["into_bits"], optional = true }
-zeroize = { version = ">=1, <1.4", default-features = false }
+zeroize = { version = "1", default-features = false }
 fiat-crypto = { version = "0.1.6", optional = true}
 
 [features]

--- a/README.md
+++ b/README.md
@@ -103,6 +103,13 @@ builds using `--no-default-features`.  Note that this requires explicitly
 selecting an arithmetic backend using one of the `_backend` features.
 If no backend is selected, compilation will fail.
 
+
+# Minimum Supported Rust Version
+
+This crate requires Rust 1.56.1 at a minimum. 3.x releases of this crate supported an MSRV of 1.41.
+
+In the future, MSRV changes will be accompanied by a minor version bump.
+
 # Safety
 
 The `curve25519-dalek` types are designed to make illegal states


### PR DESCRIPTION
This is to correspond to 
https://github.com/dalek-cryptography/curve25519-dalek/issues/452#issuecomment-1749807071

However, it increased MSRV and may break not locked versions that are not using newer rustc