### PR TITLE
ed25519-dalek: use `SignatureAlgorithmIdenfier` instead of the dynamic counterpart

### DIFF
--- a/ed25519-dalek/src/signing.rs
+++ b/ed25519-dalek/src/signing.rs
@@ -672,20 +672,6 @@ impl pkcs8::EncodePrivateKey for SigningKey {
     }
 }
 
-#[cfg(all(feature = "alloc", feature = "pkcs8"))]
-impl pkcs8::spki::DynSignatureAlgorithmIdentifier for SigningKey {
-    fn signature_algorithm_identifier(
-        &self,
-    ) -> pkcs8::spki::Result<pkcs8::spki::AlgorithmIdentifierOwned> {
-        // From https://datatracker.ietf.org/doc/html/rfc8410
-        // `id-Ed25519   OBJECT IDENTIFIER ::= { 1 3 101 112 }`
-        Ok(pkcs8::spki::AlgorithmIdentifier {
-            oid: ed25519::pkcs8::ALGORITHM_OID,
-            parameters: None,
-        })
-    }
-}
-
 #[cfg(feature = "pkcs8")]
 impl TryFrom<pkcs8::KeypairBytes> for SigningKey {
     type Error = pkcs8::Error;
@@ -714,6 +700,14 @@ impl TryFrom<&pkcs8::KeypairBytes> for SigningKey {
 
         Ok(signing_key)
     }
+}
+
+#[cfg(feature = "pkcs8")]
+impl pkcs8::spki::SignatureAlgorithmIdentifier for SigningKey {
+    type Params = pkcs8::spki::der::AnyRef<'static>;
+
+    const SIGNATURE_ALGORITHM_IDENTIFIER: pkcs8::spki::AlgorithmIdentifier<Self::Params> =
+        <Signature as pkcs8::spki::AssociatedAlgorithmIdentifier>::ALGORITHM_IDENTIFIER;
 }
 
 #[cfg(feature = "pkcs8")]

--- a/ed25519-dalek/src/verifying.rs
+++ b/ed25519-dalek/src/verifying.rs
@@ -610,6 +610,14 @@ impl TryFrom<&[u8]> for VerifyingKey {
     }
 }
 
+#[cfg(feature = "pkcs8")]
+impl pkcs8::spki::SignatureAlgorithmIdentifier for VerifyingKey {
+    type Params = pkcs8::spki::der::AnyRef<'static>;
+
+    const SIGNATURE_ALGORITHM_IDENTIFIER: pkcs8::spki::AlgorithmIdentifier<Self::Params> =
+        <ed25519::Signature as pkcs8::spki::AssociatedAlgorithmIdentifier>::ALGORITHM_IDENTIFIER;
+}
+
 impl From<VerifyingKey> for EdwardsPoint {
     fn from(vk: VerifyingKey) -> EdwardsPoint {
         vk.point
@@ -620,20 +628,6 @@ impl From<VerifyingKey> for EdwardsPoint {
 impl pkcs8::EncodePublicKey for VerifyingKey {
     fn to_public_key_der(&self) -> pkcs8::spki::Result<pkcs8::Document> {
         pkcs8::PublicKeyBytes::from(self).to_public_key_der()
-    }
-}
-
-#[cfg(all(feature = "alloc", feature = "pkcs8"))]
-impl pkcs8::spki::DynSignatureAlgorithmIdentifier for VerifyingKey {
-    fn signature_algorithm_identifier(
-        &self,
-    ) -> pkcs8::spki::Result<pkcs8::spki::AlgorithmIdentifierOwned> {
-        // From https://datatracker.ietf.org/doc/html/rfc8410
-        // `id-Ed25519   OBJECT IDENTIFIER ::= { 1 3 101 112 }`
-        Ok(ed25519::pkcs8::spki::AlgorithmIdentifierOwned {
-            oid: ed25519::pkcs8::ALGORITHM_OID,
-            parameters: None,
-        })
     }
 }
 


### PR DESCRIPTION
This allows to use ed25519 to create certificates for example

Related to #707 & https://github.com/RustCrypto/signatures/pull/889

This partially reverts #712

This is a revive of https://github.com/dalek-cryptography/curve25519-dalek/pull/728 after target branch got removed.