### PR TITLE
curve: fix `nightly` build

### DIFF
--- a/curve25519-dalek/src/lib.rs
+++ b/curve25519-dalek/src/lib.rs
@@ -10,14 +10,6 @@
 // - Henry de Valence <hdevalence@hdevalence.ca>
 
 #![no_std]
-#![cfg_attr(
-    all(
-        curve25519_dalek_backend = "simd",
-        nightly,
-        any(target_arch = "x86", target_arch = "x86_64")
-    ),
-    feature(stdarch_x86_avx512)
-)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg, doc_cfg, doc_cfg_hide))]
 #![cfg_attr(docsrs, doc(cfg_hide(docsrs)))]
 //------------------------------------------------------------------------


### PR DESCRIPTION
The latest nightlies have stabilized `stdarch_x86_avx512` so having it present is now an error