### PR TITLE
Undeprecate `Scalar::from_bits`

### DIFF
--- a/curve25519-dalek/src/scalar.rs
+++ b/curve25519-dalek/src/scalar.rs
@@ -271,10 +271,6 @@ impl Scalar {
     /// `EdwardsPoint::vartime_double_scalar_mul_basepoint`. **Do not use this function** unless
     /// you absolutely have to.
     #[cfg(feature = "legacy_compatibility")]
-    #[deprecated(
-        since = "4.0.0",
-        note = "This constructor outputs scalars with undefined scalar-scalar arithmetic. See docs."
-    )]
     pub const fn from_bits(bytes: [u8; 32]) -> Scalar {
         let mut s = Scalar { bytes };
         // Ensure invariant #1 holds. That is, make s < 2^255 by masking the high bit.

--- a/ed25519-dalek/src/signature.rs
+++ b/ed25519-dalek/src/signature.rs
@@ -80,8 +80,6 @@ fn check_scalar(bytes: [u8; 32]) -> Result<Scalar, SignatureError> {
 
     // You cannot do arithmetic with scalars construct with Scalar::from_bits. We only use this
     // scalar for EdwardsPoint::vartime_double_scalar_mul_basepoint, which is an accepted usecase.
-    // The `from_bits` method is deprecated because it's unsafe. We know this.
-    #[allow(deprecated)]
     Ok(Scalar::from_bits(bytes))
 }
 


### PR DESCRIPTION
As discussed in #778, we need to expose `Scalar::from_bits` for `ed25519` to function. It shouldn't be marked as deprecated if we're going to expose it indefinitely. So I removed the deprecation.