### PR TITLE
docs: minor documentation fixes

### DIFF
--- a/curve25519-dalek/src/edwards.rs
+++ b/curve25519-dalek/src/edwards.rs
@@ -19,8 +19,8 @@
 //! ## Equality Testing
 //!
 //! The `EdwardsPoint` struct implements the [`subtle::ConstantTimeEq`]
-//! trait for constant-time equality checking, and the Rust `Eq` trait
-//! for variable-time equality checking.
+//! trait for constant-time equality checking, and also uses this to
+//! ensure `Eq` equality checking runs in constant time.
 //!
 //! ## Cofactor-related functions
 //!
@@ -438,7 +438,7 @@ impl Zeroize for CompressedEdwardsY {
 
 #[cfg(feature = "zeroize")]
 impl Zeroize for EdwardsPoint {
-    /// Reset this `CompressedEdwardsPoint` to the identity element.
+    /// Reset this `EdwardsPoint` to the identity element.
     fn zeroize(&mut self) {
         self.X.zeroize();
         self.Y = FieldElement::ONE;

--- a/curve25519-dalek/src/ristretto.rs
+++ b/curve25519-dalek/src/ristretto.rs
@@ -76,9 +76,9 @@
 //! coordinates without requiring an inversion, so it is much faster.
 //!
 //! The `RistrettoPoint` struct implements the
-//! `subtle::ConstantTimeEq` trait for constant-time equality
-//! checking, and the Rust `Eq` trait for variable-time equality
-//! checking.
+//! [`subtle::ConstantTimeEq`] trait for constant-time equality
+//! checking, and also uses this to ensure `Eq` equality checking
+//! runs in constant time.
 //!
 //! ## Scalars
 //!


### PR DESCRIPTION
This PR makes a few small documentation fixes:
- It updates the `ristretto` module documentation to correctly note that `RistrettoPoint` equality testing is always done [in constant time](https://github.com/dalek-cryptography/curve25519-dalek/blob/5b7082bbc8e0b2106ab0d956064f61fa0f393cdc/curve25519-dalek/src/ristretto.rs#L822-L826).
- It updates the `edwards` module documentation to correctly note that `EdwardsPoint` equality testing is always done [in constant time](https://github.com/dalek-cryptography/curve25519-dalek/blob/5b7082bbc8e0b2106ab0d956064f61fa0f393cdc/curve25519-dalek/src/edwards.rs#L495-L499).
- It updates the `EdwardsPoint` documentation to fix what appears to be a copy-paste error for a type name.