### PR TITLE
chore(deps): bump `cpufeatures` from `0.2.12` to `0.2.17`

### DIFF
--- a/curve25519-dalek/Cargo.toml
+++ b/curve25519-dalek/Cargo.toml
@@ -56,7 +56,7 @@ serde = { version = "1.0", default-features = false, optional = true, features =
 zeroize = { version = "1", default-features = false, optional = true }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
-cpufeatures = "0.2.6"
+cpufeatures = "0.2.17"
 
 [target.'cfg(curve25519_dalek_backend = "fiat")'.dependencies]
 fiat-crypto = { version = "0.2.1", default-features = false }


### PR DESCRIPTION
This fixes warnings like:
```
warning: unexpected `cfg` condition value: ``
  --> curve25519-dalek/src/backend/mod.rs:58:9
   |
58 |         cpufeatures::new!(cpuid_avx512, "avx512ifma", "avx512vl");
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```