### PR TITLE
Don't implicitly enable zeroize for ed25519-dalek alloc feature

### DIFF
--- a/ed25519-dalek/Cargo.toml
+++ b/ed25519-dalek/Cargo.toml
@@ -60,7 +60,7 @@ required-features = ["rand_core"]
 
 [features]
 default = ["fast", "std", "zeroize"]
-alloc = ["curve25519-dalek/alloc", "ed25519/alloc", "serde?/alloc", "zeroize/alloc"]
+alloc = ["curve25519-dalek/alloc", "ed25519/alloc", "serde?/alloc", "zeroize?/alloc"]
 std = ["alloc", "ed25519/std", "serde?/std", "sha2/std"]
 
 asm = ["sha2/asm"]


### PR DESCRIPTION
I tried to compile `ed25519-dalek` using the new https://github.com/Rust-GPU/Rust-CUDA reboot and they mentioned they fixed a lot of issue, and I tried to include curve25519-dalek and it does miraculously compile, except it has to be without `zeroize` which is complaining about atomic fence not supported on PTX, and I have to use the equivalent intrinsic in cuda_std instead. 

As a quick demo for an internal finite field arithmetic + SIMD project and I rather need performance, I don't need zeroize at all. So a quick solution is to just disable it.

Anyway, I noticed with ed25519-dalek, when you enable the alloc feature, zeroize is implicitly enabled. This PR just add a single character to fix that