### PR TITLE
Stable: Update changelogs and bump minor version numbers

### DIFF
--- a/curve25519-dalek/CHANGELOG.md
+++ b/curve25519-dalek/CHANGELOG.md
@@ -3,12 +3,16 @@
 Entries are listed in reverse chronological order per undeprecated
 major series.
 
-## Unreleased
+## 4.x series
+
+### 4.2.0
 
 * Move AVX-512 backend selection logic to a separate CFG flag that requires nightly
 * Add Elligator2 hashing methods `EdwardsPoint::hash_to_curve()` and `FieldElement::hash_to_field()`
-
-## 4.x series
+* Deprecate `FieldElement::as_bytes` in favor of `FieldElement::to_bytes`
+* Remove deprecated `FieldElement::as_bytes`
+* Add batch conversion function `EdwardsPoint::to_montgomery_batch()`
+* Make `VartimePrecomputedStraus::optional_mixed_multiscalar_mul()` and `VartimeRistrettoPrecomputation::vartime_mixed_multiscalar_mul()` accept more points than static scalars
 
 ### 4.1.3
 

--- a/curve25519-dalek/Cargo.toml
+++ b/curve25519-dalek/Cargo.toml
@@ -4,7 +4,7 @@ name = "curve25519-dalek"
 # - update CHANGELOG
 # - update README if required by semver
 # - if README was updated, also update module documentation in src/lib.rs
-version = "4.1.3"
+version = "4.2.0"
 edition = "2021"
 rust-version = "1.60.0"
 authors = ["Isis Lovecruft <isis@patternsinthevoid.net>",

--- a/ed25519-dalek/CHANGELOG.md
+++ b/ed25519-dalek/CHANGELOG.md
@@ -6,11 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Entries are listed in reverse chronological order per undeprecated major series.
 
-# Unreleased
-
-* Add `SigningKey::verify_stream()`, and `VerifyingKey::verify_stream()`
-  
 # 2.x series
+
+## 2.2.0
+
+* Add `hazmat`-gated methods `SigningKey::verify_stream()` and `VerifyingKey::verify_stream()`
+* Add `Debug` and `Eq` traits for `hazmat::ExpandedSecretKey`
 
 ## 2.1.1
 

--- a/ed25519-dalek/Cargo.toml
+++ b/ed25519-dalek/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ed25519-dalek"
-version = "2.1.1"
+version = "2.2.0"
 edition = "2021"
 authors = [
     "isis lovecruft <isis@patternsinthevoid.net>",


### PR DESCRIPTION
I updated the changelogs and version numbers for our stable branch. I think this is the last thing to do for cutting minor releases for curve and ed.