### PR TITLE
main: Update all READMEs and CHANGELOGs

### DIFF
--- a/curve25519-dalek/CHANGELOG.md
+++ b/curve25519-dalek/CHANGELOG.md
@@ -3,12 +3,26 @@
 Entries are listed in reverse chronological order per undeprecated
 major series.
 
-## Unreleased
+## 5.x series
+
+## 5.0.0-pre
+
+* Update edition to 2024
+* Update the MSRV from 1.60 to 1.85
+* Remove deprecated functions `FieldElement::as_bytes()` and `EdwardsPoint::nonspec_map_to_curve()`
+* Use constant-time equality testing for compressed Ristretto and Edwards points, rather than autoderived equality
+* Undeprecate `Scalar::from_bits()`
+
+## 4.x series
+
+### 4.2.0
 
 * Move AVX-512 backend selection logic to a separate CFG flag that requires nightly
 * Add Elligator2 hashing methods `EdwardsPoint::hash_to_curve()` and `FieldElement::hash_to_field()`
-
-## 4.x series
+* Deprecate `FieldElement::as_bytes` in favor of `FieldElement::to_bytes`
+* Remove deprecated `FieldElement::as_bytes`
+* Add batch conversion function `EdwardsPoint::to_montgomery_batch()`
+* Make `VartimePrecomputedStraus::optional_mixed_multiscalar_mul()` and `VartimeRistrettoPrecomputation::vartime_mixed_multiscalar_mul()` accept more points than static scalars
 
 ### 4.1.3
 

--- a/curve25519-dalek/README.md
+++ b/curve25519-dalek/README.md
@@ -55,7 +55,8 @@ curve25519-dalek = ">= 5.0, < 5.2"
 | `digest`           |          | Enables `RistrettoPoint::{from_hash, hash_from_bytes}` and `Scalar::{from_hash, hash_from_bytes}`. This is an optional dependency whose version is not subject to SemVer. See [below](#public-api-semver-exemptions) for more details. |
 | `serde`            |          | Enables `serde` serialization/deserialization for all the point and scalar types. |
 | `legacy_compatibility`|       | Enables `Scalar::from_bits`, which allows the user to build unreduced scalars whose arithmetic is broken. Do not use this unless you know what you're doing. |
-| `group`            |          | Enables external `group` and `ff` crate traits |
+| `group`            |          | Enables external `group` and `ff` crate traits. |
+| `group-bits`       |          | Enables `group` and impls `ff::PrimeFieldBits` for `Scalar`.  |
 
 To disable the default features when using `curve25519-dalek` as a dependency,
 add `default-features = false` to the dependency in your `Cargo.toml`. To

--- a/curve25519-dalek/README.md
+++ b/curve25519-dalek/README.md
@@ -35,20 +35,20 @@ cofactor-related abstraction mismatches.
 To import `curve25519-dalek`, add the following to the dependencies section of
 your project's `Cargo.toml`:
 ```toml
-curve25519-dalek = "4"
+curve25519-dalek = "5.0.0-pre"
 ```
 
 If opting into [SemVer-exempted features](#public-api-semver-exemptions) a range
 can be used to scope the tested compatible version range e.g.:
 ```toml
-curve25519-dalek = ">= 4.0, < 4.2"
+curve25519-dalek = ">= 5.0, < 5.2"
 ```
 
 ## Feature Flags
 
 | Feature            | Default? | Description |
 | :---               |  :---:   | :---        |
-| `alloc`            |    ✓     | Enables Edwards and Ristretto multiscalar multiplication, batch scalar inversion, and batch Ristretto double-and-compress. Also enables `zeroize`. |
+| `alloc`            |    ✓     | Enables Edwards and Ristretto multiscalar multiplication, batch scalar inversion, and batch Ristretto double-and-compress. |
 | `zeroize`          |    ✓     | Enables [`Zeroize`][zeroize-trait] for all scalar and curve point types. |
 | `precomputed-tables` |    ✓     | Includes precomputed basepoint multiplication tables. This speeds up `EdwardsPoint::mul_base` and `RistrettoPoint::mul_base` by ~4x, at the cost of ~30KB added to the code size. |
 | `rand_core`        |          | Enables `Scalar::random` and `RistrettoPoint::random`. This is an optional dependency whose version is not subject to SemVer. See [below](#public-api-semver-exemptions) for more details. |
@@ -67,24 +67,13 @@ Breaking changes for each major version release can be found in
 [`CHANGELOG.md`](CHANGELOG.md), under the "Breaking changes" subheader. The
 latest breaking changes in high level are below:
 
-### Breaking changes in 4.0.0
+### Breaking changes in 5.0.0
 
-* Update the MSRV from 1.41 to 1.60
-* Provide SemVer policy
-* Make `digest` and `rand_core` optional features
-* Remove `std` and `nightly` features
-* Replace backend selection - See [CHANGELOG.md](CHANGELOG.md) and [backends](#backends)
-* Replace methods `Scalar::{zero, one}` with constants `Scalar::{ZERO, ONE}`
-* `Scalar::from_canonical_bytes` now returns `CtOption`
-* `Scalar::is_canonical` now returns `Choice`
-* Remove `Scalar::from_bytes_clamped` and `Scalar::reduce`
-* Deprecate and feature-gate `Scalar::from_bits` behind `legacy_compatibility`
-* Deprecate `EdwardsPoint::hash_from_bytes` and rename it
-  `EdwardsPoint::nonspec_map_to_curve`
-* Require including a new trait, `use curve25519_dalek::traits::BasepointTable`
-  whenever using `EdwardsBasepointTable` or `RistrettoBasepointTable`
-
-This release also does a lot of dependency updates and relaxations to unblock upstream build issues.
+* Update edition to 2024
+* Update the MSRV from 1.60 to 1.85
+* Remove deprecated functions `FieldElement::as_bytes()` and `EdwardsPoint::nonspec_map_to_curve()`
+* Use constant-time equality testing for compressed Ristretto and Edwards points, rather than autoderived equality
+* Undeprecate `Scalar::from_bits()`
 
 # Backends
 
@@ -188,6 +177,7 @@ for MSRV and public API.
 
 | Releases | MSRV   |
 | :---     |:-------|
+| 5.x      | 1.85.0 |
 | 4.x      | 1.60.0 |
 | 3.x      | 1.41.0 |
 
@@ -200,6 +190,7 @@ _some_ version bump. Below are the specific policies:
 
 | Releases | Public API Component(s)                         | Policy              |
 | :---     | :---                                            | :---                |
+| 5.x      | Dependencies `group`, `digest` and `rand_core`  | Minor SemVer bump   |
 | 4.x      | Dependencies `group`, `digest` and `rand_core`  | Minor SemVer bump   |
 
 # Safety

--- a/ed25519-dalek/CHANGELOG.md
+++ b/ed25519-dalek/CHANGELOG.md
@@ -6,11 +6,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Entries are listed in reverse chronological order per undeprecated major series.
 
-# Unreleased
+# 3.x series
 
-* Add `SigningKey::verify_stream()`, and `VerifyingKey::verify_stream()`
-  
+## 3.0.0-pre
+
+* Update edition to 2024
+* Update the MSRV from 1.60 to 1.85
+* Update `ed25519` and `signature` deps
+* Make signing and verifying keys use `pkcs8::spki::SignatureAlgorithmIdentifier` instead of `DynSignatureAlgorithmIdentifier`
+
 # 2.x series
+
+## 2.2.0
+
+* Add `hazmat`-gated methods `SigningKey::verify_stream()` and `VerifyingKey::verify_stream()`
+* Add `Debug` and `Eq` traits for `hazmat::ExpandedSecretKey`
 
 ## 2.1.1
 

--- a/ed25519-dalek/Cargo.toml
+++ b/ed25519-dalek/Cargo.toml
@@ -61,9 +61,8 @@ harness = false
 required-features = ["rand_core"]
 
 [features]
-default = ["fast", "std", "zeroize"]
+default = ["fast", "zeroize"]
 alloc = ["curve25519-dalek/alloc", "ed25519/alloc", "signature/alloc", "serde?/alloc", "zeroize?/alloc"]
-std = ["alloc", "ed25519/std", "serde?/std"]
 
 batch = ["alloc", "dep:keccak", "rand_core"]
 fast = ["curve25519-dalek/precomputed-tables"]

--- a/ed25519-dalek/README.md
+++ b/ed25519-dalek/README.md
@@ -8,7 +8,7 @@ verification.
 To import `ed25519-dalek`, add the following to the dependencies section of
 your project's `Cargo.toml`:
 ```toml
-ed25519-dalek = "2"
+ed25519-dalek = "3.0.0-pre"
 ```
 
 # Feature Flags
@@ -33,19 +33,12 @@ This crate is `#[no_std]` compatible with `default-features = false`.
 
 See [CHANGELOG.md](CHANGELOG.md) for a list of changes made in past versions of this crate.
 
-## Breaking Changes in 2.0.0
+## Breaking Changes in 3.0.0
 
-* Bump MSRV from 1.41 to 1.60.0
-* Bump Rust edition
-* Bump `signature` dependency to 2.0
-* Make `digest` an optional dependency
-* Make `zeroize` an optional dependency
-* Make `rand_core` an optional dependency
-* Adopt [curve25519-backend selection](https://github.com/dalek-cryptography/curve25519-dalek/#backends) over features
-* Make all batch verification deterministic remove `batch_deterministic` ([#256](https://github.com/dalek-cryptography/ed25519-dalek/pull/256))
-* Remove `ExpandedSecretKey` API ([#205](https://github.com/dalek-cryptography/ed25519-dalek/pull/205))
-* Rename `Keypair` → `SigningKey` and `PublicKey` → `VerifyingKey`
-* Make `hazmat` feature to expose, `ExpandedSecretKey`, `raw_sign()`, `raw_sign_prehashed()`, `raw_verify()`, and `raw_verify_prehashed()`
+* Update edition to 2024
+* Update the MSRV from 1.60 to 1.85
+* Update `ed25519` and `signature` deps
+* Make signing and verifying keys use `pkcs8::spki::SignatureAlgorithmIdentifier` instead of `DynSignatureAlgorithmIdentifier`
 
 # Documentation
 
@@ -60,6 +53,7 @@ SemVer exemptions are outlined below for MSRV and public API.
 
 | Releases | MSRV   |
 | :---     | :---   |
+| 3.x      | 1.85   |
 | 2.x      | 1.60   |
 | 1.x      | 1.41   |
 
@@ -73,6 +67,7 @@ Below are the specific policies:
 
 | Releases | Public API Component(s) | Policy |
 | :---     | :---                    | :---   |
+| 3.x      | Dependencies `digest`, `pkcs8` and `rand_core` | Minor SemVer bump |
 | 2.x      | Dependencies `digest`, `pkcs8` and `rand_core` | Minor SemVer bump |
 
 # Safety

--- a/ed25519-dalek/README.md
+++ b/ed25519-dalek/README.md
@@ -19,11 +19,11 @@ This crate is `#[no_std]` compatible with `default-features = false`.
 | :---                   | :---     | :---        |
 | `alloc`                | ✓        | When `pkcs8` is enabled, implements `EncodePrivateKey`/`EncodePublicKey` for `SigningKey`/`VerifyingKey`, respectively. |
 | `std`                  | ✓        | Implements `std::error::Error` for `SignatureError`. Also enables `alloc`. |
+| `fast`                 | ✓        | Enables the use of precomputed tables for curve arithmetic. Makes key generation, signing, and verifying faster. |
 | `zeroize`              | ✓        | Implements `Zeroize` and `ZeroizeOnDrop` for `SigningKey` |
 | `rand_core`            |          | Enables `SigningKey::generate` |
-| `batch`                |          | Enables `verify_batch` for verifying many signatures quickly. Also enables `rand_core`. |
+| `batch`                |          | Enables `verify_batch` for verifying many signatures quickly. Also enables `alloc` and `rand_core`. |
 | `digest`               |          | Enables `Context`, `SigningKey::{with_context, sign_prehashed}` and `VerifyingKey::{with_context, verify_prehashed, verify_prehashed_strict}` for Ed25519ph prehashed signatures |
-| `asm`                  |          | Enables assembly optimizations in the SHA-512 compression functions |
 | `pkcs8`                |          | Enables [PKCS#8](https://en.wikipedia.org/wiki/PKCS_8) serialization/deserialization for `SigningKey` and `VerifyingKey` |
 | `pem`                  |          | Enables PEM serialization support for PKCS#8 private keys and SPKI public keys. Also enables `alloc`. |
 | `legacy_compatibility` |          | **Unsafe:** Disables certain signature checks. See [below](#malleability-and-the-legacy_compatibility-feature) |

--- a/ed25519-dalek/README.md
+++ b/ed25519-dalek/README.md
@@ -18,7 +18,6 @@ This crate is `#[no_std]` compatible with `default-features = false`.
 | Feature                | Default? | Description |
 | :---                   | :---     | :---        |
 | `alloc`                | ✓        | When `pkcs8` is enabled, implements `EncodePrivateKey`/`EncodePublicKey` for `SigningKey`/`VerifyingKey`, respectively. |
-| `std`                  | ✓        | Implements `std::error::Error` for `SignatureError`. Also enables `alloc`. |
 | `fast`                 | ✓        | Enables the use of precomputed tables for curve arithmetic. Makes key generation, signing, and verifying faster. |
 | `zeroize`              | ✓        | Implements `Zeroize` and `ZeroizeOnDrop` for `SigningKey` |
 | `rand_core`            |          | Enables `SigningKey::generate` |

--- a/ed25519-dalek/benches/ed25519_benchmarks.rs
+++ b/ed25519-dalek/benches/ed25519_benchmarks.rs
@@ -15,10 +15,10 @@ mod ed25519_benches {
     use ed25519_dalek::Signer;
     use ed25519_dalek::SigningKey;
     use rand::prelude::ThreadRng;
-    use rand::thread_rng;
+    use rand::rng;
 
     fn sign(c: &mut Criterion) {
-        let mut csprng: ThreadRng = thread_rng();
+        let mut csprng: ThreadRng = rng();
         let keypair: SigningKey = SigningKey::generate(&mut csprng);
         let msg: &[u8] = b"";
 
@@ -26,7 +26,7 @@ mod ed25519_benches {
     }
 
     fn verify(c: &mut Criterion) {
-        let mut csprng: ThreadRng = thread_rng();
+        let mut csprng: ThreadRng = rng();
         let keypair: SigningKey = SigningKey::generate(&mut csprng);
         let msg: &[u8] = b"";
         let sig: Signature = keypair.sign(msg);
@@ -37,7 +37,7 @@ mod ed25519_benches {
     }
 
     fn verify_strict(c: &mut Criterion) {
-        let mut csprng: ThreadRng = thread_rng();
+        let mut csprng: ThreadRng = rng();
         let keypair: SigningKey = SigningKey::generate(&mut csprng);
         let msg: &[u8] = b"";
         let sig: Signature = keypair.sign(msg);
@@ -58,7 +58,7 @@ mod ed25519_benches {
         for size in BATCH_SIZES {
             let name = format!("size={size}");
             group.bench_function(name, |b| {
-                let mut csprng: ThreadRng = thread_rng();
+                let mut csprng: ThreadRng = rng();
                 let keypairs: Vec<SigningKey> = (0..size)
                     .map(|_| SigningKey::generate(&mut csprng))
                     .collect();
@@ -78,7 +78,7 @@ mod ed25519_benches {
     fn verify_batch_signatures(_: &mut Criterion) {}
 
     fn key_generation(c: &mut Criterion) {
-        let mut csprng: ThreadRng = thread_rng();
+        let mut csprng: ThreadRng = rng();
 
         c.bench_function("Ed25519 keypair generation", move |b| {
             b.iter(|| SigningKey::generate(&mut csprng))

--- a/ed25519-dalek/src/lib.rs
+++ b/ed25519-dalek/src/lib.rs
@@ -257,7 +257,7 @@
 #[cfg(feature = "batch")]
 extern crate alloc;
 
-#[cfg(any(feature = "std", test))]
+#[cfg(test)]
 #[macro_use]
 extern crate std;
 
@@ -295,8 +295,8 @@ pub use crate::verifying::*;
 // Re-export the `Signer` and `Verifier` traits from the `signature` crate
 #[cfg(feature = "digest")]
 pub use ::signature::{DigestSigner, DigestVerifier};
-pub use ed25519::Signature;
 pub use ed25519::signature::{Signer, Verifier};
+pub use ed25519::Signature;
 
 #[cfg(feature = "pkcs8")]
 pub use ed25519::pkcs8;

--- a/ed25519-dalek/src/lib.rs
+++ b/ed25519-dalek/src/lib.rs
@@ -295,8 +295,8 @@ pub use crate::verifying::*;
 // Re-export the `Signer` and `Verifier` traits from the `signature` crate
 #[cfg(feature = "digest")]
 pub use ::signature::{DigestSigner, DigestVerifier};
-pub use ed25519::signature::{Signer, Verifier};
 pub use ed25519::Signature;
+pub use ed25519::signature::{Signer, Verifier};
 
 #[cfg(feature = "pkcs8")]
 pub use ed25519::pkcs8;

--- a/x25519-dalek/CHANGELOG.md
+++ b/x25519-dalek/CHANGELOG.md
@@ -2,9 +2,15 @@
 
 Entries are listed in reverse chronological order.
 
-## Unreleased
+# 3.x Series
 
+## 3.0.0-pre
+
+* Update edition to 2024
+* Update the MSRV from 1.60 to 1.85
+* Update `rand_core` dep
 * Remove `Zeroize` impl for `x25519::{EphemeralSecret, ReusableSecret, SharedSecret, StaticSecret}` to prevent misuse. These are now only zeroized on drop.
+* Remove deprecated functions `{Ephemeral,Reusable,Static}Secret::new()`
 
 # 2.x Series
 

--- a/x25519-dalek/README.md
+++ b/x25519-dalek/README.md
@@ -103,12 +103,12 @@ To install, add the following to your project's `Cargo.toml`:
 
 ```toml
 [dependencies]
-x25519-dalek = "2"
+x25519-dalek = "3.0.0-pre"
 ```
 
 # MSRV
 
-Current MSRV is 1.60.
+Current MSRV is 1.85.
 
 # Documentation
 


### PR DESCRIPTION
Sorry this got a bit messy. This updates the READMEs and CHANGELOGs to include everything since v4.1.3 (copying stuff from the `curve-v4` branch). While I was at it, I noticed a few things:
1. ed doesn't have an `asm` feature anymore. Removed.
2. ed has a `fast` feature that wasn't documented. Added (will backport)
3. ed was not using `std` anywhere other than testing. Removed the feature.
4. curve has a `group-bits` feature that wasn't documented. Added (will backport)
5. ed's benches use `thread_rng()` which is deprecated. Fixed.

Lmk if I missed anything