### PR TITLE
Implement `Zeroize` for assorted types

### DIFF
--- a/ed25519-dalek/src/hazmat.rs
+++ b/ed25519-dalek/src/hazmat.rs
@@ -42,10 +42,17 @@ pub struct ExpandedSecretKey {
 }
 
 #[cfg(feature = "zeroize")]
-impl Drop for ExpandedSecretKey {
-    fn drop(&mut self) {
+impl Zeroize for ExpandedSecretKey {
+    fn zeroize(&mut self) {
         self.scalar.zeroize();
         self.hash_prefix.zeroize()
+    }
+}
+
+#[cfg(feature = "zeroize")]
+impl Drop for ExpandedSecretKey {
+    fn drop(&mut self) {
+        self.zeroize()
     }
 }
 

--- a/ed25519-dalek/src/signing.rs
+++ b/ed25519-dalek/src/signing.rs
@@ -651,6 +651,13 @@ impl Eq for SigningKey {}
 #[cfg(feature = "zeroize")]
 impl Drop for SigningKey {
     fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
+#[cfg(feature = "zeroize")]
+impl Zeroize for SigningKey {
+    fn zeroize(&mut self) {
         self.secret_key.zeroize();
     }
 }

--- a/ed25519-dalek/src/verifying.rs
+++ b/ed25519-dalek/src/verifying.rs
@@ -34,6 +34,9 @@ use crate::context::Context;
 #[cfg(feature = "digest")]
 use signature::DigestVerifier;
 
+#[cfg(feature = "zeroize")]
+use zeroize::Zeroize;
+
 use crate::{
     constants::PUBLIC_KEY_LENGTH,
     errors::{InternalError, SignatureError},
@@ -84,6 +87,14 @@ impl Hash for VerifyingKey {
 impl PartialEq<VerifyingKey> for VerifyingKey {
     fn eq(&self, other: &VerifyingKey) -> bool {
         self.as_bytes() == other.as_bytes()
+    }
+}
+
+#[cfg(feature = "zeroize")]
+impl Zeroize for VerifyingKey {
+    fn zeroize(&mut self) {
+        self.point.zeroize();
+        self.compressed.zeroize();
     }
 }
 


### PR DESCRIPTION
This PR implements `Zeroize` for `ExpandedSecretKey`, `SigningKey` and `VerifiyingKey`.

I initially implemented them as zeroizing to scalar `1` or the base point, but noticed that these types don't uphold these invariants themselves.