### PR TITLE
Sign/verify by digest update + StreamVerifier

### DIFF
--- a/ed25519-dalek/CHANGELOG.md
+++ b/ed25519-dalek/CHANGELOG.md
@@ -9,8 +9,6 @@ Entries are listed in reverse chronological order per undeprecated major series.
 # Unreleased
 
 * Add `SigningKey::verify_stream()`, and `VerifyingKey::verify_stream()`
-* Add `hazmat` `raw_sign_byupdate()` and `raw_verify_byupdate()` to allow
-  passing a message incrementally.
   
 # 2.x series
 

--- a/ed25519-dalek/CHANGELOG.md
+++ b/ed25519-dalek/CHANGELOG.md
@@ -8,6 +8,7 @@ Entries are listed in reverse chronological order per undeprecated major series.
 
 # Unreleased
 
+* Add `SigningKey::verify_stream()`, and `VerifyingKey::verify_stream()`
 * Add `hazmat` `raw_sign_byupdate()` and `raw_verify_byupdate()` to allow
   passing a message incrementally.
   

--- a/ed25519-dalek/CHANGELOG.md
+++ b/ed25519-dalek/CHANGELOG.md
@@ -8,6 +8,9 @@ Entries are listed in reverse chronological order per undeprecated major series.
 
 # Unreleased
 
+* Add `hazmat` `raw_sign_byupdate()` and `raw_verify_byupdate()` to allow
+  passing a message incrementally.
+  
 # 2.x series
 
 ## 2.1.1

--- a/ed25519-dalek/src/hazmat.rs
+++ b/ed25519-dalek/src/hazmat.rs
@@ -311,4 +311,111 @@ mod test {
             .unwrap();
         raw_verify_prehashed::<CtxDigest, MsgDigest>(&vk, h, Some(ctx_str), &sig).unwrap();
     }
+
+    #[test]
+    fn sign_byupdate() {
+        // Generate the keypair
+        let mut rng = OsRng;
+        let esk = ExpandedSecretKey::random(&mut rng);
+        let vk = VerifyingKey::from(&esk);
+
+        let msg = b"realistic";
+        // signatures are deterministic so we can compare with a good one
+        let good_sig = raw_sign::<CtxDigest>(&esk, msg, &vk);
+
+        let sig = raw_sign_byupdate::<CtxDigest, _>(
+            &esk,
+            |h| {
+                h.update(msg);
+                Ok(())
+            },
+            &vk,
+        );
+        assert!(sig.unwrap() == good_sig, "sign byupdate matches");
+
+        let sig = raw_sign_byupdate::<CtxDigest, _>(
+            &esk,
+            |h| {
+                h.update(msg);
+                Err(SignatureError::new())
+            },
+            &vk,
+        );
+        assert!(sig.is_err(), "sign byupdate failure propagates");
+
+        let sig = raw_sign_byupdate::<CtxDigest, _>(
+            &esk,
+            |h| {
+                h.update(&msg[..1]);
+                h.update(&msg[1..]);
+                Ok(())
+            },
+            &vk,
+        );
+        assert!(sig.unwrap() == good_sig, "sign byupdate two part");
+    }
+
+    #[test]
+    fn verify_byupdate() {
+        // Generate the keypair
+        let mut rng = OsRng;
+        let esk = ExpandedSecretKey::random(&mut rng);
+        let vk = VerifyingKey::from(&esk);
+
+        let msg = b"Torrens title";
+        let sig = raw_sign::<CtxDigest>(&esk, msg, &vk);
+        let wrong_sig = raw_sign::<CtxDigest>(&esk, b"nope", &vk);
+
+        let r = raw_verify_byupdate::<CtxDigest, _>(
+            &vk,
+            |h| {
+                h.update(msg);
+                Ok(())
+            },
+            &sig,
+        );
+        assert!(r.is_ok(), "verify byupdate success");
+
+        let r = raw_verify_byupdate::<CtxDigest, _>(
+            &vk,
+            |h| {
+                h.update(msg);
+                Ok(())
+            },
+            &wrong_sig,
+        );
+        assert!(r.is_err(), "verify byupdate wrong fails");
+
+        let r = raw_verify_byupdate::<CtxDigest, _>(
+            &vk,
+            |h| {
+                h.update(&msg[..5]);
+                h.update(&msg[5..]);
+                Ok(())
+            },
+            &sig,
+        );
+        assert!(r.is_ok(), "verify byupdate two-part");
+
+        let r = raw_verify_byupdate::<CtxDigest, _>(
+            &vk,
+            |h| {
+                h.update(msg);
+                h.update(b"X");
+                Ok(())
+            },
+            &sig,
+        );
+        assert!(r.is_err(), "verify byupdate extra fails");
+
+        let r = raw_verify_byupdate::<CtxDigest, _>(
+            &vk,
+            |h| {
+                h.update(msg);
+                Err(SignatureError::new())
+            },
+            &sig,
+        );
+        assert!(r.is_err(), "verify byupdate error propagates");
+    }
 }

--- a/ed25519-dalek/src/hazmat.rs
+++ b/ed25519-dalek/src/hazmat.rs
@@ -180,7 +180,7 @@ where
 /// Sha512`.
 ///
 ///
-/// # ⚠️  Unsafe
+/// # ⚠️  Cryptographically Unsafe
 ///
 /// Do NOT use this function unless you absolutely must. Using the wrong values in
 /// `ExpandedSecretKey` can leak your signing key. See

--- a/ed25519-dalek/src/hazmat.rs
+++ b/ed25519-dalek/src/hazmat.rs
@@ -169,6 +169,34 @@ where
     esk.raw_sign_prehashed::<CtxDigest, MsgDigest>(prehashed_message, verifying_key, context)
 }
 
+/// Compute an ordinary Ed25519 signature, with the message contents provided incrementally
+/// by updating a digest instance.
+///
+/// The `msg_update` closure provides the message content, updating a hash argument.
+/// It will be called twice.
+///
+/// `CtxDigest` is the digest used to
+/// calculate the pseudorandomness needed for signing. According to the Ed25519 spec, `CtxDigest =
+/// Sha512`.
+///
+///
+/// # ⚠️  Unsafe
+///
+/// Do NOT use this function unless you absolutely must. Using the wrong values in
+/// `ExpandedSecretKey` can leak your signing key. See
+/// [here](https://github.com/MystenLabs/ed25519-unsafe-libs) for more details on this attack.
+pub fn raw_sign_byupdate<CtxDigest, F>(
+    esk: &ExpandedSecretKey,
+    msg_update: F,
+    verifying_key: &VerifyingKey,
+) -> Result<Signature, SignatureError>
+where
+    CtxDigest: Digest<OutputSize = U64>,
+    F: Fn(&mut CtxDigest) -> Result<(), SignatureError>,
+{
+    esk.raw_sign_byupdate::<CtxDigest, F>(msg_update, verifying_key)
+}
+
 /// The ordinary non-batched Ed25519 verification check, rejecting non-canonical R
 /// values.`CtxDigest` is the digest used to calculate the pseudorandomness needed for signing.
 /// According to the Ed25519 spec, `CtxDigest = Sha512`.
@@ -200,6 +228,26 @@ where
     CtxDigest: Digest<OutputSize = U64>,
 {
     vk.raw_verify_prehashed::<CtxDigest, MsgDigest>(prehashed_message, context, signature)
+}
+
+/// Performs an ordinary Ed25519 verification check, with the message passed incrementally.
+///
+/// Instead of passing the message directly ([`raw_verify()`]), the caller
+/// provides a `msg_update` closure that will be called to feed the
+/// hash of the message being verified.
+///
+/// `CtxDigest` is the digest used to calculate the pseudorandomness needed for signing.
+/// According to the Ed25519 spec, `CtxDigest = Sha512`.
+pub fn raw_verify_byupdate<CtxDigest, F>(
+    vk: &VerifyingKey,
+    msg_update: F,
+    signature: &ed25519::Signature,
+) -> Result<(), SignatureError>
+where
+    CtxDigest: Digest<OutputSize = U64>,
+    F: Fn(&mut CtxDigest) -> Result<(), SignatureError>,
+{
+    vk.raw_verify_byupdate::<CtxDigest, F>(msg_update, signature)
 }
 
 #[cfg(test)]

--- a/ed25519-dalek/src/hazmat.rs
+++ b/ed25519-dalek/src/hazmat.rs
@@ -245,7 +245,7 @@ pub fn raw_verify_byupdate<CtxDigest, F>(
 ) -> Result<(), SignatureError>
 where
     CtxDigest: Digest<OutputSize = U64>,
-    F: Fn(&mut CtxDigest) -> Result<(), SignatureError>,
+    F: FnOnce(&mut CtxDigest) -> Result<(), SignatureError>,
 {
     vk.raw_verify_byupdate::<CtxDigest, F>(msg_update, signature)
 }

--- a/ed25519-dalek/src/signing.rs
+++ b/ed25519-dalek/src/signing.rs
@@ -820,6 +820,7 @@ impl ExpandedSecretKey {
     /// This definition is loose in its parameters so that end-users of the `hazmat` module can
     /// change how the `ExpandedSecretKey` is calculated and which hash function to use.
     #[allow(non_snake_case)]
+    #[allow(clippy::unwrap_used)]
     #[inline(always)]
     pub(crate) fn raw_sign<CtxDigest>(
         &self,
@@ -829,10 +830,34 @@ impl ExpandedSecretKey {
     where
         CtxDigest: Digest<OutputSize = U64>,
     {
+        // OK unwrap, update can't fail.
+        self.raw_sign_byupdate(
+            |h: &mut CtxDigest| {
+                h.update(message);
+                Ok(())
+            },
+            verifying_key,
+        )
+        .unwrap()
+    }
+
+    /// Sign a message provided in parts. The `msg_update` closure
+    /// will be called twice to hash the message parts.
+    #[allow(non_snake_case)]
+    #[inline(always)]
+    pub(crate) fn raw_sign_byupdate<CtxDigest, F>(
+        &self,
+        msg_update: F,
+        verifying_key: &VerifyingKey,
+    ) -> Result<Signature, SignatureError>
+    where
+        CtxDigest: Digest<OutputSize = U64>,
+        F: Fn(&mut CtxDigest) -> Result<(), SignatureError>,
+    {
         let mut h = CtxDigest::new();
 
         h.update(self.hash_prefix);
-        h.update(message);
+        msg_update(&mut h)?;
 
         let r = Scalar::from_hash(h);
         let R: CompressedEdwardsY = EdwardsPoint::mul_base(&r).compress();
@@ -840,12 +865,12 @@ impl ExpandedSecretKey {
         h = CtxDigest::new();
         h.update(R.as_bytes());
         h.update(verifying_key.as_bytes());
-        h.update(message);
+        msg_update(&mut h)?;
 
         let k = Scalar::from_hash(h);
         let s: Scalar = (k * self.scalar) + r;
 
-        InternalSignature { R, s }.into()
+        Ok(InternalSignature { R, s }.into())
     }
 
     /// The prehashed signing function for Ed25519 (i.e., Ed25519ph). `CtxDigest` is the digest

--- a/ed25519-dalek/src/signing.rs
+++ b/ed25519-dalek/src/signing.rs
@@ -39,12 +39,14 @@ use signature::DigestSigner;
 #[cfg(feature = "zeroize")]
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
+#[cfg(feature = "hazmat")]
+use crate::verifying::StreamVerifier;
 use crate::{
     constants::{KEYPAIR_LENGTH, SECRET_KEY_LENGTH},
     errors::{InternalError, SignatureError},
     hazmat::ExpandedSecretKey,
     signature::InternalSignature,
-    verifying::{StreamVerifier, VerifyingKey},
+    verifying::VerifyingKey,
     Signature,
 };
 
@@ -486,6 +488,7 @@ impl SigningKey {
     /// Constructs stream verifier with candidate `signature`.
     ///
     /// See [`VerifyingKey::verify_stream()`] for more details.
+    #[cfg(feature = "hazmat")]
     pub fn verify_stream(
         &self,
         signature: &ed25519::Signature,

--- a/ed25519-dalek/src/signing.rs
+++ b/ed25519-dalek/src/signing.rs
@@ -44,7 +44,7 @@ use crate::{
     errors::{InternalError, SignatureError},
     hazmat::ExpandedSecretKey,
     signature::InternalSignature,
-    verifying::VerifyingKey,
+    verifying::{StreamVerifier, VerifyingKey},
     Signature,
 };
 
@@ -481,6 +481,16 @@ impl SigningKey {
         signature: &Signature,
     ) -> Result<(), SignatureError> {
         self.verifying_key.verify_strict(message, signature)
+    }
+
+    /// Constructs stream verifier with candidate `signature`.
+    ///
+    /// See [`VerifyingKey::verify_stream()`] for more details.
+    pub fn verify_stream(
+        &self,
+        signature: &ed25519::Signature,
+    ) -> Result<StreamVerifier, SignatureError> {
+        self.verifying_key.verify_stream(signature)
     }
 
     /// Convert this signing key into a byte representation of an unreduced, unclamped Curve25519

--- a/ed25519-dalek/src/signing.rs
+++ b/ed25519-dalek/src/signing.rs
@@ -833,7 +833,6 @@ impl ExpandedSecretKey {
     /// This definition is loose in its parameters so that end-users of the `hazmat` module can
     /// change how the `ExpandedSecretKey` is calculated and which hash function to use.
     #[allow(non_snake_case)]
-    #[allow(clippy::unwrap_used)]
     #[inline(always)]
     pub(crate) fn raw_sign<CtxDigest>(
         &self,
@@ -843,34 +842,10 @@ impl ExpandedSecretKey {
     where
         CtxDigest: Digest<OutputSize = U64>,
     {
-        // OK unwrap, update can't fail.
-        self.raw_sign_byupdate(
-            |h: &mut CtxDigest| {
-                h.update(message);
-                Ok(())
-            },
-            verifying_key,
-        )
-        .unwrap()
-    }
-
-    /// Sign a message provided in parts. The `msg_update` closure
-    /// will be called twice to hash the message parts.
-    #[allow(non_snake_case)]
-    #[inline(always)]
-    pub(crate) fn raw_sign_byupdate<CtxDigest, F>(
-        &self,
-        msg_update: F,
-        verifying_key: &VerifyingKey,
-    ) -> Result<Signature, SignatureError>
-    where
-        CtxDigest: Digest<OutputSize = U64>,
-        F: Fn(&mut CtxDigest) -> Result<(), SignatureError>,
-    {
         let mut h = CtxDigest::new();
 
         h.update(self.hash_prefix);
-        msg_update(&mut h)?;
+        h.update(message);
 
         let r = Scalar::from_hash(h);
         let R: CompressedEdwardsY = EdwardsPoint::mul_base(&r).compress();
@@ -878,12 +853,12 @@ impl ExpandedSecretKey {
         h = CtxDigest::new();
         h.update(R.as_bytes());
         h.update(verifying_key.as_bytes());
-        msg_update(&mut h)?;
+        h.update(message);
 
         let k = Scalar::from_hash(h);
         let s: Scalar = (k * self.scalar) + r;
 
-        Ok(InternalSignature { R, s }.into())
+        InternalSignature { R, s }.into()
     }
 
     /// The prehashed signing function for Ed25519 (i.e., Ed25519ph). `CtxDigest` is the digest

--- a/ed25519-dalek/src/verifying.rs
+++ b/ed25519-dalek/src/verifying.rs
@@ -186,58 +186,8 @@ impl VerifyingKey {
         self.point.is_small_order()
     }
 
-    // A helper function that computes `H(R || A || M)` where `H` is the 512-bit hash function
-    // given by `CtxDigest` (this is SHA-512 in spec-compliant Ed25519). If `context.is_some()`,
-    // this does the prehashed variant of the computation using its contents.
-    #[allow(non_snake_case)]
-    fn compute_challenge<CtxDigest>(
-        context: Option<&[u8]>,
-        R: &CompressedEdwardsY,
-        A: &CompressedEdwardsY,
-        M: &[u8],
-    ) -> Scalar
-    where
-        CtxDigest: Digest<OutputSize = U64>,
-    {
-        let mut h = CtxDigest::new();
-        if let Some(c) = context {
-            h.update(b"SigEd25519 no Ed25519 collisions");
-            h.update([1]); // Ed25519ph
-            h.update([c.len() as u8]);
-            h.update(c);
-        }
-        h.update(R.as_bytes());
-        h.update(A.as_bytes());
-        h.update(M);
-
-        Scalar::from_hash(h)
-    }
-
-    // Helper function for verification. Computes the _expected_ R component of the signature. The
-    // caller compares this to the real R component.  If `context.is_some()`, this does the
-    // prehashed variant of the computation using its contents.
-    // Note that this returns the compressed form of R and the caller does a byte comparison. This
-    // means that all our verification functions do not accept non-canonically encoded R values.
-    // See the validation criteria blog post for more details:
-    //     https://hdevalence.ca/blog/2020-10-04-its-25519am
-    #[allow(non_snake_case)]
-    fn recompute_R<CtxDigest>(
-        &self,
-        context: Option<&[u8]>,
-        signature: &InternalSignature,
-        M: &[u8],
-    ) -> CompressedEdwardsY
-    where
-        CtxDigest: Digest<OutputSize = U64>,
-    {
-        let k = Self::compute_challenge::<CtxDigest>(context, &signature.R, &self.compressed, M);
-        let minus_A: EdwardsPoint = -self.point;
-        // Recall the (non-batched) verification equation: -[k]A + [s]B = R
-        EdwardsPoint::vartime_double_scalar_mul_basepoint(&k, &(minus_A), &signature.s).compress()
-    }
-
     /// The ordinary non-batched Ed25519 verification check, rejecting non-canonical R values. (see
-    /// [`Self::recompute_R`]). `CtxDigest` is the digest used to calculate the pseudorandomness
+    /// [`Self::RCompute`]). `CtxDigest` is the digest used to calculate the pseudorandomness
     /// needed for signing. According to the spec, `CtxDigest = Sha512`.
     ///
     /// This definition is loose in its parameters so that end-users of the `hazmat` module can
@@ -253,7 +203,7 @@ impl VerifyingKey {
     {
         let signature = InternalSignature::try_from(signature)?;
 
-        let expected_R = self.recompute_R::<CtxDigest>(None, &signature, message);
+        let expected_R = RCompute::<CtxDigest>::compute(self, signature, None, message);
         if expected_R == signature.R {
             Ok(())
         } else {
@@ -289,7 +239,8 @@ impl VerifyingKey {
         );
 
         let message = prehashed_message.finalize();
-        let expected_R = self.recompute_R::<CtxDigest>(Some(ctx), &signature, &message);
+
+        let expected_R = RCompute::<CtxDigest>::compute(self, signature, Some(ctx), &message);
 
         if expected_R == signature.R {
             Ok(())
@@ -415,7 +366,7 @@ impl VerifyingKey {
             return Err(InternalError::Verify.into());
         }
 
-        let expected_R = self.recompute_R::<Sha512>(None, &signature, message);
+        let expected_R = RCompute::<Sha512>::compute(self, signature, None, message);
         if expected_R == signature.R {
             Ok(())
         } else {
@@ -477,7 +428,7 @@ impl VerifyingKey {
         }
 
         let message = prehashed_message.finalize();
-        let expected_R = self.recompute_R::<Sha512>(Some(ctx), &signature, &message);
+        let expected_R = RCompute::<Sha512>::compute(self, signature, Some(ctx), &message);
 
         if expected_R == signature.R {
             Ok(())
@@ -508,6 +459,78 @@ impl VerifyingKey {
     /// Return this verifying key in Edwards form.
     pub fn to_edwards(&self) -> EdwardsPoint {
         self.point
+    }
+}
+
+// Helper for verification. Computes the _expected_ R component of the signature. The
+// caller compares this to the real R component.
+// This computes `H(R || A || M)` where `H` is the 512-bit hash function
+// given by `CtxDigest` (this is SHA-512 in spec-compliant Ed25519).
+
+// For prehashed variants a `h` with the context already included can be provided.
+// Note that this returns the compressed form of R and the caller does a byte comparison. This
+// means that all our verification functions do not accept non-canonically encoded R values.
+// See the validation criteria blog post for more details:
+//     https://hdevalence.ca/blog/2020-10-04-its-25519am
+pub(crate) struct RCompute<CtxDigest> {
+    key: VerifyingKey,
+    signature: InternalSignature,
+    h: CtxDigest,
+}
+
+#[allow(non_snake_case)]
+impl<CtxDigest> RCompute<CtxDigest>
+where
+    CtxDigest: Digest<OutputSize = U64>,
+{
+    // If `prehash_ctx.is_some()`, this does the prehashed variant of the computation using its contents.
+    pub fn compute(
+        key: &VerifyingKey,
+        signature: InternalSignature,
+        prehash_ctx: Option<&[u8]>,
+        message: &[u8],
+    ) -> CompressedEdwardsY {
+        let mut c = Self::new(key, signature, prehash_ctx);
+        c.update(message);
+        c.finish()
+    }
+
+    pub fn new(
+        key: &VerifyingKey,
+        signature: InternalSignature,
+        prehash_ctx: Option<&[u8]>,
+    ) -> Self {
+        let R = &signature.R;
+        let A = &key.compressed;
+
+        let mut h = CtxDigest::new();
+        if let Some(c) = prehash_ctx {
+            h.update(b"SigEd25519 no Ed25519 collisions");
+            h.update([1]); // Ed25519ph
+            h.update([c.len() as u8]);
+            h.update(c);
+        }
+
+        h.update(R.as_bytes());
+        h.update(A.as_bytes());
+        Self {
+            key: *key,
+            signature,
+            h,
+        }
+    }
+
+    pub fn update(&mut self, m: &[u8]) {
+        self.h.update(m)
+    }
+
+    pub fn finish(self) -> CompressedEdwardsY {
+        let k = Scalar::from_hash(self.h);
+
+        let minus_A: EdwardsPoint = -self.key.point;
+        // Recall the (non-batched) verification equation: -[k]A + [s]B = R
+        EdwardsPoint::vartime_double_scalar_mul_basepoint(&k, &(minus_A), &self.signature.s)
+            .compress()
     }
 }
 

--- a/ed25519-dalek/src/verifying.rs
+++ b/ed25519-dalek/src/verifying.rs
@@ -42,6 +42,9 @@ use crate::{
     signing::SigningKey,
 };
 
+mod stream;
+pub use self::stream::StreamVerifier;
+
 /// An ed25519 public key.
 ///
 /// # Note
@@ -397,8 +400,21 @@ impl VerifyingKey {
         }
     }
 
+    /// Constructs stream verifier with candidate `signature`.
+    ///
+    /// Useful for cases where the whole message is not available all at once, allowing the
+    /// internal signature state to be updated incrementally and verified at the end. In some cases,
+    /// this will reduce the need for additional allocations.
+    pub fn verify_stream(
+        &self,
+        signature: &ed25519::Signature,
+    ) -> Result<StreamVerifier, SignatureError> {
+        let signature = InternalSignature::try_from(signature)?;
+        Ok(StreamVerifier::new(*self, signature))
+    }
+
     /// Verify a `signature` on a `prehashed_message` using the Ed25519ph algorithm,
-    /// using strict signture checking as defined by [`Self::verify_strict`].
+    /// using strict signature checking as defined by [`Self::verify_strict`].
     ///
     /// # Inputs
     ///

--- a/ed25519-dalek/src/verifying.rs
+++ b/ed25519-dalek/src/verifying.rs
@@ -42,7 +42,9 @@ use crate::{
     signing::SigningKey,
 };
 
+#[cfg(feature = "hazmat")]
 mod stream;
+#[cfg(feature = "hazmat")]
 pub use self::stream::StreamVerifier;
 
 /// An ed25519 public key.
@@ -405,6 +407,7 @@ impl VerifyingKey {
     /// Useful for cases where the whole message is not available all at once, allowing the
     /// internal signature state to be updated incrementally and verified at the end. In some cases,
     /// this will reduce the need for additional allocations.
+    #[cfg(feature = "hazmat")]
     pub fn verify_stream(
         &self,
         signature: &ed25519::Signature,

--- a/ed25519-dalek/src/verifying.rs
+++ b/ed25519-dalek/src/verifying.rs
@@ -211,6 +211,29 @@ impl VerifyingKey {
         }
     }
 
+    #[allow(non_snake_case)]
+    pub(crate) fn raw_verify_byupdate<CtxDigest, F>(
+        &self,
+        msg_update: F,
+        signature: &ed25519::Signature,
+    ) -> Result<(), SignatureError>
+    where
+        CtxDigest: Digest<OutputSize = U64>,
+        F: Fn(&mut CtxDigest) -> Result<(), SignatureError>,
+    {
+        let signature = InternalSignature::try_from(signature)?;
+
+        let mut c = RCompute::<CtxDigest>::new(self, signature, None);
+        msg_update(&mut c.h)?;
+        let expected_R = c.finish();
+
+        if expected_R == signature.R {
+            Ok(())
+        } else {
+            Err(InternalError::Verify.into())
+        }
+    }
+
     /// The prehashed non-batched Ed25519 verification check, rejecting non-canonical R values.
     /// (see [`Self::recompute_R`]). `CtxDigest` is the digest used to calculate the
     /// pseudorandomness needed for signing. `MsgDigest` is the digest used to hash the signed

--- a/ed25519-dalek/src/verifying.rs
+++ b/ed25519-dalek/src/verifying.rs
@@ -216,29 +216,6 @@ impl VerifyingKey {
         }
     }
 
-    #[allow(non_snake_case)]
-    pub(crate) fn raw_verify_byupdate<CtxDigest, F>(
-        &self,
-        msg_update: F,
-        signature: &ed25519::Signature,
-    ) -> Result<(), SignatureError>
-    where
-        CtxDigest: Digest<OutputSize = U64>,
-        F: FnOnce(&mut CtxDigest) -> Result<(), SignatureError>,
-    {
-        let signature = InternalSignature::try_from(signature)?;
-
-        let mut c = RCompute::<CtxDigest>::new(self, signature, None);
-        msg_update(&mut c.h)?;
-        let expected_R = c.finish();
-
-        if expected_R == signature.R {
-            Ok(())
-        } else {
-            Err(InternalError::Verify.into())
-        }
-    }
-
     /// The prehashed non-batched Ed25519 verification check, rejecting non-canonical R values.
     /// (see [`Self::recompute_R`]). `CtxDigest` is the digest used to calculate the
     /// pseudorandomness needed for signing. `MsgDigest` is the digest used to hash the signed

--- a/ed25519-dalek/src/verifying/stream.rs
+++ b/ed25519-dalek/src/verifying/stream.rs
@@ -1,0 +1,58 @@
+use curve25519_dalek::{edwards::EdwardsPoint, scalar::Scalar};
+use sha2::{Digest, Sha512};
+
+use crate::{signature::InternalSignature, InternalError, SignatureError, VerifyingKey};
+
+/// An IUF verifier for ed25519.
+///
+/// Created with [`VerifyingKey::verify_stream()`] or [`SigningKey::verify_stream()`].
+///
+/// [`SigningKey::verify_stream()`]: super::SigningKey::verify_stream()
+#[derive(Debug)]
+pub struct StreamVerifier {
+    /// Public key to verify with.
+    pub(crate) public_key: VerifyingKey,
+
+    /// Candidate signature to verify against.
+    pub(crate) signature: InternalSignature,
+
+    /// Hash state.
+    pub(crate) hasher: Sha512,
+}
+
+impl StreamVerifier {
+    /// Constructs new stream verifier.
+    ///
+    /// Seeds hash state with public key and signature components.
+    pub(crate) fn new(public_key: VerifyingKey, signature: InternalSignature) -> Self {
+        let mut hasher = Sha512::new();
+        hasher.update(signature.R.as_bytes());
+        hasher.update(public_key.as_bytes());
+
+        Self {
+            public_key,
+            hasher,
+            signature,
+        }
+    }
+
+    /// Digest message chunk.
+    pub fn update(&mut self, chunk: impl AsRef<[u8]>) {
+        self.hasher.update(&chunk);
+    }
+
+    /// Finalize verifier and check against candidate signature.
+    #[allow(non_snake_case)]
+    pub fn finalize_and_verify(self) -> Result<(), SignatureError> {
+        let minus_A: EdwardsPoint = -self.public_key.point;
+        let k = Scalar::from_hash(self.hasher);
+        let R =
+            EdwardsPoint::vartime_double_scalar_mul_basepoint(&k, &(minus_A), &self.signature.s);
+
+        if R.compress() == self.signature.R {
+            Ok(())
+        } else {
+            Err(InternalError::Verify.into())
+        }
+    }
+}

--- a/ed25519-dalek/tests/ed25519.rs
+++ b/ed25519-dalek/tests/ed25519.rs
@@ -338,28 +338,25 @@ mod integrations {
     #[test]
     fn sign_verify_digest_equivalence() {
         // TestSignVerify
-        let keypair: SigningKey;
-        let good_sig: Signature;
-        let bad_sig: Signature;
+
+        let mut csprng = OsRng {};
 
         let good: &[u8] = "test message".as_bytes();
         let bad: &[u8] = "wrong message".as_bytes();
 
-        let mut csprng = OsRng {};
-
-        keypair = SigningKey::generate(&mut csprng);
-        good_sig = keypair.sign(&good);
-        bad_sig = keypair.sign(&bad);
+        let keypair: SigningKey = SigningKey::generate(&mut csprng);
+        let good_sig: Signature = keypair.sign(good);
+        let bad_sig: Signature = keypair.sign(bad);
 
         let mut verifier = keypair.verify_stream(&good_sig).unwrap();
-        verifier.update(&good);
+        verifier.update(good);
         assert!(
             verifier.finalize_and_verify().is_ok(),
             "Verification of a valid signature failed!"
         );
 
         let mut verifier = keypair.verify_stream(&bad_sig).unwrap();
-        verifier.update(&good);
+        verifier.update(good);
         assert!(
             verifier.finalize_and_verify().is_err(),
             "Verification of a signature on a different message passed!"
@@ -374,7 +371,7 @@ mod integrations {
         );
 
         let mut verifier = keypair.verify_stream(&good_sig).unwrap();
-        verifier.update(&bad);
+        verifier.update(bad);
         assert!(
             verifier.finalize_and_verify().is_err(),
             "Verification of a signature on a different message passed!"

--- a/ed25519-dalek/tests/ed25519.rs
+++ b/ed25519-dalek/tests/ed25519.rs
@@ -365,6 +365,14 @@ mod integrations {
             "Verification of a signature on a different message passed!"
         );
 
+        let mut verifier = keypair.verify_stream(&bad_sig).unwrap();
+        verifier.update("test ");
+        verifier.update("message");
+        assert!(
+            verifier.finalize_and_verify().is_err(),
+            "Verification of a signature on a different chunked message passed!"
+        );
+
         let mut verifier = keypair.verify_stream(&good_sig).unwrap();
         verifier.update(&bad);
         assert!(

--- a/ed25519-dalek/tests/ed25519.rs
+++ b/ed25519-dalek/tests/ed25519.rs
@@ -336,6 +336,45 @@ mod integrations {
 
     #[cfg(feature = "digest")]
     #[test]
+    fn sign_verify_digest_equivalence() {
+        // TestSignVerify
+        let keypair: SigningKey;
+        let good_sig: Signature;
+        let bad_sig: Signature;
+
+        let good: &[u8] = "test message".as_bytes();
+        let bad: &[u8] = "wrong message".as_bytes();
+
+        let mut csprng = OsRng {};
+
+        keypair = SigningKey::generate(&mut csprng);
+        good_sig = keypair.sign(&good);
+        bad_sig = keypair.sign(&bad);
+
+        let mut verifier = keypair.verify_stream(&good_sig).unwrap();
+        verifier.update(&good);
+        assert!(
+            verifier.finalize_and_verify().is_ok(),
+            "Verification of a valid signature failed!"
+        );
+
+        let mut verifier = keypair.verify_stream(&bad_sig).unwrap();
+        verifier.update(&good);
+        assert!(
+            verifier.finalize_and_verify().is_err(),
+            "Verification of a signature on a different message passed!"
+        );
+
+        let mut verifier = keypair.verify_stream(&good_sig).unwrap();
+        verifier.update(&bad);
+        assert!(
+            verifier.finalize_and_verify().is_err(),
+            "Verification of a signature on a different message passed!"
+        );
+    }
+
+    #[cfg(feature = "digest")]
+    #[test]
     fn ed25519ph_sign_verify() {
         let good: &[u8] = b"test message";
         let bad: &[u8] = b"wrong message";

--- a/ed25519-dalek/tests/ed25519.rs
+++ b/ed25519-dalek/tests/ed25519.rs
@@ -362,12 +362,12 @@ mod integrations {
             "Verification of a signature on a different message passed!"
         );
 
-        let mut verifier = keypair.verify_stream(&bad_sig).unwrap();
+        let mut verifier = keypair.verify_stream(&good_sig).unwrap();
         verifier.update("test ");
         verifier.update("message");
         assert!(
-            verifier.finalize_and_verify().is_err(),
-            "Verification of a signature on a different chunked message passed!"
+            verifier.finalize_and_verify().is_ok(),
+            "Verification of a valid signature failed!"
         );
 
         let mut verifier = keypair.verify_stream(&good_sig).unwrap();


### PR DESCRIPTION
see description and discussion in https://github.com/dalek-cryptography/curve25519-dalek/pull/556

this PR reuses all commits from that one, and adds in the feature guard we talked about

~nightly CI failure is unrelated~