### PR TITLE
curve: add `EdwardsPoint::compress_batch` and inherent `::random`

### DIFF
--- a/curve25519-dalek/benches/dalek_benchmarks.rs
+++ b/curve25519-dalek/benches/dalek_benchmarks.rs
@@ -30,9 +30,8 @@ mod edwards_benches {
                 &batch_size,
                 |b, &size| {
                     let mut rng = OsRng;
-                    let points: Vec<EdwardsPoint> = (0..size)
-                        .map(|_| EdwardsPoint::random(&mut rng))
-                        .collect();
+                    let points: Vec<EdwardsPoint> =
+                        (0..size).map(|_| EdwardsPoint::random(&mut rng)).collect();
                     b.iter(|| EdwardsPoint::compress_batch(&points));
                 },
             );

--- a/curve25519-dalek/src/edwards.rs
+++ b/curve25519-dalek/src/edwards.rs
@@ -1342,6 +1342,7 @@ impl group::Group for EdwardsPoint {
     type Scalar = Scalar;
 
     fn random(rng: impl RngCore) -> Self {
+        // Call the inherent `pub fn random` defined above
         Self::random(rng)
     }
 

--- a/curve25519-dalek/src/edwards.rs
+++ b/curve25519-dalek/src/edwards.rs
@@ -585,8 +585,8 @@ impl EdwardsPoint {
             .iter()
             .zip(&zs)
             .map(|(input, recip)| {
-                let x = &input.X * &recip;
-                let y = &input.Y * &recip;
+                let x = &input.X * recip;
+                let y = &input.Y * recip;
 
                 let mut s = y.as_bytes();
                 s[31] ^= x.is_negative().unwrap_u8() << 7;

--- a/curve25519-dalek/src/edwards.rs
+++ b/curve25519-dalek/src/edwards.rs
@@ -582,8 +582,8 @@ impl EdwardsPoint {
             .iter()
             .zip(&zs)
             .map(|(input, recip)| {
-                let x = &input.X * &recip;
-                let y = &input.Y * &recip;
+                let x = &input.X * recip;
+                let y = &input.Y * recip;
                 Self::compress_affine(x, y)
             })
             .collect()


### PR DESCRIPTION
We've had various requests to implement batch point compression for `EdwardsPoint`, e.g. #705.

We can leverage `FieldElement::batch_invert` to implement it, which results in a fairly significant speedup.

The name `EdwardsPoint::compress_batch` has been chosen to match `RistrettoPoint::double_and_compress_batch`.

For benchmarking, randomized `EdwardsPoint`s have been used. To obtain these, an inherent `EdwardsPoint::random` has been extracted from the existing `Group::random` implementation, which uses rejection sampling. `Group::random` has been updated to call the inherent `EdwardsPoint::random`. This avoids a `group` dependency just to run the batch compression benchmarks.

The following benchmark results have been obtained:

```
edwards benches/EdwardsPoint compression
                        time:   [3.5029 µs 3.5098 µs 3.5171 µs]

edwards benches/Batch EdwardsPoint compression/1
                        time:   [3.6698 µs 3.6758 µs 3.6817 µs]
edwards benches/Batch EdwardsPoint compression/2
                        time:   [3.8410 µs 3.8461 µs 3.8516 µs]
edwards benches/Batch EdwardsPoint compression/4
                        time:   [4.1534 µs 4.1961 µs 4.2558 µs]
edwards benches/Batch EdwardsPoint compression/8
                        time:   [4.8466 µs 4.8533 µs 4.8600 µs]
edwards benches/Batch EdwardsPoint compression/16
                        time:   [6.1216 µs 6.1315 µs 6.1410 µs]
```

As you can see, it affords a fairly significant speedup, batch compressing 16 points in less time than the standard point compression algorithm would take to compress 2 in a row.