### PR TITLE
docs: remove unnecessary `CofactorGroup` documentation

### DIFF
--- a/curve25519-dalek/src/edwards.rs
+++ b/curve25519-dalek/src/edwards.rs
@@ -1698,7 +1698,6 @@ impl GroupEncoding for SubgroupPoint {
 #[cfg(feature = "group")]
 impl PrimeGroup for SubgroupPoint {}
 
-/// Ristretto has a cofactor of 1.
 #[cfg(feature = "group")]
 impl CofactorGroup for EdwardsPoint {
     type Subgroup = SubgroupPoint;


### PR DESCRIPTION
The `CofactorGroup` documentation for `EdwardsPoint` merely notes that Ristretto has a trivial cofactor. This is true, but seems out of place here, and seems like it could confuse the reader into thinking this holds for `EdwardsPoint` as well (which it most certainly [does not](https://github.com/dalek-cryptography/curve25519-dalek/blob/0964f800ab2114a862543ca000291a6e3531c203/curve25519-dalek/src/edwards.rs#L1186-L1189)).