### PR TITLE
feat : Trait Reduce implemented for U256 and U512 on struct Scalar

### DIFF
--- a/curve25519-dalek/src/scalar.rs
+++ b/curve25519-dalek/src/scalar.rs
@@ -1362,7 +1362,17 @@ fn read_le_u64_into(src: &[u8], dst: &mut [u64]) {
         );
     }
 }
+// Implementing the Reduce trait for curve25519_dalek::Scalar
+impl Reduce<U256> for Scalar {
+    fn reduce(value: U256) -> Self {
+        Self::from_bytes_mod_order(value.to_bytes())
+    }
+}
 
+impl Reduce<U512> for Scalar {
+    fn reduce(value: U512) -> Self {
+        Self::from_bytes_mod_order_wide(value.to_bytes())
+  
 /// _Clamps_ the given little-endian representation of a 32-byte integer. Clamping the value puts
 /// it in the range:
 ///

--- a/curve25519-dalek/src/traits.rs
+++ b/curve25519-dalek/src/traits.rs
@@ -421,3 +421,9 @@ pub(crate) trait ValidityCheck {
     /// Checks whether the point is on the curve. Not CT.
     fn is_valid(&self) -> bool;
 }
+
+// Reduce trait 
+
+pub trait Reduce<T>{
+    fn reduce(value:T) -> Self
+}


### PR DESCRIPTION
This implementation will help standardize scalar reduction across different elliptic curve libraries, addressing the inconsistency 
closes #688 