### PR TITLE
Update ed25519 and signature crates to latest pre-releases

### DIFF
--- a/ed25519-dalek/Cargo.toml
+++ b/ed25519-dalek/Cargo.toml
@@ -27,8 +27,8 @@ features = ["batch", "digest", "hazmat", "pem", "serde"]
 
 [dependencies]
 curve25519-dalek = { version = "4", path = "../curve25519-dalek", default-features = false, features = ["digest"] }
-ed25519 = { version = ">=2.2, <2.3", default-features = false }
-signature = { version = ">=2.0, <2.3", optional = true, default-features = false }
+ed25519 = { version = "2.3.0-pre.0", default-features = false }
+signature = { version = "2.3.0-pre.4", optional = true, default-features = false }
 sha2 = { version = "0.10", default-features = false }
 subtle = { version = "2.3.0", default-features = false }
 


### PR DESCRIPTION
The RustCrypto crates are close to a plethora of releases and while trying to get my project compiling I got here.

This PR does not update the `sha2` crate, because doing so breaks a fair amount of stuff. I wanted to test the waters here first before doing work that may or may not be welcome. :)


