### PR TITLE
ed: Expose `hazmat::raw_sign_byupdate()` for streamed signing

### DIFF
--- a/ed25519-dalek/src/hazmat.rs
+++ b/ed25519-dalek/src/hazmat.rs
@@ -106,7 +106,7 @@ impl TryFrom<&[u8]> for ExpandedSecretKey {
 /// calculate the pseudorandomness needed for signing. According to the Ed25519 spec, `CtxDigest =
 /// Sha512`.
 ///
-/// # ⚠️  Unsafe
+/// # ⚠️  Cryptographically Unsafe
 ///
 /// Do NOT use this function unless you absolutely must. Using the wrong values in
 /// `ExpandedSecretKey` can leak your signing key. See
@@ -127,7 +127,7 @@ where
 /// `CtxDigest` is the digest function used to calculate the pseudorandomness needed for signing.
 /// According to the Ed25519 spec, `MsgDigest = CtxDigest = Sha512`.
 ///
-/// # ⚠️  Unsafe
+/// # ⚠️  Cryptographically Unsafe
 //
 /// Do NOT use this function unless you absolutely must. Using the wrong values in
 /// `ExpandedSecretKey` can leak your signing key. See
@@ -173,12 +173,13 @@ where
 /// updating a digest instance.
 ///
 /// The `msg_update` closure provides the message content, updating a hasher argument. It will be
-/// called twice.
+/// called twice. This closure MUST leave its hasher in the same state (i.e., must hash the same
+/// values) after both calls. Otherwise it will produce an invalid signature.
 ///
 /// `CtxDigest` is the digest used to calculate the pseudorandomness needed for signing. According
 /// to the Ed25519 spec, `CtxDigest = Sha512`.
 ///
-/// # ⚠️  Unsafe
+/// # ⚠️  Cryptographically Unsafe
 ///
 /// Do NOT use this function unless you absolutely must. Using the wrong values in
 /// `ExpandedSecretKey` can leak your signing key. See

--- a/ed25519-dalek/src/signing.rs
+++ b/ed25519-dalek/src/signing.rs
@@ -854,8 +854,9 @@ impl ExpandedSecretKey {
         .unwrap()
     }
 
-    /// Sign a message provided in parts. The `msg_update` closure
-    /// will be called twice to hash the message parts.
+    /// Sign a message provided in parts. The `msg_update` closure will be called twice to hash the
+    /// message parts. This closure MUST leave its hasher in the same state (i.e., must hash the
+    /// same values) after both calls. Otherwise it will produce an invalid signature.
     #[allow(non_snake_case)]
     #[inline(always)]
     pub(crate) fn raw_sign_byupdate<CtxDigest, F>(

--- a/ed25519-dalek/src/signing.rs
+++ b/ed25519-dalek/src/signing.rs
@@ -833,6 +833,7 @@ impl ExpandedSecretKey {
     /// This definition is loose in its parameters so that end-users of the `hazmat` module can
     /// change how the `ExpandedSecretKey` is calculated and which hash function to use.
     #[allow(non_snake_case)]
+    #[allow(clippy::unwrap_used)]
     #[inline(always)]
     pub(crate) fn raw_sign<CtxDigest>(
         &self,

--- a/ed25519-dalek/src/signing.rs
+++ b/ed25519-dalek/src/signing.rs
@@ -842,10 +842,34 @@ impl ExpandedSecretKey {
     where
         CtxDigest: Digest<OutputSize = U64>,
     {
+        // OK unwrap, update can't fail.
+        self.raw_sign_byupdate(
+            |h: &mut CtxDigest| {
+                h.update(message);
+                Ok(())
+            },
+            verifying_key,
+        )
+        .unwrap()
+    }
+
+    /// Sign a message provided in parts. The `msg_update` closure
+    /// will be called twice to hash the message parts.
+    #[allow(non_snake_case)]
+    #[inline(always)]
+    pub(crate) fn raw_sign_byupdate<CtxDigest, F>(
+        &self,
+        msg_update: F,
+        verifying_key: &VerifyingKey,
+    ) -> Result<Signature, SignatureError>
+    where
+        CtxDigest: Digest<OutputSize = U64>,
+        F: Fn(&mut CtxDigest) -> Result<(), SignatureError>,
+    {
         let mut h = CtxDigest::new();
 
         h.update(self.hash_prefix);
-        h.update(message);
+        msg_update(&mut h)?;
 
         let r = Scalar::from_hash(h);
         let R: CompressedEdwardsY = EdwardsPoint::mul_base(&r).compress();
@@ -853,12 +877,12 @@ impl ExpandedSecretKey {
         h = CtxDigest::new();
         h.update(R.as_bytes());
         h.update(verifying_key.as_bytes());
-        h.update(message);
+        msg_update(&mut h)?;
 
         let k = Scalar::from_hash(h);
         let s: Scalar = (k * self.scalar) + r;
 
-        InternalSignature { R, s }.into()
+        Ok(InternalSignature { R, s }.into())
     }
 
     /// The prehashed signing function for Ed25519 (i.e., Ed25519ph). `CtxDigest` is the digest


### PR DESCRIPTION
Currently, if you want to sign a serialized object, you have to serialize it in full, then sign it. When memory is constrained, this is hard.

This PR defines a function, `hazmat::raw_sign_byupdate`, which, rather than taking a single contiguous message slice, takes a `Fn(&mut Digest)` that knows how to update a hasher with the parts of the message. So, in the case of serialization, the closure will simply serialize each component to a small buffer, do `h.update(buf)`, then fill the buffer with the next serialized component, etc.

This comes from discussion [here](https://github.com/dalek-cryptography/curve25519-dalek/pull/735#discussion_r2119269994), [here](https://github.com/dalek-cryptography/curve25519-dalek/pull/556#issuecomment-1707656494), and hypothetical impl [here](https://github.com/mkj/sunset/blob/3c7d6879da93684832f8ec19df4191523999a2f3/src/sign.rs#L324-L338).

This is feature-gated behind `hazmat` because it takes an expanded secret key, which is possible to catastrophically misuse.

@mkj 