### PR TITLE
docs: update `VartimeRistrettoPrecomputation` documentation

### DIFF
--- a/curve25519-dalek/src/ristretto.rs
+++ b/curve25519-dalek/src/ristretto.rs
@@ -1007,7 +1007,7 @@ impl VartimeMultiscalarMul for RistrettoPoint {
 }
 
 /// Precomputation for variable-time multiscalar multiplication with `RistrettoPoint`s.
-/// 
+///
 /// Note that for large numbers of `RistrettoPoint`s, this functionality may be less
 /// efficient than the corresponding `VartimeMultiscalarMul` implementation.
 // This wraps the inner implementation in a facade type so that we can

--- a/curve25519-dalek/src/ristretto.rs
+++ b/curve25519-dalek/src/ristretto.rs
@@ -1007,6 +1007,9 @@ impl VartimeMultiscalarMul for RistrettoPoint {
 }
 
 /// Precomputation for variable-time multiscalar multiplication with `RistrettoPoint`s.
+/// 
+/// Note that for large numbers of `RistrettoPoint`s, this functionality may be less
+/// efficient than the corresponding `VartimeMultiscalarMul` implementation.
 // This wraps the inner implementation in a facade type so that we can
 // decouple stability of the inner type from the stability of the
 // outer type.


### PR DESCRIPTION
It is the case that performing variable-time Ristretto multiscalar multiplication evaluation using [`VartimeRistrettoPrecomputation`](https://docs.rs/curve25519-dalek/latest/curve25519_dalek/ristretto/struct.VartimeRistrettoPrecomputation.html) may be less efficient than the corresponding [`VartimeMultiscalarMul`](https://docs.rs/curve25519-dalek/latest/curve25519_dalek/traits/trait.VartimeMultiscalarMul.html) implementation, depending on the number of points used.

This PR updates the documentation to make this clear, since the decision of whether or not to use precomputation may depend highly on the use case.