### PR TITLE
nightly and stable disagree on usage of unsafe

### DIFF
--- a/curve25519-dalek-derive/README.md
+++ b/curve25519-dalek-derive/README.md
@@ -81,14 +81,7 @@ to build out more elaborate abstractions it starts to become painful to use.
 This crate exposes an `#[unsafe_target_feature]` macro which works just like `#[target_feature]` except
 it moves the `unsafe` from the function prototype into the macro name, and can be used on safe functions.
 
-```rust,compile_fail
-// ERROR: `#[target_feature(..)]` can only be applied to `unsafe` functions
-#[target_feature(enable = "avx2")]
-fn func() {}
-```
-
 ```rust
-// It works, but must be `unsafe`
 # #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[target_feature(enable = "avx2")]
 unsafe fn func() {}

--- a/curve25519-dalek/src/backend/vector/avx2/field.rs
+++ b/curve25519-dalek/src/backend/vector/avx2/field.rs
@@ -9,6 +9,11 @@
 // - isis agora lovecruft <isis@patternsinthevoid.net>
 // - Henry de Valence <hdevalence@hdevalence.ca>
 
+// Nightly and stable currently disagree on the requirement of unsafe blocks when `unsafe_target_feature`
+// gets used.
+// See: https://github.com/rust-lang/rust/issues/132856
+#![allow(unused_unsafe)]
+
 //! An implementation of 4-way vectorized 32bit field arithmetic using
 //! AVX2.
 //!

--- a/curve25519-dalek/src/backend/vector/ifma/field.rs
+++ b/curve25519-dalek/src/backend/vector/ifma/field.rs
@@ -9,6 +9,10 @@
 // - isis agora lovecruft <isis@patternsinthevoid.net>
 // - Henry de Valence <hdevalence@hdevalence.ca>
 
+// Nightly and stable currently disagree on the requirement of unsafe blocks when `unsafe_target_feature`
+// gets used.
+// See: https://github.com/rust-lang/rust/issues/132856
+#![allow(unused_unsafe)]
 #![allow(non_snake_case)]
 
 use crate::backend::vector::packed_simd::u64x4;

--- a/curve25519-dalek/src/backend/vector/packed_simd.rs
+++ b/curve25519-dalek/src/backend/vector/packed_simd.rs
@@ -3,6 +3,11 @@
 // This file is part of curve25519-dalek.
 // See LICENSE for licensing information.
 
+// Nightly and stable currently disagree on the requirement of unsafe blocks when `unsafe_target_feature`
+// gets used.
+// See: https://github.com/rust-lang/rust/issues/132856
+#![allow(unused_unsafe)]
+
 //! This module defines wrappers over platform-specific SIMD types to make them
 //! more convenient to use.
 //!


### PR DESCRIPTION
```
error: unnecessary `unsafe` block
492
   --> curve25519-dalek/src/backend/vector/avx2/field.rs:479:28
493
    |
494
479 |         let c9_19: u32x8 = unsafe {
495
    |                            ^^^^^^ unnecessary `unsafe` block
```

This would only happen on nightly.