### PR TITLE
curve: remove `feature(avx512_target_feature)`

### DIFF
--- a/curve25519-dalek/src/lib.rs
+++ b/curve25519-dalek/src/lib.rs
@@ -18,10 +18,6 @@
     ),
     feature(stdarch_x86_avx512)
 )]
-#![cfg_attr(
-    all(curve25519_dalek_backend = "simd", nightly),
-    feature(avx512_target_feature)
-)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg, doc_cfg, doc_cfg_hide))]
 #![cfg_attr(docsrs, doc(cfg_hide(docsrs)))]
 //------------------------------------------------------------------------


### PR DESCRIPTION
The build is currently broken because it's been stabilized:

    error: the feature `avx512_target_feature` has been stable since 1.89.0-nightly and no longer requires an attribute to enable