### PR TITLE
Add methods to expose inner elements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ build*.txt
 *.bak
 
 *.s
+.idea

--- a/curve25519-dalek/src/edwards.rs
+++ b/curve25519-dalek/src/edwards.rs
@@ -375,6 +375,13 @@ pub struct EdwardsPoint {
     pub(crate) T: FieldElement,
 }
 
+impl EdwardsPoint {
+    /// Expose the inner coordinates
+    pub fn get_coordinates(&self) -> [FieldElement; 4] {
+        [self.X, self.Y, self.Z, self.T]
+    }
+}
+
 // ------------------------------------------------------------------------
 // Constructors
 // ------------------------------------------------------------------------

--- a/curve25519-dalek/src/ristretto.rs
+++ b/curve25519-dalek/src/ristretto.rs
@@ -484,6 +484,12 @@ impl<'de> Deserialize<'de> for CompressedRistretto {
 #[derive(Copy, Clone)]
 pub struct RistrettoPoint(pub(crate) EdwardsPoint);
 
+impl Into<EdwardsPoint> for RistrettoPoint {
+    fn into(self) -> EdwardsPoint {
+        self.0
+    }
+}
+
 impl RistrettoPoint {
     /// Compress this point using the Ristretto encoding.
     pub fn compress(&self) -> CompressedRistretto {


### PR DESCRIPTION
Currently `RistrettoPoint` hides the `EdwardsPoint`.
And `EdwardsPoint` hides `X,Y,Z,T` , but sometimes (like in my case), we need access to them.
Hence adding access methods.