### PR TITLE
x: Remove Zeroize impl for secret types

### DIFF
--- a/x25519-dalek/CHANGELOG.md
+++ b/x25519-dalek/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Entries are listed in reverse chronological order.
 
+## Unreleased
+
+* Remove `Zeroize` impl for `x25519::{EphemeralSecret, ReusableSecret, SharedSecret, StaticSecret}` to prevent misuse. These are now only zeroized on drop.
+
 # 2.x Series
 
 * Note: All `x255919-dalek` 2.x releases are in sync with the underlying `curve25519-dalek` 4.x releases. 

--- a/x25519-dalek/src/x25519.rs
+++ b/x25519-dalek/src/x25519.rs
@@ -111,13 +111,6 @@ impl<'a> From<&'a EphemeralSecret> for PublicKey {
 impl Drop for EphemeralSecret {
     fn drop(&mut self) {
         #[cfg(feature = "zeroize")]
-        self.zeroize();
-    }
-}
-
-#[cfg(feature = "zeroize")]
-impl Zeroize for EphemeralSecret {
-    fn zeroize(&mut self) {
         self.0.zeroize();
     }
 }
@@ -182,13 +175,6 @@ impl<'a> From<&'a ReusableSecret> for PublicKey {
 impl Drop for ReusableSecret {
     fn drop(&mut self) {
         #[cfg(feature = "zeroize")]
-        self.zeroize();
-    }
-}
-
-#[cfg(all(feature = "reusable_secrets", feature = "zeroize"))]
-impl Zeroize for ReusableSecret {
-    fn zeroize(&mut self) {
         self.0.zeroize();
     }
 }
@@ -279,13 +265,6 @@ impl AsRef<[u8]> for StaticSecret {
 impl Drop for StaticSecret {
     fn drop(&mut self) {
         #[cfg(feature = "zeroize")]
-        self.zeroize();
-    }
-}
-
-#[cfg(all(feature = "static_secrets", feature = "zeroize"))]
-impl Zeroize for StaticSecret {
-    fn zeroize(&mut self) {
         self.0.zeroize();
     }
 }
@@ -362,13 +341,6 @@ impl AsRef<[u8]> for SharedSecret {
 impl Drop for SharedSecret {
     fn drop(&mut self) {
         #[cfg(feature = "zeroize")]
-        self.zeroize();
-    }
-}
-
-#[cfg(feature = "zeroize")]
-impl Zeroize for SharedSecret {
-    fn zeroize(&mut self) {
         self.0.zeroize();
     }
 }


### PR DESCRIPTION
As discussed somewhat in https://github.com/dalek-cryptography/curve25519-dalek/pull/747, we should not implement `Zeroize` for types that can be badly misused when zeroed (ie secrets), and we do not need to implement `ZeroizeOnDrop` for types that don't need to always be zeroized (ie not-necessarily-secrets).

This basically means every type should at most implement `Zeroize` XOR `ZeroizeOnDrop`.

Previously, some of the x25519 secret types implemented both. Since they're secrets, we keep `ZeroizeOnDrop` and remove `Zeroize`.