### PR TITLE
Enable unexpected cfgs lint

### DIFF
--- a/curve25519-dalek/Cargo.toml
+++ b/curve25519-dalek/Cargo.toml
@@ -71,3 +71,13 @@ group-bits = ["group", "ff/bits"]
 
 [target.'cfg(all(not(curve25519_dalek_backend = "fiat"), not(curve25519_dalek_backend = "serial"), target_arch = "x86_64"))'.dependencies]
 curve25519-dalek-derive = { version = "0.1", path = "../curve25519-dalek-derive" }
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = [
+    'cfg(allow_unused_unsafe)',
+    'cfg(curve25519_dalek_backend, values("fiat", "serial", "simd"))',
+    'cfg(curve25519_dalek_diagnostics, values("build"))',
+    'cfg(curve25519_dalek_bits, values("32", "64"))',
+    'cfg(nightly)',
+]

--- a/curve25519-dalek/src/backend/vector/ifma/edwards.rs
+++ b/curve25519-dalek/src/backend/vector/ifma/edwards.rs
@@ -249,7 +249,7 @@ impl<'a> From<&'a edwards::EdwardsPoint> for NafLookupTable8<CachedPoint> {
     }
 }
 
-#[cfg(target_feature = "avx512ifma,avx512vl")]
+#[cfg(all(target_feature = "avx512ifma", target_feature = "avx512vl"))]
 #[cfg(test)]
 mod test {
     use super::*;

--- a/curve25519-dalek/src/backend/vector/ifma/field.rs
+++ b/curve25519-dalek/src/backend/vector/ifma/field.rs
@@ -629,7 +629,7 @@ impl<'a, 'b> Mul<&'b F51x4Reduced> for &'a F51x4Reduced {
     }
 }
 
-#[cfg(target_feature = "avx512ifma,avx512vl")]
+#[cfg(all(target_feature = "avx512ifma", target_feature = "avx512vl"))]
 #[cfg(test)]
 mod test {
     use super::*;

--- a/curve25519-dalek/src/lib.rs
+++ b/curve25519-dalek/src/lib.rs
@@ -42,8 +42,6 @@
     unused_lifetimes,
     unused_qualifications
 )]
-// Requires MSRV 1.77 as it does not allow build.rs gating
-#![allow(unexpected_cfgs)]
 
 //------------------------------------------------------------------------
 // External dependencies:


### PR DESCRIPTION
The `unexpected_cfgs` lint was previously disabled in 9252fa5c0d09054fed. Since the lint can now be configured using `Cargo.toml`[^2] no `build.rs` shenanigans are necessary anymore.

This PR also fixes some immediate bugs found, two tests used comma-seperated config flags `cfg(target_feature = "avx512ifma,avx512vl")`, which is invalid (and always false). Instead, it should be `cfg(all(target_feature = "avx512ifma", target_feature = "avx512vl"))`.
From what I've seen, this pattern also exists in the proc-macros used to enable target features for certain functions. But I don't understand the codebase well enough to say this for certain, and I didn't look too much into it either.

I believe usage `cfg(nightly)` is also a bug - the documentation[^1] seems to suggest that features are automatically enabled when compiled 
> If compiled on a non-nightly compiler, curve25519-dalek will not include AVX512 code, and therefore will never select it at runtime.

This is incorrect, since `cfg(nightly)` does not exist, and AFAIK there is no way to detect whether code is being compiled by a "nightly" compiler (and the definition of "nightly" changes all the time anyways). But perhaps this was intended to be used manually? (via `--cfg nightly`)

[^2]:https://blog.rust-lang.org/2024/05/06/check-cfg.html#expecting-custom-cfgs
[^1]:https://docs.rs/curve25519-dalek/latest/curve25519_dalek/#simd-backend