### PR TITLE
Updates license field to valid SPDX format

### DIFF
--- a/curve25519-dalek-derive/Cargo.toml
+++ b/curve25519-dalek-derive/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 repository = "https://github.com/dalek-cryptography/curve25519-dalek"
 homepage = "https://github.com/dalek-cryptography/curve25519-dalek"
 documentation = "https://docs.rs/curve25519-dalek-derive"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 readme = "README.md"
 description = "curve25519-dalek Derives"
 


### PR DESCRIPTION
The popular [`dependency-review-action`](https://github.com/actions/dependency-review-action) requires the license field be in valid SPDX format. (We are hitting false positives on this dependency via `dependency-review-action` over at [Teleport](https://github.com/gravitational/teleport)).