### PR TITLE
ed: update `VerifyingKey::from_bytes` with ZIP-215 info

### DIFF
--- a/ed25519-dalek/src/verifying.rs
+++ b/ed25519-dalek/src/verifying.rs
@@ -124,11 +124,8 @@ impl VerifyingKey {
 
     /// Construct a `VerifyingKey` from a slice of bytes.
     ///
-    /// # Warning
-    ///
-    /// The caller is responsible for ensuring that the bytes passed into this
-    /// method actually represent a `curve25519_dalek::curve::CompressedEdwardsY`
-    /// and that said compressed point is actually a point on the curve.
+    /// Verifies the point is valid under [ZIP-215] rules. RFC 8032 / NIST point validation criteria
+    /// are currently unsupported (see [dalek-cryptography/curve25519-dalek#626]).
     ///
     /// # Example
     ///
@@ -156,6 +153,9 @@ impl VerifyingKey {
     ///
     /// A `Result` whose okay value is an EdDSA `VerifyingKey` or whose error value
     /// is a `SignatureError` describing the error that occurred.
+    ///
+    /// [ZIP-215]: https://zips.z.cash/zip-0215
+    /// [dalek-cryptography/curve25519-dalek#626]: https://github.com/dalek-cryptography/curve25519-dalek/issues/626
     #[inline]
     pub fn from_bytes(bytes: &[u8; PUBLIC_KEY_LENGTH]) -> Result<VerifyingKey, SignatureError> {
         let compressed = CompressedEdwardsY(*bytes);


### PR DESCRIPTION
Removes the previous warning that points are unvalidated: they're validated using the ZIP-215 rules, which allows unreduced y-coordinates. Points are ensured valid by performing decompression, which finds a solution to the curve equation, or returns an error.

Adds references to ZIP-215 and dalek-cryptography/curve25519-dalek#626 which is an issue about potentially adding support for the RFC8032/NIST validation criteria in the future.