### PR TITLE
x25519: use manual impls instead of `zeroize_derive`

### DIFF
--- a/x25519-dalek/Cargo.toml
+++ b/x25519-dalek/Cargo.toml
@@ -41,7 +41,7 @@ features = ["getrandom", "reusable_secrets", "serde", "static_secrets"]
 curve25519-dalek = { version = "4", path = "../curve25519-dalek", default-features = false }
 rand_core = { version = "0.6", default-features = false }
 serde = { version = "1", default-features = false, optional = true, features = ["derive"] }
-zeroize = { version = "1", default-features = false, optional = true, features = ["zeroize_derive"] }
+zeroize = { version = "1", default-features = false, optional = true }
 
 [dev-dependencies]
 bincode = "1"


### PR DESCRIPTION
The types involved are all simple 1-tuple newtypes where zeroization only involves calling `zeroize` on the inner type, making all of the involved impls relatively trivial.

Avoiding custom derive arguably improves auditability as you don't need to expand a proc macro to see the resulting code. It decreases the number of required dependencies in order for the `zeroize` feature to work, where some of those dependencies are incredibly heavy (particularly `syn`).