### PR TITLE
Update to `&[&[u8]]` messages

### DIFF
--- a/ed25519-dalek/benches/ed25519_benchmarks.rs
+++ b/ed25519-dalek/benches/ed25519_benchmarks.rs
@@ -32,7 +32,7 @@ mod ed25519_benches {
         let sig: Signature = keypair.sign(msg);
 
         c.bench_function("Ed25519 signature verification", move |b| {
-            b.iter(|| keypair.verify(msg, &sig))
+            b.iter(|| keypair.verify(&[msg], &sig))
         });
     }
 
@@ -43,7 +43,7 @@ mod ed25519_benches {
         let sig: Signature = keypair.sign(msg);
 
         c.bench_function("Ed25519 strict signature verification", move |b| {
-            b.iter(|| keypair.verify_strict(msg, &sig))
+            b.iter(|| keypair.verify_strict(&[msg], &sig))
         });
     }
 

--- a/ed25519-dalek/src/hazmat.rs
+++ b/ed25519-dalek/src/hazmat.rs
@@ -113,7 +113,7 @@ impl TryFrom<&[u8]> for ExpandedSecretKey {
 /// [here](https://github.com/MystenLabs/ed25519-unsafe-libs) for more details on this attack.
 pub fn raw_sign<CtxDigest>(
     esk: &ExpandedSecretKey,
-    message: &[u8],
+    message: &[&[u8]],
     verifying_key: &VerifyingKey,
 ) -> Signature
 where
@@ -174,7 +174,7 @@ where
 /// According to the Ed25519 spec, `CtxDigest = Sha512`.
 pub fn raw_verify<CtxDigest>(
     vk: &VerifyingKey,
-    message: &[u8],
+    message: &[&[u8]],
     signature: &ed25519::Signature,
 ) -> Result<(), SignatureError>
 where
@@ -235,8 +235,8 @@ mod test {
         let msg = b"Then one day, a piano fell on my head";
 
         // Sign and verify
-        let sig = raw_sign::<CtxDigest>(&esk, msg, &vk);
-        raw_verify::<CtxDigest>(&vk, msg, &sig).unwrap();
+        let sig = raw_sign::<CtxDigest>(&esk, &[msg], &vk);
+        raw_verify::<CtxDigest>(&vk, &[msg], &sig).unwrap();
     }
 
     // Check that raw_sign_prehashed and raw_verify_prehashed work when distinct, non-spec

--- a/ed25519-dalek/src/lib.rs
+++ b/ed25519-dalek/src/lib.rs
@@ -59,7 +59,7 @@
 //! # let message: &[u8] = b"This is a test of the tsunami alert system.";
 //! # let signature: Signature = signing_key.sign(message);
 //! use ed25519_dalek::Verifier;
-//! assert!(signing_key.verify(message, &signature).is_ok());
+//! assert!(signing_key.verify(&[message], &signature).is_ok());
 //! # }
 //! ```
 //!

--- a/ed25519-dalek/tests/ed25519.rs
+++ b/ed25519-dalek/tests/ed25519.rs
@@ -83,13 +83,13 @@ mod vectors {
 
             assert!(sig1 == sig2, "Signature bytes not equal on line {}", lineno);
             assert!(
-                signing_key.verify(&msg_bytes, &sig2).is_ok(),
+                signing_key.verify(&[&msg_bytes], &sig2).is_ok(),
                 "Signature verification failed on line {}",
                 lineno
             );
             assert!(
                 expected_verifying_key
-                    .verify_strict(&msg_bytes, &sig2)
+                    .verify_strict(&[&msg_bytes], &sig2)
                     .is_ok(),
                 "Signature strict verification failed on line {}",
                 lineno
@@ -234,8 +234,8 @@ mod vectors {
 
         // Now check that the sigs fail under verify_strict. This is because verify_strict rejects
         // small order pubkeys.
-        assert!(vk.verify_strict(message1, &sig).is_err());
-        assert!(vk.verify_strict(message2, &sig).is_err());
+        assert!(vk.verify_strict(&[message1], &sig).is_err());
+        assert!(vk.verify_strict(&[message2], &sig).is_err());
     }
 
     // Identical to repudiation() above, but testing verify_prehashed against
@@ -309,27 +309,27 @@ mod integrations {
         assert!(!verifying_key.is_weak());
 
         assert!(
-            signing_key.verify(good, &good_sig).is_ok(),
+            signing_key.verify(&[good], &good_sig).is_ok(),
             "Verification of a valid signature failed!"
         );
         assert!(
-            verifying_key.verify_strict(good, &good_sig).is_ok(),
+            verifying_key.verify_strict(&[good], &good_sig).is_ok(),
             "Strict verification of a valid signature failed!"
         );
         assert!(
-            signing_key.verify(good, &bad_sig).is_err(),
+            signing_key.verify(&[good], &bad_sig).is_err(),
             "Verification of a signature on a different message passed!"
         );
         assert!(
-            verifying_key.verify_strict(good, &bad_sig).is_err(),
+            verifying_key.verify_strict(&[good], &bad_sig).is_err(),
             "Strict verification of a signature on a different message passed!"
         );
         assert!(
-            signing_key.verify(bad, &good_sig).is_err(),
+            signing_key.verify(&[bad], &good_sig).is_err(),
             "Verification of a signature on a different message passed!"
         );
         assert!(
-            verifying_key.verify_strict(bad, &good_sig).is_err(),
+            verifying_key.verify_strict(&[bad], &good_sig).is_err(),
             "Strict verification of a signature on a different message passed!"
         );
     }

--- a/ed25519-dalek/tests/validation_criteria.rs
+++ b/ed25519-dalek/tests/validation_criteria.rs
@@ -154,7 +154,7 @@ fn check_validation_criteria() {
 
         // If all the verify_strict-permitted flags here are ones we permit, then verify_strict()
         // should succeed. Otherwise, it should not.
-        let success = pubkey.verify_strict(&msg, &sig).is_ok();
+        let success = pubkey.verify_strict(&[&msg], &sig).is_ok();
         if flags.is_subset(&verify_strict_allowed_edgecases) {
             assert!(
                 success,
@@ -211,7 +211,7 @@ fn find_validation_criteria() {
 
         // If verify_strict() was a success, add all the associated flags to
         // verify_strict-permitted set
-        let success = pubkey.verify_strict(&msg, &sig).is_ok();
+        let success = pubkey.verify_strict(&[&msg], &sig).is_ok();
         if success {
             for flag in &flags {
                 verify_strict_allowed_edgecases.insert(*flag);


### PR DESCRIPTION
Just showing off https://github.com/RustCrypto/traits/pull/1880. The current plan is to move this to a separate trait, which I'm, as of yet, unsure how it will integrate into `ed25519-dalek`.