### PR TITLE
[WIP] Bump `digest`, `ed25519`, `signature`, and `sha2`

### DIFF
--- a/curve25519-dalek/Cargo.toml
+++ b/curve25519-dalek/Cargo.toml
@@ -30,7 +30,7 @@ rustdoc-args = [
 features = ["serde", "rand_core", "digest", "legacy_compatibility", "group-bits"]
 
 [dev-dependencies]
-sha2 = { version = "0.10", default-features = false }
+sha2 = { version = "=0.11.0-pre.4", default-features = false }
 bincode = "1"
 criterion = { version = "0.5", features = ["html_reports"] }
 hex = "0.4.2"
@@ -50,7 +50,7 @@ cfg-if = "1"
 ff = { version = "0.13", default-features = false, optional = true }
 group = { version = "0.13", default-features = false, optional = true }
 rand_core = { version = "0.6.4", default-features = false, optional = true }
-digest = { version = "0.10", default-features = false, optional = true }
+digest = { version = "=0.11.0-pre.9", default-features = false, optional = true }
 subtle = { version = "2.6.0", default-features = false }
 serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
 zeroize = { version = "1", default-features = false, optional = true }

--- a/curve25519-dalek/src/edwards.rs
+++ b/curve25519-dalek/src/edwards.rs
@@ -104,7 +104,7 @@ use core::ops::{Mul, MulAssign};
 use cfg_if::cfg_if;
 
 #[cfg(feature = "digest")]
-use digest::{generic_array::typenum::U64, Digest};
+use digest::{array::typenum::U64, Digest};
 
 #[cfg(feature = "group")]
 use {

--- a/curve25519-dalek/src/ristretto.rs
+++ b/curve25519-dalek/src/ristretto.rs
@@ -173,7 +173,7 @@ use core::ops::{Mul, MulAssign};
 use rand_core::CryptoRngCore;
 
 #[cfg(feature = "digest")]
-use digest::generic_array::typenum::U64;
+use digest::array::typenum::U64;
 #[cfg(feature = "digest")]
 use digest::Digest;
 

--- a/curve25519-dalek/src/scalar.rs
+++ b/curve25519-dalek/src/scalar.rs
@@ -134,7 +134,7 @@ use rand_core::RngCore;
 use rand_core::CryptoRngCore;
 
 #[cfg(feature = "digest")]
-use digest::generic_array::typenum::U64;
+use digest::array::typenum::U64;
 #[cfg(feature = "digest")]
 use digest::Digest;
 

--- a/ed25519-dalek/Cargo.toml
+++ b/ed25519-dalek/Cargo.toml
@@ -27,9 +27,9 @@ features = ["batch", "digest", "hazmat", "pem", "serde"]
 
 [dependencies]
 curve25519-dalek = { version = "4", path = "../curve25519-dalek", default-features = false, features = ["digest"] }
-ed25519 = { version = ">=2.2, <2.3", default-features = false }
-signature = { version = ">=2.0, <2.3", optional = true, default-features = false }
-sha2 = { version = "0.10", default-features = false }
+ed25519 = { version = "=2.3.0-pre.0", default-features = false }
+signature = { version = "=2.3.0-pre.4", optional = true, default-features = false }
+sha2 = { version = "=0.11.0-pre.4", default-features = false }
 subtle = { version = "2.3.0", default-features = false }
 
 # optional features
@@ -41,8 +41,8 @@ zeroize = { version = "1.5", default-features = false, optional = true }
 [dev-dependencies]
 curve25519-dalek = { version = "4", path = "../curve25519-dalek", default-features = false, features = ["digest", "rand_core"] }
 x25519-dalek = { version = "2", path = "../x25519-dalek", default-features = false, features = ["static_secrets"] }
-blake2 = "0.10"
-sha3 = "0.10"
+blake2 = "=0.11.0-pre.4"
+sha3 = "=0.11.0-pre.4"
 hex = "0.4"
 bincode = "1.0"
 serde_json = "1.0"
@@ -63,7 +63,6 @@ default = ["fast", "std", "zeroize"]
 alloc = ["curve25519-dalek/alloc", "ed25519/alloc", "serde?/alloc", "zeroize/alloc"]
 std = ["alloc", "ed25519/std", "serde?/std", "sha2/std"]
 
-asm = ["sha2/asm"]
 batch = ["alloc", "merlin", "rand_core"]
 fast = ["curve25519-dalek/precomputed-tables"]
 digest = ["signature/digest"]

--- a/ed25519-dalek/src/hazmat.rs
+++ b/ed25519-dalek/src/hazmat.rs
@@ -22,7 +22,7 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 
 // These are used in the functions that are made public when the hazmat feature is set
 use crate::{Signature, VerifyingKey};
-use curve25519_dalek::digest::{generic_array::typenum::U64, Digest};
+use curve25519_dalek::digest::{array::typenum::U64, Digest};
 
 /// Contains the secret scalar and domain separator used for generating signatures.
 ///

--- a/ed25519-dalek/src/signing.rs
+++ b/ed25519-dalek/src/signing.rs
@@ -24,7 +24,7 @@ use sha2::Sha512;
 use subtle::{Choice, ConstantTimeEq};
 
 use curve25519_dalek::{
-    digest::{generic_array::typenum::U64, Digest},
+    digest::{array::typenum::U64, Digest},
     edwards::{CompressedEdwardsY, EdwardsPoint},
     scalar::Scalar,
 };

--- a/ed25519-dalek/src/verifying.rs
+++ b/ed25519-dalek/src/verifying.rs
@@ -13,7 +13,7 @@ use core::fmt::Debug;
 use core::hash::{Hash, Hasher};
 
 use curve25519_dalek::{
-    digest::{generic_array::typenum::U64, Digest},
+    digest::{array::typenum::U64, Digest},
     edwards::{CompressedEdwardsY, EdwardsPoint},
     montgomery::MontgomeryPoint,
     scalar::Scalar,


### PR DESCRIPTION
Bumps the aforementioned dependencies to their latest (pre)releases