### PR TITLE
curve,x: Clear deprecated functions

### DIFF
--- a/curve25519-dalek/src/backend/serial/fiat_u32/field.rs
+++ b/curve25519-dalek/src/backend/serial/fiat_u32/field.rs
@@ -239,12 +239,6 @@ impl FieldElement2625 {
         FieldElement2625(output)
     }
 
-    /// Renamed to `to_bytes`.
-    #[deprecated(since = "4.1.4", note = "use `to_bytes` instead")]
-    pub fn as_bytes(&self) -> [u8; 32] {
-        self.to_bytes()
-    }
-
     /// Serialize this `FieldElement51` to a 32-byte array.  The
     /// encoding is canonical.
     pub fn to_bytes(self) -> [u8; 32] {

--- a/curve25519-dalek/src/backend/serial/fiat_u64/field.rs
+++ b/curve25519-dalek/src/backend/serial/fiat_u64/field.rs
@@ -216,12 +216,6 @@ impl FieldElement51 {
         FieldElement51(output)
     }
 
-    /// Renamed to `to_bytes`.
-    #[deprecated(since = "4.1.4", note = "use `to_bytes` instead")]
-    pub fn as_bytes(&self) -> [u8; 32] {
-        self.to_bytes()
-    }
-
     /// Serialize this `FieldElement51` to a 32-byte array.  The
     /// encoding is canonical.
     pub fn to_bytes(self) -> [u8; 32] {

--- a/curve25519-dalek/src/backend/serial/u32/field.rs
+++ b/curve25519-dalek/src/backend/serial/u32/field.rs
@@ -431,12 +431,6 @@ impl FieldElement2625 {
         FieldElement2625::reduce(h)
     }
 
-    /// Renamed to `to_bytes`.
-    #[deprecated(since = "4.1.4", note = "use `to_bytes` instead")]
-    pub fn as_bytes(&self) -> [u8; 32] {
-        self.to_bytes()
-    }
-
     /// Serialize this `FieldElement51` to a 32-byte array.  The
     /// encoding is canonical.
     #[allow(clippy::identity_op)]

--- a/curve25519-dalek/src/backend/serial/u64/field.rs
+++ b/curve25519-dalek/src/backend/serial/u64/field.rs
@@ -362,12 +362,6 @@ impl FieldElement51 {
         ])
     }
 
-    /// Renamed to `to_bytes`.
-    #[deprecated(since = "4.1.4", note = "use `to_bytes` instead")]
-    pub fn as_bytes(&self) -> [u8; 32] {
-        self.to_bytes()
-    }
-
     /// Serialize this `FieldElement51` to a 32-byte array.  The
     /// encoding is canonical.
     #[rustfmt::skip] // keep alignment of s[*] calculations

--- a/curve25519-dalek/src/backend/vector/avx2/edwards.rs
+++ b/curve25519-dalek/src/backend/vector/avx2/edwards.rs
@@ -360,7 +360,7 @@ mod test {
 
         macro_rules! print_var {
             ($x:ident) => {
-                println!("{} = {:?}", stringify!($x), $x.as_bytes());
+                println!("{} = {:?}", stringify!($x), $x.to_bytes());
             };
         }
 
@@ -472,7 +472,7 @@ mod test {
 
         macro_rules! print_var {
             ($x:ident) => {
-                println!("{} = {:?}", stringify!($x), $x.as_bytes());
+                println!("{} = {:?}", stringify!($x), $x.to_bytes());
             };
         }
 

--- a/curve25519-dalek/src/constants.rs
+++ b/curve25519-dalek/src/constants.rs
@@ -69,10 +69,7 @@ pub const RISTRETTO_BASEPOINT_POINT: RistrettoPoint = RistrettoPoint(ED25519_BAS
 /// $$
 /// \ell = 2^\{252\} + 27742317777372353535851937790883648493.
 /// $$
-#[deprecated(since = "4.1.1", note = "Should not have been in public API")]
-pub const BASEPOINT_ORDER: Scalar = BASEPOINT_ORDER_PRIVATE;
-
-pub(crate) const BASEPOINT_ORDER_PRIVATE: Scalar = Scalar {
+pub(crate) const BASEPOINT_ORDER: Scalar = Scalar {
     bytes: [
         0xed, 0xd3, 0xf5, 0x5c, 0x1a, 0x63, 0x12, 0x58, 0xd6, 0x9c, 0xf7, 0xa2, 0xde, 0xf9, 0xde,
         0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,

--- a/curve25519-dalek/src/edwards.rs
+++ b/curve25519-dalek/src/edwards.rs
@@ -106,8 +106,8 @@ use core::ops::{Mul, MulAssign};
 
 #[cfg(feature = "digest")]
 use digest::{
-    FixedOutput, HashMarker, array::typenum::U64, consts::True,
-    crypto_common::BlockSizeUser, typenum::IsGreater,
+    FixedOutput, HashMarker, array::typenum::U64, consts::True, crypto_common::BlockSizeUser,
+    typenum::IsGreater,
 };
 
 #[cfg(feature = "group")]

--- a/curve25519-dalek/src/edwards.rs
+++ b/curve25519-dalek/src/edwards.rs
@@ -106,7 +106,7 @@ use core::ops::{Mul, MulAssign};
 
 #[cfg(feature = "digest")]
 use digest::{
-    Digest, FixedOutput, HashMarker, array::typenum::U64, consts::True,
+    FixedOutput, HashMarker, array::typenum::U64, consts::True,
     crypto_common::BlockSizeUser, typenum::IsGreater,
 };
 
@@ -671,41 +671,6 @@ impl EdwardsPoint {
             &(&ED25519_SQRTAM2 * &FieldElement::from_bytes(&M1.to_bytes())) * &E1_opt.X.invert();
         E1_opt.X.conditional_negate(is_sq ^ mont_v.is_negative());
         E1_opt.mul_by_cofactor()
-    }
-
-    #[cfg(feature = "digest")]
-    /// Maps the digest of the input bytes to the curve. This is NOT a hash-to-curve function, as
-    /// it produces points with a non-uniform distribution. Rather, it performs something that
-    /// resembles (but is not) half of the
-    /// [`hash_to_curve`](https://www.rfc-editor.org/rfc/rfc9380.html#section-3-4.2.1)
-    /// function from the Elligator2 spec.
-    ///
-    /// For a hash to curve with uniform distribution and compatible with the spec, see
-    /// [`Self::hash_to_curve`].
-    #[deprecated(
-        since = "4.0.0",
-        note = "previously named `hash_from_bytes`, this is not a secure hash function"
-    )]
-    pub fn nonspec_map_to_curve<D>(bytes: &[u8]) -> EdwardsPoint
-    where
-        D: Digest<OutputSize = U64> + Default,
-    {
-        let mut hash = D::new();
-        hash.update(bytes);
-        let h = hash.finalize();
-        let mut res = [0u8; 32];
-        res.copy_from_slice(&h[..32]);
-
-        let sign_bit = (res[31] & 0x80) >> 7;
-
-        let fe = FieldElement::from_bytes(&res);
-
-        let (M1, _) = crate::montgomery::elligator_encode(&fe);
-        let E1_opt = M1.to_edwards(sign_bit);
-
-        E1_opt
-            .expect("Montgomery conversion to Edwards point in Elligator failed")
-            .mul_by_cofactor()
     }
 
     /// Return an `EdwardsPoint` chosen uniformly at random using a user-provided RNG.
@@ -1392,7 +1357,7 @@ impl EdwardsPoint {
     /// assert_eq!((P+Q).is_torsion_free(), false);
     /// ```
     pub fn is_torsion_free(&self) -> bool {
-        (self * constants::BASEPOINT_ORDER_PRIVATE).is_identity()
+        (self * constants::BASEPOINT_ORDER).is_identity()
     }
 }
 
@@ -1739,7 +1704,7 @@ impl CofactorGroup for EdwardsPoint {
     }
 
     fn is_torsion_free(&self) -> Choice {
-        (self * constants::BASEPOINT_ORDER_PRIVATE).ct_eq(&Self::identity())
+        (self * constants::BASEPOINT_ORDER).ct_eq(&Self::identity())
     }
 }
 
@@ -1926,7 +1891,7 @@ mod test {
     /// Test that multiplication by the basepoint order kills the basepoint
     #[test]
     fn basepoint_mult_by_basepoint_order() {
-        let should_be_id = EdwardsPoint::mul_base(&constants::BASEPOINT_ORDER_PRIVATE);
+        let should_be_id = EdwardsPoint::mul_base(&constants::BASEPOINT_ORDER);
         assert!(should_be_id.is_identity());
     }
 
@@ -2412,70 +2377,6 @@ mod test {
         let raw_bytes = constants::ED25519_BASEPOINT_COMPRESSED.as_bytes();
         let bp: EdwardsPoint = bincode::deserialize(raw_bytes).unwrap();
         assert_eq!(bp, constants::ED25519_BASEPOINT_POINT);
-    }
-
-    ////////////////////////////////////////////////////////////
-    // Signal tests from                                      //
-    //     https://github.com/signalapp/libsignal-protocol-c/ //
-    ////////////////////////////////////////////////////////////
-
-    #[cfg(all(feature = "alloc", feature = "digest"))]
-    fn signal_test_vectors() -> Vec<Vec<&'static str>> {
-        vec![
-            vec![
-                "214f306e1576f5a7577636fe303ca2c625b533319f52442b22a9fa3b7ede809f",
-                "c95becf0f93595174633b9d4d6bbbeb88e16fa257176f877ce426e1424626052",
-            ],
-            vec![
-                "2eb10d432702ea7f79207da95d206f82d5a3b374f5f89f17a199531f78d3bea6",
-                "d8f8b508edffbb8b6dab0f602f86a9dd759f800fe18f782fdcac47c234883e7f",
-            ],
-            vec![
-                "84cbe9accdd32b46f4a8ef51c85fd39d028711f77fb00e204a613fc235fd68b9",
-                "93c73e0289afd1d1fc9e4e78a505d5d1b2642fbdf91a1eff7d281930654b1453",
-            ],
-            vec![
-                "c85165952490dc1839cb69012a3d9f2cc4b02343613263ab93a26dc89fd58267",
-                "43cbe8685fd3c90665b91835debb89ff1477f906f5170f38a192f6a199556537",
-            ],
-            vec![
-                "26e7fc4a78d863b1a4ccb2ce0951fbcd021e106350730ee4157bacb4502e1b76",
-                "b6fc3d738c2c40719479b2f23818180cdafa72a14254d4016bbed8f0b788a835",
-            ],
-            vec![
-                "1618c08ef0233f94f0f163f9435ec7457cd7a8cd4bb6b160315d15818c30f7a2",
-                "da0b703593b29dbcd28ebd6e7baea17b6f61971f3641cae774f6a5137a12294c",
-            ],
-            vec![
-                "48b73039db6fcdcb6030c4a38e8be80b6390d8ae46890e77e623f87254ef149c",
-                "ca11b25acbc80566603eabeb9364ebd50e0306424c61049e1ce9385d9f349966",
-            ],
-            vec![
-                "a744d582b3a34d14d311b7629da06d003045ae77cebceeb4e0e72734d63bd07d",
-                "fad25a5ea15d4541258af8785acaf697a886c1b872c793790e60a6837b1adbc0",
-            ],
-            vec![
-                "80a6ff33494c471c5eff7efb9febfbcf30a946fe6535b3451cda79f2154a7095",
-                "57ac03913309b3f8cd3c3d4c49d878bb21f4d97dc74a1eaccbe5c601f7f06f47",
-            ],
-            vec![
-                "f06fc939bc10551a0fd415aebf107ef0b9c4ee1ef9a164157bdd089127782617",
-                "785b2a6a00a5579cc9da1ff997ce8339b6f9fb46c6f10cf7a12ff2986341a6e0",
-            ],
-        ]
-    }
-
-    #[test]
-    #[allow(deprecated)]
-    #[cfg(all(feature = "alloc", feature = "digest"))]
-    fn elligator_signal_test_vectors() {
-        for vector in signal_test_vectors().iter() {
-            let input = hex::decode(vector[0]).unwrap();
-            let output = hex::decode(vector[1]).unwrap();
-
-            let point = EdwardsPoint::nonspec_map_to_curve::<sha2::Sha512>(&input);
-            assert_eq!(point.compress().to_bytes(), output[..]);
-        }
     }
 
     // Hash-to-curve test vectors from

--- a/curve25519-dalek/src/scalar.rs
+++ b/curve25519-dalek/src/scalar.rs
@@ -1331,7 +1331,7 @@ impl PrimeFieldBits for Scalar {
     }
 
     fn char_le_bits() -> FieldBits<Self::ReprBits> {
-        constants::BASEPOINT_ORDER_PRIVATE.to_bytes().into()
+        constants::BASEPOINT_ORDER.to_bytes().into()
     }
 }
 

--- a/x25519-dalek/src/x25519.rs
+++ b/x25519-dalek/src/x25519.rs
@@ -87,15 +87,6 @@ impl EphemeralSecret {
     }
 
     /// Generate a new [`EphemeralSecret`] with the supplied RNG.
-    #[deprecated(
-        since = "2.0.0",
-        note = "Renamed to `random_from_rng`. This will be removed in 2.1.0"
-    )]
-    pub fn new<R: CryptoRng + ?Sized>(csprng: &mut R) -> Self {
-        Self::random_from_rng(csprng)
-    }
-
-    /// Generate a new [`EphemeralSecret`] with the supplied RNG.
     pub fn random_from_rng<R: CryptoRng + ?Sized>(csprng: &mut R) -> Self {
         // The secret key is random bytes. Clamping is done later.
         let mut bytes = [0u8; 32];
@@ -165,15 +156,6 @@ impl ReusableSecret {
     }
 
     /// Generate a new [`ReusableSecret`] with the supplied RNG.
-    #[deprecated(
-        since = "2.0.0",
-        note = "Renamed to `random_from_rng`. This will be removed in 2.1.0."
-    )]
-    pub fn new<R: CryptoRng + ?Sized>(csprng: &mut R) -> Self {
-        Self::random_from_rng(csprng)
-    }
-
-    /// Generate a new [`ReusableSecret`] with the supplied RNG.
     pub fn random_from_rng<R: CryptoRng + ?Sized>(csprng: &mut R) -> Self {
         // The secret key is random bytes. Clamping is done later.
         let mut bytes = [0u8; 32];
@@ -239,15 +221,6 @@ impl StaticSecret {
     /// `their_public` key to produce a `SharedSecret`.
     pub fn diffie_hellman(&self, their_public: &PublicKey) -> SharedSecret {
         SharedSecret(their_public.0.mul_clamped(self.0))
-    }
-
-    /// Generate a new [`StaticSecret`] with the supplied RNG.
-    #[deprecated(
-        since = "2.0.0",
-        note = "Renamed to `random_from_rng`. This will be removed in 2.1.0"
-    )]
-    pub fn new<R: CryptoRng + ?Sized>(csprng: &mut R) -> Self {
-        Self::random_from_rng(csprng)
     }
 
     /// Generate a new [`StaticSecret`] with the supplied RNG.

--- a/x25519-dalek/tests/x25519_tests.rs
+++ b/x25519-dalek/tests/x25519_tests.rs
@@ -185,24 +185,18 @@ mod rand_core {
 
     #[test]
     fn ephemeral_from_rng() {
-        #[allow(deprecated)]
-        EphemeralSecret::new(&mut OsRng.unwrap_err());
         EphemeralSecret::random_from_rng(&mut OsRng.unwrap_err());
     }
 
     #[test]
     #[cfg(feature = "reusable_secrets")]
     fn reusable_from_rng() {
-        #[allow(deprecated)]
-        ReusableSecret::new(&mut OsRng.unwrap_err());
         ReusableSecret::random_from_rng(&mut OsRng.unwrap_err());
     }
 
     #[test]
     #[cfg(feature = "static_secrets")]
     fn static_from_rng() {
-        #[allow(deprecated)]
-        StaticSecret::new(&mut OsRng.unwrap_err());
         StaticSecret::random_from_rng(&mut OsRng.unwrap_err());
     }
 }


### PR DESCRIPTION
One thing that isn't clear is how to deprecated `Scalar::from_bits`. Ed uses this public function in `legacy_compatability` mode. We can't remove it because it's a direct dependency. And we can't vendor it in Ed because Ed doesn't have access to the type's fields. Should this just be a perma-visible deprecation?