### PR TITLE
Mitigate check-cfg until MSRV 1.77

### DIFF
--- a/curve25519-dalek-derive/tests/tests.rs
+++ b/curve25519-dalek-derive/tests/tests.rs
@@ -24,10 +24,6 @@ where
 }
 
 #[unsafe_target_feature("sse2")]
-#[cfg(feature = "dummy")]
-fn function_with_cfg() {}
-
-#[unsafe_target_feature("sse2")]
 #[rustfmt::skip]
 fn function_with_rustfmt_skip() {}
 
@@ -45,9 +41,6 @@ impl Struct {
     fn member_function_with_const_arg<const N: u32>(self) -> u32 {
         self.a - N
     }
-
-    #[cfg(feature = "dummy")]
-    fn member_function_with_cfg() {}
 }
 
 struct StructWithGenerics<T>
@@ -93,7 +86,7 @@ mod inner {
     }
 }
 
-#[unsafe_target_feature_specialize("sse2", "avx2", conditional("avx512ifma", disabled))]
+#[unsafe_target_feature_specialize("sse2", "avx2")]
 mod inner_spec {
     #[for_target_feature("sse2")]
     const CONST: u32 = 1;

--- a/curve25519-dalek/src/lib.rs
+++ b/curve25519-dalek/src/lib.rs
@@ -42,6 +42,8 @@
     unused_lifetimes,
     unused_qualifications
 )]
+// Requires MSRV 1.77 as it does not allow build.rs gating
+#![allow(unexpected_cfgs)]
 
 //------------------------------------------------------------------------
 // External dependencies:

--- a/curve25519-dalek/src/scalar.rs
+++ b/curve25519-dalek/src/scalar.rs
@@ -1233,10 +1233,12 @@ impl Field for Scalar {
     }
 
     fn sqrt_ratio(num: &Self, div: &Self) -> (Choice, Self) {
+        #[allow(unused_qualifications)]
         group::ff::helpers::sqrt_ratio_generic(num, div)
     }
 
     fn sqrt(&self) -> CtOption<Self> {
+        #[allow(unused_qualifications)]
         group::ff::helpers::sqrt_tonelli_shanks(
             self,
             [

--- a/x25519-dalek/src/lib.rs
+++ b/x25519-dalek/src/lib.rs
@@ -15,7 +15,6 @@
 // README.md as the crate documentation.
 
 #![no_std]
-#![cfg_attr(feature = "bench", feature(test))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg, doc_cfg, doc_cfg_hide))]
 #![cfg_attr(docsrs, doc(cfg_hide(docsrs)))]
 #![deny(missing_docs)]


### PR DESCRIPTION
1.80 and nightly (2024-05-05) has introduced cfg-check spitting out some warnings.

The  problem is if we declare the cfg's as intended - this  will then complain about MSRV despite where we would only print these flags when rustc is >= 1.77 a.k.a this feature hard-checks MSRV and then asks to bump MSRV 1.77 despite build.rs never using the feature as gated in build.rs for below <= 1.77 as checked.

In order to mitigate this we can just temporarily allow the status-quo and when MSRV jumps to 1.77 we can declare them when MSRV bumps to 1.77.

Also need to allow two occassions unnecessary qualification (group::ff) where when only group feature is used when ff is available directrly where as it's always available via group::ff - leading to lint complaining.