### PR TITLE
chore: fix quotation marks

### DIFF
--- a/curve25519-dalek/docs/ifma-notes.md
+++ b/curve25519-dalek/docs/ifma-notes.md
@@ -32,14 +32,14 @@ Integer Arithmetic Using Intel IFMA Extensions_][2016_gueron_krasnov].
 The basic idea is that multiplication of large integers (such as 1024,
 2048, or more bits) can be performed as follows.
 
-First, convert a “packed” 64-bit representation
+First, convert a "packed" 64-bit representation
 \\[
 \begin{aligned}
 x &= x'_0 + x'_1 2^{64} + x'_2 2^{128} + \cdots \\\\
 y &= y'_0 + y'_1 2^{64} + y'_2 2^{128} + \cdots 
 \end{aligned}
 \\]
-into a “redundant” 52-bit representation
+into a "redundant" 52-bit representation
 \\[
 \begin{aligned}
 x &= x_0 + x_1 2^{52} + x_2 2^{104} + \cdots \\\\
@@ -49,7 +49,7 @@ y &= y_0 + y_1 2^{52} + y_2 2^{104} + \cdots
 with each \\(x_i, y_j\\) in a 64-bit lane.
 
 Writing the product as \\(z = z_0 + z_1 2^{52} + z_2 2^{104} + \cdots\\),
-the “schoolbook” multiplication strategy gives
+the "schoolbook" multiplication strategy gives
 \\[
 \begin{aligned}
 &z_0   &&=& x_0      &   y_0    &           &          &           &          &           &          &        &       \\\\

--- a/curve25519-dalek/docs/parallel-formulas.md
+++ b/curve25519-dalek/docs/parallel-formulas.md
@@ -9,7 +9,7 @@ using AVX2, and the other using AVX512-IFMA.
 # Overview
 
 The 2008 paper [_Twisted Edwards Curves Revisited_][hwcd08] by Hisil,
-Wong, Carter, and Dawson (HWCD) introduced the “extended coordinates”
+Wong, Carter, and Dawson (HWCD) introduced the "extended coordinates"
 and mixed-model representations which are used by most Edwards curve
 implementations.
 
@@ -242,7 +242,7 @@ possible to pre-multiply by \\(19\\).
 
 Second, the parallel doubling formulas incur both a theoretical and
 practical slowdown.  The parallel formulas described above work on the
-\\( \mathbb P\^3 \\) “extended” coordinates.  The \\( \mathbb P\^2 \\)
+\\( \mathbb P\^3 \\) "extended" coordinates.  The \\( \mathbb P\^2 \\)
 model introduced earlier by [Bernstein, Birkner, Joye, Lange, and
 Peters][bbjlp08] allows slightly faster doublings, so HWCD suggest
 mixing coordinate systems while performing scalar multiplication

--- a/curve25519-dalek/src/edwards.rs
+++ b/curve25519-dalek/src/edwards.rs
@@ -68,8 +68,8 @@
 //!
 //! ## Implementation
 //!
-//! The Edwards arithmetic is implemented using the “extended twisted
-//! coordinates” of Hisil, Wong, Carter, and Dawson, and the
+//! The Edwards arithmetic is implemented using the "extended twisted
+//! coordinates" of Hisil, Wong, Carter, and Dawson, and the
 //! corresponding complete formulas.  For more details,
 //! see the [`curve_models` submodule][curve_models]
 //! of the internal documentation.
@@ -1236,7 +1236,7 @@ impl EdwardsPoint {
         self.mul_by_cofactor().is_identity()
     }
 
-    /// Determine if this point is “torsion-free”, i.e., is contained in
+    /// Determine if this point is "torsion-free", i.e., is contained in
     /// the prime-order subgroup.
     ///
     /// # Return

--- a/curve25519-dalek/src/montgomery.rs
+++ b/curve25519-dalek/src/montgomery.rs
@@ -12,8 +12,8 @@
 //! Scalar multiplication on the Montgomery form of Curve25519.
 //!
 //! To avoid notational confusion with the Edwards code, we use
-//! variables \\( u, v \\) for the Montgomery curve, so that “Montgomery
-//! \\(u\\)” here corresponds to “Montgomery \\(x\\)” elsewhere.
+//! variables \\( u, v \\) for the Montgomery curve, so that "Montgomery
+//! \\(u\\)" here corresponds to "Montgomery \\(x\\)" elsewhere.
 //!
 //! Montgomery arithmetic works not on the curve itself, but on the
 //! \\(u\\)-line, which discards sign information and unifies the curve

--- a/curve25519-dalek/src/ristretto.rs
+++ b/curve25519-dalek/src/ristretto.rs
@@ -35,7 +35,7 @@
 //! small cofactor \\(h\\) (for instance, Edwards curves, which have
 //! cofactor at least \\(4\\)).
 //!
-//! This abstraction mismatch is commonly “handled” by pushing the
+//! This abstraction mismatch is commonly "handled" by pushing the
 //! complexity upwards, adding ad-hoc protocol modifications.  But
 //! these modifications require careful analysis and are a recurring
 //! source of [vulnerabilities][cryptonote] and [design
@@ -46,8 +46,8 @@
 //! the correct abstraction for cryptographic systems, while retaining
 //! the speed and safety benefits of an Edwards curve.
 //!
-//! Decaf is named “after the procedure which divides the effect of
-//! coffee by \\(4\\)”.  However, Curve25519 has a cofactor of
+//! Decaf is named "after the procedure which divides the effect of
+//! coffee by \\(4\\)".  However, Curve25519 has a cofactor of
 //! \\(8\\).  To eliminate its cofactor, Ristretto restricts further;
 //! this [additional restriction][ristretto_coffee] gives the
 //! _Ristretto_ encoding.


### PR DESCRIPTION
Some editors could have trouble accurately rendering these characters, with these characters showing up as gibberish or causing formatting problems. It will confuse readers.