### PR TITLE
curve: add precomputation length

### DIFF
--- a/curve25519-dalek/src/backend/mod.rs
+++ b/curve25519-dalek/src/backend/mod.rs
@@ -128,6 +128,30 @@ impl VartimePrecomputedStraus {
         }
     }
 
+    pub fn len(&self) -> usize {
+        use crate::traits::VartimePrecomputedMultiscalarMul;
+
+        match self {
+            #[cfg(curve25519_dalek_backend = "simd")]
+            VartimePrecomputedStraus::Avx2(inner) => inner.len(),
+            #[cfg(all(curve25519_dalek_backend = "unstable_avx512", nightly))]
+            VartimePrecomputedStraus::Avx512ifma(inner) => inner.len(),
+            VartimePrecomputedStraus::Scalar(inner) => inner.len(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        use crate::traits::VartimePrecomputedMultiscalarMul;
+
+        match self {
+            #[cfg(curve25519_dalek_backend = "simd")]
+            VartimePrecomputedStraus::Avx2(inner) => inner.is_empty(),
+            #[cfg(all(curve25519_dalek_backend = "unstable_avx512", nightly))]
+            VartimePrecomputedStraus::Avx512ifma(inner) => inner.is_empty(),
+            VartimePrecomputedStraus::Scalar(inner) => inner.is_empty(),
+        }
+    }
+
     pub fn optional_mixed_multiscalar_mul<I, J, K>(
         &self,
         static_scalars: I,

--- a/curve25519-dalek/src/backend/mod.rs
+++ b/curve25519-dalek/src/backend/mod.rs
@@ -128,6 +128,7 @@ impl VartimePrecomputedStraus {
         }
     }
 
+    /// Return the number of static points in the precomputation.
     pub fn len(&self) -> usize {
         use crate::traits::VartimePrecomputedMultiscalarMul;
 
@@ -140,6 +141,7 @@ impl VartimePrecomputedStraus {
         }
     }
 
+    /// Determine if the precomputation is empty.
     pub fn is_empty(&self) -> bool {
         use crate::traits::VartimePrecomputedMultiscalarMul;
 

--- a/curve25519-dalek/src/backend/serial/scalar_mul/precomputed_straus.rs
+++ b/curve25519-dalek/src/backend/serial/scalar_mul/precomputed_straus.rs
@@ -46,6 +46,14 @@ impl VartimePrecomputedMultiscalarMul for VartimePrecomputedStraus {
         }
     }
 
+    fn len(&self) -> usize {
+        self.static_lookup_tables.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.static_lookup_tables.is_empty()
+    }
+
     fn optional_mixed_multiscalar_mul<I, J, K>(
         &self,
         static_scalars: I,

--- a/curve25519-dalek/src/backend/vector/scalar_mul/precomputed_straus.rs
+++ b/curve25519-dalek/src/backend/vector/scalar_mul/precomputed_straus.rs
@@ -57,6 +57,14 @@ pub mod spec {
             }
         }
 
+        fn len(&self) -> usize {
+            self.static_lookup_tables.len()
+        }
+
+        fn is_empty(&self) -> bool {
+            self.static_lookup_tables.is_empty()
+        }
+
         fn optional_mixed_multiscalar_mul<I, J, K>(
             &self,
             static_scalars: I,

--- a/curve25519-dalek/src/edwards.rs
+++ b/curve25519-dalek/src/edwards.rs
@@ -879,6 +879,14 @@ impl VartimePrecomputedMultiscalarMul for VartimeEdwardsPrecomputation {
         Self(crate::backend::VartimePrecomputedStraus::new(static_points))
     }
 
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
     fn optional_mixed_multiscalar_mul<I, J, K>(
         &self,
         static_scalars: I,
@@ -2135,6 +2143,9 @@ mod test {
             .collect::<Vec<_>>();
 
         let precomputation = VartimeEdwardsPrecomputation::new(static_points.iter());
+
+        assert_eq!(precomputation.len(), 128);
+        assert!(!precomputation.is_empty());
 
         let P = precomputation.vartime_mixed_multiscalar_mul(
             &static_scalars,

--- a/curve25519-dalek/src/ristretto.rs
+++ b/curve25519-dalek/src/ristretto.rs
@@ -1027,6 +1027,14 @@ impl VartimePrecomputedMultiscalarMul for VartimeRistrettoPrecomputation {
         ))
     }
 
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
     fn optional_mixed_multiscalar_mul<I, J, K>(
         &self,
         static_scalars: I,
@@ -1851,6 +1859,9 @@ mod test {
             .collect::<Vec<_>>();
 
         let precomputation = VartimeRistrettoPrecomputation::new(static_points.iter());
+
+        assert_eq!(precomputation.len(), 128);
+        assert!(!precomputation.is_empty());
 
         let P = precomputation.vartime_mixed_multiscalar_mul(
             &static_scalars,

--- a/curve25519-dalek/src/traits.rs
+++ b/curve25519-dalek/src/traits.rs
@@ -299,6 +299,12 @@ pub trait VartimePrecomputedMultiscalarMul: Sized {
         I: IntoIterator,
         I::Item: Borrow<Self::Point>;
 
+    /// Return the number of static points in the precomputation.
+    fn len(&self) -> usize;
+
+    /// Determine if the precomputation is empty.
+    fn is_empty(&self) -> bool;
+
     /// Given `static_scalars`, an iterator of public scalars
     /// \\(b_i\\), compute
     /// $$


### PR DESCRIPTION
Adds functionality to `VartimePrecomputedMultiscalarMul` to return the number of points in the precomputation.