### PR TITLE
Bump to rand[_core] 0.9

### DIFF
--- a/curve25519-dalek/Cargo.toml
+++ b/curve25519-dalek/Cargo.toml
@@ -34,8 +34,8 @@ sha2 = { version = "0.10", default-features = false }
 bincode = "1"
 criterion = { version = "0.5", features = ["html_reports"] }
 hex = "0.4.2"
-rand = "0.8"
-rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
+rand = "0.9"
+rand_core = { version = "0.9", default-features = false, features = ["getrandom"] }
 
 [build-dependencies]
 rustc_version = "0.4.0"
@@ -49,7 +49,7 @@ required-features = ["alloc", "rand_core"]
 cfg-if = "1"
 ff = { version = "0.13", default-features = false, optional = true }
 group = { version = "0.13", default-features = false, optional = true }
-rand_core = { version = "0.6.4", default-features = false, optional = true }
+rand_core = { version = "0.9", default-features = false, optional = true }
 digest = { version = "0.10", default-features = false, optional = true }
 subtle = { version = "2.6.0", default-features = false, features = ["const-generics"]}
 serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }

--- a/ed25519-dalek/Cargo.toml
+++ b/ed25519-dalek/Cargo.toml
@@ -34,7 +34,7 @@ subtle = { version = "2.3.0", default-features = false }
 
 # optional features
 merlin = { version = "3", default-features = false, optional = true }
-rand_core = { version = "0.6.4", default-features = false, optional = true }
+rand_core = { version = "0.9", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, optional = true }
 zeroize = { version = "1.5", default-features = false, optional = true }
 
@@ -48,8 +48,8 @@ bincode = "1.0"
 serde_json = "1.0"
 criterion = { version = "0.5", features = ["html_reports"] }
 hex-literal = "0.4"
-rand = "0.8"
-rand_core = { version = "0.6.4", default-features = false }
+rand = "0.9"
+rand_core = { version = "0.9", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 toml = { version = "0.7" }
 

--- a/x25519-dalek/Cargo.toml
+++ b/x25519-dalek/Cargo.toml
@@ -39,14 +39,14 @@ features = ["getrandom", "reusable_secrets", "serde", "static_secrets"]
 
 [dependencies]
 curve25519-dalek = { version = "4", path = "../curve25519-dalek", default-features = false }
-rand_core = { version = "0.6", default-features = false }
+rand_core = { version = "0.9", default-features = false }
 serde = { version = "1", default-features = false, optional = true, features = ["derive"] }
 zeroize = { version = "1", default-features = false, optional = true, features = ["zeroize_derive"] }
 
 [dev-dependencies]
 bincode = "1"
 criterion = "0.5"
-rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
+rand_core = { version = "0.9", default-features = false, features = ["getrandom"] }
 
 [[bench]]
 name = "x25519"


### PR DESCRIPTION
@tarcieri Any idea re: this complaint with 1.84 on dev-deps `rand_core, .. features = ["getrandom"]`

Using `getrandom` (which is implicit dep)
```
he package `curve25519-dalek` depends on `rand_core`, with features: `getrandom` but `rand_core` does not have these features.
 It has an optional dependency with that name, but that dependency uses the "dep:" syntax in the features table, so it does not have an implicit feature with that name.
```

Using `dep:getrandom` as it suggests
```toml
feature `dep:getrandom` in dependency `rand_core` is not allowed to use explicit `dep:` syntax
  If you want to enable an optional dependency, specify the name of the optional dependency without the `dep:` prefix, or specify a feature from the dependency's `[features]` table that enables the optional dependency.
```