### PR TITLE
curve!: use constant-time compressed Edwards equality testing

### DIFF
--- a/curve25519-dalek/src/edwards.rs
+++ b/curve25519-dalek/src/edwards.rs
@@ -166,12 +166,20 @@ use alloc::vec::Vec;
 ///
 /// The first 255 bits of a `CompressedEdwardsY` represent the
 /// \\(y\\)-coordinate.  The high bit of the 32nd byte gives the sign of \\(x\\).
-#[derive(Copy, Clone, Eq, PartialEq, Hash)]
+#[allow(clippy::derived_hash_with_manual_eq)]
+#[derive(Copy, Clone, Hash)]
 pub struct CompressedEdwardsY(pub [u8; 32]);
 
 impl ConstantTimeEq for CompressedEdwardsY {
     fn ct_eq(&self, other: &CompressedEdwardsY) -> Choice {
         self.as_bytes().ct_eq(other.as_bytes())
+    }
+}
+
+impl Eq for CompressedEdwardsY {}
+impl PartialEq for CompressedEdwardsY {
+    fn eq(&self, other: &Self) -> bool {
+        self.ct_eq(other).into()
     }
 }
 


### PR DESCRIPTION
This ensures that `CompressedEdwardsY` equality testing is always done in constant time.

BREAKING CHANGE: This can [break](https://github.com/dalek-cryptography/curve25519-dalek/pull/669#discussion_r1667195282) certain uses of `match`.