### PR TITLE
curve: support zeroizing for `SubgroupPoint`

### DIFF
--- a/curve25519-dalek/src/edwards.rs
+++ b/curve25519-dalek/src/edwards.rs
@@ -1532,6 +1532,13 @@ impl ConditionallySelectable for SubgroupPoint {
     }
 }
 
+#[cfg(all(feature = "group", feature = "zeroize"))]
+impl Zeroize for SubgroupPoint {
+    fn zeroize(&mut self) {
+        self.0.zeroize();
+    }
+}
+
 #[cfg(feature = "group")]
 impl group::Group for SubgroupPoint {
     type Scalar = Scalar;


### PR DESCRIPTION
This PR adds `Zeroizing` support to `SubgroupPoint`, as it was missing.

Closes #617.