### PR TITLE
Indicate that the rand_core feature is required

### DIFF
--- a/ed25519-dalek/src/lib.rs
+++ b/ed25519-dalek/src/lib.rs
@@ -21,6 +21,7 @@
 #![cfg_attr(feature = "rand_core", doc = "```")]
 #![cfg_attr(not(feature = "rand_core"), doc = "```ignore")]
 //! # fn main() {
+//! // $ cargo add ed25519_dalek --features rand_core
 //! use rand::rngs::OsRng;
 //! use ed25519_dalek::SigningKey;
 //! use ed25519_dalek::Signature;


### PR DESCRIPTION
The main example doesn't explicitly indicate that the `rand_core` feature is required, and rust gives confusing error messages if you don't include it. This change simply adds a line reminding the new user of the crate to include the `rand_core` feature.

Closes #633