### PR TITLE
Implementation of `elliptic-curve` traits for curve25519 and ed25519.

### DIFF
--- a/curve25519-dalek/Cargo.toml
+++ b/curve25519-dalek/Cargo.toml
@@ -54,6 +54,7 @@ digest = { version = "0.10", default-features = false, optional = true }
 subtle = { version = "2.6.0", default-features = false, features = ["const-generics"]}
 serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
 zeroize = { version = "1", default-features = false, optional = true }
+elliptic-curve = { version = "0.13", optional = true }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 cpufeatures = "0.2.6"
@@ -66,8 +67,9 @@ default = ["alloc", "precomputed-tables", "zeroize"]
 alloc = ["zeroize?/alloc"]
 precomputed-tables = []
 legacy_compatibility = []
-group = ["dep:group", "rand_core"]
+group = ["dep:group", "rand_core", "digest"]
 group-bits = ["group", "ff/bits"]
+elliptic-curve = ["group", "dep:ff", "dep:elliptic-curve"]
 
 [target.'cfg(all(not(curve25519_dalek_backend = "fiat"), not(curve25519_dalek_backend = "serial"), target_arch = "x86_64"))'.dependencies]
 curve25519-dalek-derive = { version = "0.1", path = "../curve25519-dalek-derive" }

--- a/curve25519-dalek/src/ed25519.rs
+++ b/curve25519-dalek/src/ed25519.rs
@@ -1,0 +1,24 @@
+use elliptic_curve::{bigint::U256, consts::U32, Curve, CurveArithmetic, FieldBytesEncoding};
+
+use crate::{constants::BASEPOINT_ORDER_PRIVATE, edwards::CompressedEdwardsY, EdwardsPoint, Scalar};
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, PartialOrd, Ord, Hash)]
+pub struct Ed25519;
+
+impl Curve for Ed25519 {
+    type FieldBytesSize = U32;
+
+    type Uint = U256;
+
+    const ORDER: Self::Uint = U256::from_le_slice(&BASEPOINT_ORDER_PRIVATE.bytes);
+}
+
+impl CurveArithmetic for Ed25519 {
+    type AffinePoint = CompressedEdwardsY;
+
+    type ProjectivePoint = EdwardsPoint;
+
+    type Scalar = Scalar;
+}
+
+impl FieldBytesEncoding<Ed25519> for U256 {}

--- a/curve25519-dalek/src/ed25519.rs
+++ b/curve25519-dalek/src/ed25519.rs
@@ -2,6 +2,8 @@ use elliptic_curve::{bigint::U256, consts::U32, Curve, CurveArithmetic, FieldByt
 
 use crate::{constants::BASEPOINT_ORDER_PRIVATE, edwards::CompressedEdwardsY, EdwardsPoint, Scalar};
 
+/// QUESTION: I don't know where to put this singleton. Maybe in the crate's root?
+/// Otherwise, I thought of something like "singleton" or "curve".
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, PartialOrd, Ord, Hash)]
 pub struct Ed25519;
 

--- a/curve25519-dalek/src/edwards.rs
+++ b/curve25519-dalek/src/edwards.rs
@@ -285,7 +285,6 @@ impl elliptic_curve::point::AffineCoordinates for CompressedEdwardsY {
     }
 
     fn y_is_odd(&self) -> Choice {
-        // TODO: here I assume that the Y is encoded in little-endian, which I should check.
         Choice::from(self.as_bytes()[0] & 0x01)
     }
 }

--- a/curve25519-dalek/src/edwards.rs
+++ b/curve25519-dalek/src/edwards.rs
@@ -105,7 +105,6 @@ use cfg_if::cfg_if;
 
 #[cfg(feature = "digest")]
 use digest::{generic_array::typenum::{U64, U32}, Digest};
-use zeroize::DefaultIsZeroes;
 
 #[cfg(feature = "group")]
 use {
@@ -122,7 +121,7 @@ use subtle::ConditionallySelectable;
 use subtle::ConstantTimeEq;
 
 #[cfg(feature = "zeroize")]
-use zeroize::Zeroize;
+use zeroize::DefaultIsZeroes;
 
 use crate::constants;
 
@@ -1587,11 +1586,7 @@ impl ConditionallySelectable for SubgroupPoint {
 }
 
 #[cfg(all(feature = "group", feature = "zeroize"))]
-impl Zeroize for SubgroupPoint {
-    fn zeroize(&mut self) {
-        self.0.zeroize();
-    }
-}
+impl DefaultIsZeroes for SubgroupPoint {}
 
 #[cfg(feature = "group")]
 impl group::Group for SubgroupPoint {

--- a/curve25519-dalek/src/edwards.rs
+++ b/curve25519-dalek/src/edwards.rs
@@ -271,8 +271,8 @@ impl elliptic_curve::point::AffineCoordinates for CompressedEdwardsY {
 
     fn x(&self) -> Self::FieldRepr {
         // QUESTION: here we assume that the CompressedEdwardsY valid, and it won't panic in dbg mode.
-        // We should either change the CompressedEdwardsY API to now allow instancing a
-        // `CompressedEdwardsY` that is invalid, or clearly document that case somewhere.
+        // We should either change the CompressedEdwardsY API to not allow instancing a
+        // `CompressedEdwardsY` that is invalid, or use another type.
         // How should we handle this?
         let (is_valid, mut X, _, _) =  decompress::step_1(self);
         debug_assert!(bool::from(is_valid));

--- a/curve25519-dalek/src/edwards.rs
+++ b/curve25519-dalek/src/edwards.rs
@@ -1667,7 +1667,8 @@ impl CofactorGroup for EdwardsPoint {
 // Interop between CompressedEdwardsY and EdwardsPoint for group traits
 // ------------------------------------------------------------------------
 
-// Again, here we assume throughout that CompressedEdwardsY is a valid point.
+// Again, we assume throughout that CompressedEdwardsY is a valid point (this is not what we
+// want, just something that somewhat works until we know what to do).
 
 impl From<CompressedEdwardsY> for EdwardsPoint {
     fn from(value: CompressedEdwardsY) -> Self {

--- a/curve25519-dalek/src/lib.rs
+++ b/curve25519-dalek/src/lib.rs
@@ -109,3 +109,6 @@ pub use crate::{
 // Build time diagnostics for validation
 #[cfg(curve25519_dalek_diagnostics = "build")]
 mod diagnostics;
+
+#[cfg(feature = "elliptic-curve")]
+mod ed25519;

--- a/curve25519-dalek/src/scalar.rs
+++ b/curve25519-dalek/src/scalar.rs
@@ -1251,7 +1251,7 @@ impl Field for Scalar {
     }
 }
 
-#[cfg(all(feature = "group", feature = "digest"))]
+#[cfg(feature = "group")]
 impl PrimeField for Scalar {
     // DISCUSSION: it sucks that we have to use this type but that's what `ArithmeticCurve`
     // requires. This is only a minor version bump since this trait was already behind the "group"
@@ -1983,7 +1983,7 @@ pub(crate) mod test {
         );
     }
 
-    #[cfg(all(feature = "group", feature = "digest"))]
+    #[cfg(feature = "group")]
     #[test]
     fn ff_impls() {
         assert!(bool::from(Scalar::ZERO.is_even()));

--- a/curve25519-dalek/src/scalar.rs
+++ b/curve25519-dalek/src/scalar.rs
@@ -560,6 +560,11 @@ impl Zeroize for Scalar {
     }
 }
 
+impl AsRef<Scalar> for Scalar {
+    fn as_ref(&self) -> &Scalar {
+        self
+    }
+}
 impl Scalar {
     /// The scalar \\( 0 \\).
     pub const ZERO: Self = Self { bytes: [0u8; 32] };

--- a/curve25519-dalek/src/scalar.rs
+++ b/curve25519-dalek/src/scalar.rs
@@ -1231,6 +1231,23 @@ impl core::ops::ShrAssign<usize> for Scalar {
     }
 }
 
+#[cfg(feature = "elliptic-curve")]
+impl elliptic_curve::ops::Reduce<elliptic_curve::bigint::U256> for Scalar {
+    type Bytes = elliptic_curve::generic_array::GenericArray<
+        u8,
+        elliptic_curve::generic_array::typenum::U32,
+    >;
+
+    fn reduce(n: elliptic_curve::bigint::U256) -> Self {
+        use elliptic_curve::bigint::Encoding;
+        Scalar::from_bytes_mod_order(n.to_le_bytes())
+    }
+
+    fn reduce_bytes(bytes: &Self::Bytes) -> Self {
+        Scalar::from_bytes_mod_order(<[u8; 32]>::from(*bytes))
+    }
+}
+
 #[cfg(feature = "group")]
 impl Field for Scalar {
     const ZERO: Self = Self::ZERO;

--- a/curve25519-dalek/src/scalar.rs
+++ b/curve25519-dalek/src/scalar.rs
@@ -1388,9 +1388,6 @@ impl Field for Scalar {
 
 #[cfg(feature = "group")]
 impl PrimeField for Scalar {
-    // DISCUSSION: it sucks that we have to use this type but that's what `ArithmeticCurve`
-    // requires. This is only a minor version bump since this trait was already behind the "group"
-    // feature.
     type Repr = GenericArray<u8, U32>;
 
     fn from_repr(repr: Self::Repr) -> CtOption<Self> {

--- a/curve25519-dalek/src/scalar.rs
+++ b/curve25519-dalek/src/scalar.rs
@@ -1289,8 +1289,9 @@ impl PartialOrd for Scalar {
 #[cfg(feature = "elliptic-curve")]
 impl Ord for Scalar {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
-        elliptic_curve::bigint::U256::from_le_bytes(self.bytes).cmp(
-            &elliptic_curve::bigint::U256::from_le_bytes(other.bytes)
+        use elliptic_curve::bigint::{Encoding, U256};
+        U256::from_le_bytes(self.bytes).cmp(
+            &U256::from_le_bytes(other.bytes)
         )
     }
 }

--- a/curve25519-dalek/src/scalar.rs
+++ b/curve25519-dalek/src/scalar.rs
@@ -144,7 +144,6 @@ use digest::Digest;
 use subtle::Choice;
 use subtle::ConditionallySelectable;
 use subtle::ConstantTimeEq;
-use subtle::ConstantTimeGreater;
 use subtle::CtOption;
 
 #[cfg(feature = "zeroize")]
@@ -1263,6 +1262,7 @@ impl elliptic_curve::ops::Reduce<elliptic_curve::bigint::U256> for Scalar {
 impl elliptic_curve::scalar::IsHigh for Scalar {
     fn is_high(&self) -> Choice {
         use elliptic_curve::bigint::{Encoding, U256};
+        use subtle::ConstantTimeGreater;
         U256::from_le_bytes(self.bytes).ct_gt(&U256::from_le_bytes(
             (constants::BASEPOINT_ORDER_PRIVATE * Self::TWO_INV).bytes,
         ))

--- a/curve25519-dalek/src/scalar.rs
+++ b/curve25519-dalek/src/scalar.rs
@@ -191,7 +191,7 @@ cfg_if! {
 
 /// The `Scalar` struct holds an element of \\(\mathbb Z / \ell\mathbb Z \\).
 #[allow(clippy::derived_hash_with_manual_eq)]
-#[derive(Copy, Clone, Hash)]
+#[derive(Copy, Clone, Hash, PartialOrd, Ord)]
 pub struct Scalar {
     /// `bytes` is a little-endian byte encoding of an integer representing a scalar modulo the
     /// group order.


### PR DESCRIPTION
The driving reason for implementing this is to eventually implement the `hash2curve` traits   for elligator2.

See also: #612 implements elligator2 without `hash2curve` traits.

## Main Concern for `Ed25519`

The `CurveArithmetic` trait requires an `AffinePoint` for which this crate only has `CompressedEdwardsY`. The problem is that `CurveArithmetic` requires an Infallible conversion from `AffinePoint` (`CompressedEdwardsY`) to `ProjectivePoint` (`EdwardsPoint`).

Currently, this implementation skips the fallible implementation of `CompressedEdwardsY` -> `EdwardsPoint` and creates an invalid `EdwardsPoint` if `CompressedEdwardsY` is invalid (we probably don't want this).

I can think of 2 other solutions:
- We introduce a new `pub AffineEdwardsPoint { x: FieldElement, y: FieldElement }` (with private internals) to implement `Curve` & `CurveArithmetic`. I believe this would not be a breaking change.
- We make the internals of `CompressedEdwardsY` private (__Breaking change__), and introduce a type alias for the the wire representation of `CompressedEdwardsY` e.g.:
  ```rust
  type EdwardsYBytes = [u8; 32];
  ```
  Then the creation of `CompressedEdwardsY` would require validation and would be fallible.

## Main Concern for `Curve25519`:

It does not seem like there is a public `ProjectivePoint` for `curve25519`. One solution would be to make the current one public.

## Note

Only `Ed25519` has the traits implemented (hence why this is a draft), but I would like feedback on this implementation, as I feel the implementation for `Curve25519` will have similar issues. The code contains `QUESTION`s that explain the issues faced.

Both `Ed25519` and `Curve25519` will be housed in the crate `curve25519`, since this is where the arithmetic is implemented for both curves.