### PR TITLE
{curve,ed}25519-dalek: clippy fixes

### DIFF
--- a/curve25519-dalek/src/backend/vector/avx2/edwards.rs
+++ b/curve25519-dalek/src/backend/vector/avx2/edwards.rs
@@ -14,7 +14,7 @@
 //! This module currently has two point types:
 //!
 //! * `ExtendedPoint`: a point stored in vector-friendly format, with
-//! vectorized doubling and addition;
+//!   vectorized doubling and addition;
 //!
 //! * `CachedPoint`: used for readdition.
 //!

--- a/curve25519-dalek/src/backend/vector/packed_simd.rs
+++ b/curve25519-dalek/src/backend/vector/packed_simd.rs
@@ -240,7 +240,9 @@ impl u64x4 {
     pub const fn new_const(x0: u64, x1: u64, x2: u64, x3: u64) -> Self {
         // SAFETY: Transmuting between an array and a SIMD type is safe
         // https://rust-lang.github.io/unsafe-code-guidelines/layout/packed-simd-vectors.html
-        unsafe { Self(core::mem::transmute([x0, x1, x2, x3])) }
+        unsafe {
+            Self(core::mem::transmute::<[u64; 4], core::arch::x86_64::__m256i>([x0, x1, x2, x3]))
+        }
     }
 
     /// A constified variant of `splat`.
@@ -290,7 +292,13 @@ impl u32x8 {
     ) -> Self {
         // SAFETY: Transmuting between an array and a SIMD type is safe
         // https://rust-lang.github.io/unsafe-code-guidelines/layout/packed-simd-vectors.html
-        unsafe { Self(core::mem::transmute([x0, x1, x2, x3, x4, x5, x6, x7])) }
+        unsafe {
+            Self(
+                core::mem::transmute::<[u32; 8], core::arch::x86_64::__m256i>([
+                    x0, x1, x2, x3, x4, x5, x6, x7,
+                ]),
+            )
+        }
     }
 
     /// A constified variant of `splat`.

--- a/curve25519-dalek/src/edwards.rs
+++ b/curve25519-dalek/src/edwards.rs
@@ -52,19 +52,19 @@
 //! Scalar multiplication on Edwards points is provided by:
 //!
 //! * the `*` operator between a `Scalar` and a `EdwardsPoint`, which
-//! performs constant-time variable-base scalar multiplication;
+//!   performs constant-time variable-base scalar multiplication;
 //!
 //! * the `*` operator between a `Scalar` and a
-//! `EdwardsBasepointTable`, which performs constant-time fixed-base
-//! scalar multiplication;
+//!   `EdwardsBasepointTable`, which performs constant-time fixed-base
+//!   scalar multiplication;
 //!
 //! * an implementation of the
-//! [`MultiscalarMul`](../traits/trait.MultiscalarMul.html) trait for
-//! constant-time variable-base multiscalar multiplication;
+//!   [`MultiscalarMul`](../traits/trait.MultiscalarMul.html) trait for
+//!   constant-time variable-base multiscalar multiplication;
 //!
 //! * an implementation of the
-//! [`VartimeMultiscalarMul`](../traits/trait.VartimeMultiscalarMul.html)
-//! trait for variable-time variable-base multiscalar multiplication;
+//!   [`VartimeMultiscalarMul`](../traits/trait.VartimeMultiscalarMul.html)
+//!   trait for variable-time variable-base multiscalar multiplication;
 //!
 //! ## Implementation
 //!
@@ -1234,9 +1234,9 @@ impl EdwardsPoint {
     /// # Return
     ///
     /// * `true` if `self` has zero torsion component and is in the
-    /// prime-order subgroup;
+    ///   prime-order subgroup;
     /// * `false` if `self` has a nonzero torsion component and is not
-    /// in the prime-order subgroup.
+    ///   in the prime-order subgroup.
     ///
     /// # Example
     ///

--- a/curve25519-dalek/src/montgomery.rs
+++ b/curve25519-dalek/src/montgomery.rs
@@ -215,10 +215,10 @@ impl MontgomeryPoint {
     /// # Return
     ///
     /// * `Some(EdwardsPoint)` if `self` is the \\(u\\)-coordinate of a
-    /// point on (the Montgomery form of) Curve25519;
+    ///   point on (the Montgomery form of) Curve25519;
     ///
     /// * `None` if `self` is the \\(u\\)-coordinate of a point on the
-    /// twist of (the Montgomery form of) Curve25519;
+    ///   twist of (the Montgomery form of) Curve25519;
     ///
     pub fn to_edwards(&self, sign: u8) -> Option<EdwardsPoint> {
         // To decompress the Montgomery u coordinate to an

--- a/curve25519-dalek/src/ristretto.rs
+++ b/curve25519-dalek/src/ristretto.rs
@@ -93,19 +93,19 @@
 //! Scalar multiplication on Ristretto points is provided by:
 //!
 //! * the `*` operator between a `Scalar` and a `RistrettoPoint`, which
-//! performs constant-time variable-base scalar multiplication;
+//!   performs constant-time variable-base scalar multiplication;
 //!
 //! * the `*` operator between a `Scalar` and a
-//! `RistrettoBasepointTable`, which performs constant-time fixed-base
-//! scalar multiplication;
+//!   `RistrettoBasepointTable`, which performs constant-time fixed-base
+//!   scalar multiplication;
 //!
 //! * an implementation of the
-//! [`MultiscalarMul`](../traits/trait.MultiscalarMul.html) trait for
-//! constant-time variable-base multiscalar multiplication;
+//!   [`MultiscalarMul`](../traits/trait.MultiscalarMul.html) trait for
+//!   constant-time variable-base multiscalar multiplication;
 //!
 //! * an implementation of the
-//! [`VartimeMultiscalarMul`](../traits/trait.VartimeMultiscalarMul.html)
-//! trait for variable-time variable-base multiscalar multiplication;
+//!   [`VartimeMultiscalarMul`](../traits/trait.VartimeMultiscalarMul.html)
+//!   trait for variable-time variable-base multiscalar multiplication;
 //!
 //! ## Random Points and Hashing to Ristretto
 //!
@@ -113,11 +113,11 @@
 //! used to implement
 //!
 //! * `RistrettoPoint::random()`, which generates random points from an
-//! RNG - enabled by `rand_core` feature;
+//!   RNG - enabled by `rand_core` feature;
 //!
 //! * `RistrettoPoint::from_hash()` and
-//! `RistrettoPoint::hash_from_bytes()`, which perform hashing to the
-//! group.
+//!   `RistrettoPoint::hash_from_bytes()`, which perform hashing to the
+//!   group.
 //!
 //! The Elligator map itself is not currently exposed.
 //!

--- a/ed25519-dalek/src/signing.rs
+++ b/ed25519-dalek/src/signing.rs
@@ -774,7 +774,7 @@ impl<'d> Deserialize<'d> for SigningKey {
                     ));
                 }
 
-                SigningKey::try_from(bytes).map_err(serde::de::Error::custom)
+                Ok(SigningKey::from(bytes))
             }
         }
 


### PR DESCRIPTION
Clippy 1.81 brings new lints, this fixes those warnings