### PR TITLE
curve: use derive macro for zeroizing

### DIFF
--- a/curve25519-dalek/Cargo.toml
+++ b/curve25519-dalek/Cargo.toml
@@ -53,7 +53,7 @@ rand_core = { version = "0.6.4", default-features = false, optional = true }
 digest = { version = "0.10", default-features = false, optional = true }
 subtle = { version = "2.6.0", default-features = false }
 serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
-zeroize = { version = "1", default-features = false, optional = true }
+zeroize = { version = "1", default-features = false, optional = true, features = ["zeroize_derive"] }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 cpufeatures = "0.2.6"

--- a/curve25519-dalek/src/backend/serial/curve_models/mod.rs
+++ b/curve25519-dalek/src/backend/serial/curve_models/mod.rs
@@ -180,20 +180,12 @@ pub struct CompletedPoint {
 /// can be found in the module-level documentation.
 // Safe to derive Eq because affine coordinates.
 #[derive(Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "zeroize", derive(Zeroize))]
 #[allow(missing_docs)]
 pub struct AffineNielsPoint {
     pub y_plus_x: FieldElement,
     pub y_minus_x: FieldElement,
     pub xy2d: FieldElement,
-}
-
-#[cfg(feature = "zeroize")]
-impl Zeroize for AffineNielsPoint {
-    fn zeroize(&mut self) {
-        self.y_plus_x.zeroize();
-        self.y_minus_x.zeroize();
-        self.xy2d.zeroize();
-    }
 }
 
 /// A pre-computed point on the \\( \mathbb P\^3 \\) model for the
@@ -202,22 +194,13 @@ impl Zeroize for AffineNielsPoint {
 /// More details on the relationships between the different curve models
 /// can be found in the module-level documentation.
 #[derive(Copy, Clone)]
+#[cfg_attr(feature = "zeroize", derive(Zeroize))]
 #[allow(missing_docs)]
 pub struct ProjectiveNielsPoint {
     pub Y_plus_X: FieldElement,
     pub Y_minus_X: FieldElement,
     pub Z: FieldElement,
     pub T2d: FieldElement,
-}
-
-#[cfg(feature = "zeroize")]
-impl Zeroize for ProjectiveNielsPoint {
-    fn zeroize(&mut self) {
-        self.Y_plus_X.zeroize();
-        self.Y_minus_X.zeroize();
-        self.Z.zeroize();
-        self.T2d.zeroize();
-    }
 }
 
 // ------------------------------------------------------------------------

--- a/curve25519-dalek/src/backend/serial/fiat_u32/field.rs
+++ b/curve25519-dalek/src/backend/serial/fiat_u32/field.rs
@@ -55,18 +55,12 @@ use fiat_crypto::curve25519_32::*;
 /// The backend-specific type `FieldElement2625` should not be used
 /// outside of the `curve25519_dalek::field` module.
 #[derive(Copy, Clone)]
+#[cfg_attr(feature = "zeroize", derive(Zeroize))]
 pub struct FieldElement2625(pub(crate) fiat_25519_tight_field_element);
 
 impl Debug for FieldElement2625 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "FieldElement2625({:?})", &(self.0).0[..])
-    }
-}
-
-#[cfg(feature = "zeroize")]
-impl Zeroize for FieldElement2625 {
-    fn zeroize(&mut self) {
-        (self.0).0.zeroize();
     }
 }
 

--- a/curve25519-dalek/src/backend/serial/fiat_u64/field.rs
+++ b/curve25519-dalek/src/backend/serial/fiat_u64/field.rs
@@ -44,18 +44,12 @@ use fiat_crypto::curve25519_64::*;
 /// The backend-specific type `FieldElement51` should not be used
 /// outside of the `curve25519_dalek::field` module.
 #[derive(Copy, Clone)]
+#[cfg_attr(feature = "zeroize", derive(Zeroize))]
 pub struct FieldElement51(pub(crate) fiat_25519_tight_field_element);
 
 impl Debug for FieldElement51 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "FieldElement51({:?})", &(self.0).0[..])
-    }
-}
-
-#[cfg(feature = "zeroize")]
-impl Zeroize for FieldElement51 {
-    fn zeroize(&mut self) {
-        (self.0).0.zeroize();
     }
 }
 

--- a/curve25519-dalek/src/backend/serial/u32/field.rs
+++ b/curve25519-dalek/src/backend/serial/u32/field.rs
@@ -51,18 +51,12 @@ use zeroize::Zeroize;
 /// The backend-specific type `FieldElement2625` should not be used
 /// outside of the `curve25519_dalek::field` module.
 #[derive(Copy, Clone)]
+#[cfg_attr(feature = "zeroize", derive(Zeroize))]
 pub struct FieldElement2625(pub(crate) [u32; 10]);
 
 impl Debug for FieldElement2625 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "FieldElement2625({:?})", &self.0[..])
-    }
-}
-
-#[cfg(feature = "zeroize")]
-impl Zeroize for FieldElement2625 {
-    fn zeroize(&mut self) {
-        self.0.zeroize();
     }
 }
 

--- a/curve25519-dalek/src/backend/serial/u32/scalar.rs
+++ b/curve25519-dalek/src/backend/serial/u32/scalar.rs
@@ -22,18 +22,12 @@ use crate::constants;
 /// The `Scalar29` struct represents an element in \\(\mathbb{Z} / \ell\mathbb{Z}\\) as 9 29-bit
 /// limbs
 #[derive(Copy, Clone)]
+#[cfg_attr(feature = "zeroize", derive(Zeroize))]
 pub struct Scalar29(pub [u32; 9]);
 
 impl Debug for Scalar29 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "Scalar29: {:?}", &self.0[..])
-    }
-}
-
-#[cfg(feature = "zeroize")]
-impl Zeroize for Scalar29 {
-    fn zeroize(&mut self) {
-        self.0.zeroize();
     }
 }
 

--- a/curve25519-dalek/src/backend/serial/u64/field.rs
+++ b/curve25519-dalek/src/backend/serial/u64/field.rs
@@ -40,18 +40,12 @@ use zeroize::Zeroize;
 /// The backend-specific type `FieldElement51` should not be used
 /// outside of the `curve25519_dalek::field` module.
 #[derive(Copy, Clone)]
+#[cfg_attr(feature = "zeroize", derive(Zeroize))]
 pub struct FieldElement51(pub(crate) [u64; 5]);
 
 impl Debug for FieldElement51 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "FieldElement51({:?})", &self.0[..])
-    }
-}
-
-#[cfg(feature = "zeroize")]
-impl Zeroize for FieldElement51 {
-    fn zeroize(&mut self) {
-        self.0.zeroize();
     }
 }
 

--- a/curve25519-dalek/src/backend/serial/u64/scalar.rs
+++ b/curve25519-dalek/src/backend/serial/u64/scalar.rs
@@ -23,18 +23,12 @@ use crate::constants;
 /// The `Scalar52` struct represents an element in
 /// \\(\mathbb Z / \ell \mathbb Z\\) as 5 \\(52\\)-bit limbs.
 #[derive(Copy, Clone)]
+#[cfg_attr(feature = "zeroize", derive(Zeroize))]
 pub struct Scalar52(pub [u64; 5]);
 
 impl Debug for Scalar52 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "Scalar52: {:?}", &self.0[..])
-    }
-}
-
-#[cfg(feature = "zeroize")]
-impl Zeroize for Scalar52 {
-    fn zeroize(&mut self) {
-        self.0.zeroize();
     }
 }
 

--- a/curve25519-dalek/src/montgomery.rs
+++ b/curve25519-dalek/src/montgomery.rs
@@ -72,6 +72,7 @@ use zeroize::Zeroize;
 /// Curve25519 or its twist.
 #[derive(Copy, Clone, Debug, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "zeroize", derive(Zeroize))]
 pub struct MontgomeryPoint(pub [u8; 32]);
 
 /// Equality of `MontgomeryPoint`s is defined mod p.
@@ -107,13 +108,6 @@ impl Identity for MontgomeryPoint {
     /// Return the group identity element, which has order 4.
     fn identity() -> MontgomeryPoint {
         MontgomeryPoint([0u8; 32])
-    }
-}
-
-#[cfg(feature = "zeroize")]
-impl Zeroize for MontgomeryPoint {
-    fn zeroize(&mut self) {
-        self.0.zeroize();
     }
 }
 

--- a/curve25519-dalek/src/ristretto.rs
+++ b/curve25519-dalek/src/ristretto.rs
@@ -216,6 +216,7 @@ use crate::traits::{MultiscalarMul, VartimeMultiscalarMul, VartimePrecomputedMul
 /// The Ristretto encoding is canonical, so two points are equal if and
 /// only if their encodings are equal.
 #[derive(Copy, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "zeroize", derive(Zeroize))]
 pub struct CompressedRistretto(pub [u8; 32]);
 
 impl ConstantTimeEq for CompressedRistretto {
@@ -482,6 +483,7 @@ impl<'de> Deserialize<'de> for CompressedRistretto {
 /// `EdwardsPoint`s.
 ///
 #[derive(Copy, Clone)]
+#[cfg_attr(feature = "zeroize", derive(Zeroize))]
 pub struct RistrettoPoint(pub(crate) EdwardsPoint);
 
 impl RistrettoPoint {
@@ -1248,24 +1250,6 @@ impl CofactorGroup for RistrettoPoint {
 
     fn is_torsion_free(&self) -> Choice {
         Choice::from(1)
-    }
-}
-
-// ------------------------------------------------------------------------
-// Zeroize traits
-// ------------------------------------------------------------------------
-
-#[cfg(feature = "zeroize")]
-impl Zeroize for CompressedRistretto {
-    fn zeroize(&mut self) {
-        self.0.zeroize();
-    }
-}
-
-#[cfg(feature = "zeroize")]
-impl Zeroize for RistrettoPoint {
-    fn zeroize(&mut self) {
-        self.0.zeroize();
     }
 }
 

--- a/curve25519-dalek/src/scalar.rs
+++ b/curve25519-dalek/src/scalar.rs
@@ -192,6 +192,7 @@ cfg_if! {
 /// The `Scalar` struct holds an element of \\(\mathbb Z / \ell\mathbb Z \\).
 #[allow(clippy::derived_hash_with_manual_eq)]
 #[derive(Copy, Clone, Hash)]
+#[cfg_attr(feature = "zeroize", derive(Zeroize))]
 pub struct Scalar {
     /// `bytes` is a little-endian byte encoding of an integer representing a scalar modulo the
     /// group order.
@@ -549,13 +550,6 @@ impl From<u128> for Scalar {
         let x_bytes = x.to_le_bytes();
         s_bytes[0..x_bytes.len()].copy_from_slice(&x_bytes);
         Scalar { bytes: s_bytes }
-    }
-}
-
-#[cfg(feature = "zeroize")]
-impl Zeroize for Scalar {
-    fn zeroize(&mut self) {
-        self.bytes.zeroize();
     }
 }
 


### PR DESCRIPTION
Several types implement `Zeroize` manually. It seems safer to do this via the supplied [derive macro](https://docs.rs/zeroize/latest/zeroize/#derives), since any field changes will be caught automatically.

This PR moves to this functionality.