### PR TITLE
Add proper hash_to_curve. 

### DIFF
--- a/curve25519-dalek/benches/dalek_benchmarks.rs
+++ b/curve25519-dalek/benches/dalek_benchmarks.rs
@@ -89,6 +89,21 @@ mod edwards_benches {
         );
     }
 
+    #[cfg(feature = "digest")]
+    fn hash_to_curve<M: Measurement>(c: &mut BenchmarkGroup<M>) {
+        let mut rng = rng();
+
+        let mut msg = [0u8; 32];
+        let mut domain_sep = [0u8; 32];
+        rng.fill_bytes(&mut msg);
+        rng.fill_bytes(&mut domain_sep);
+
+        c.bench_function(
+            "Elligator2 hash to curve (SHA-512, input size 32 bytes)",
+            |b| b.iter(|| EdwardsPoint::hash_to_curve::<Sha512>(&[&msg], &[&domain_sep])),
+        );
+    }
+
     pub(crate) fn edwards_benches() {
         let mut c = Criterion::default();
         let mut g = c.benchmark_group("edwards benches");
@@ -101,6 +116,7 @@ mod edwards_benches {
         consttime_variable_base_scalar_mul(&mut g);
         vartime_double_base_scalar_mul(&mut g);
         encode_to_curve(&mut g);
+        hash_to_curve(&mut g);
     }
 }
 

--- a/curve25519-dalek/benches/dalek_benchmarks.rs
+++ b/curve25519-dalek/benches/dalek_benchmarks.rs
@@ -84,7 +84,7 @@ mod edwards_benches {
         rng.fill_bytes(&mut domain_sep);
 
         c.bench_function(
-            "Elligator2 hash to curve (SHA-512, input size 32 bytes)",
+            "Elligator2 encode to curve (SHA-512, input size 32 bytes)",
             |b| b.iter(|| EdwardsPoint::encode_to_curve::<Sha512>(&[&msg], &[&domain_sep])),
         );
     }

--- a/curve25519-dalek/benches/dalek_benchmarks.rs
+++ b/curve25519-dalek/benches/dalek_benchmarks.rs
@@ -75,7 +75,7 @@ mod edwards_benches {
     }
 
     #[cfg(feature = "digest")]
-    fn hash_to_curve<M: Measurement>(c: &mut BenchmarkGroup<M>) {
+    fn encode_to_curve<M: Measurement>(c: &mut BenchmarkGroup<M>) {
         let mut rng = rng();
 
         let mut msg = [0u8; 32];
@@ -85,7 +85,7 @@ mod edwards_benches {
 
         c.bench_function(
             "Elligator2 hash to curve (SHA-512, input size 32 bytes)",
-            |b| b.iter(|| EdwardsPoint::hash_to_curve::<Sha512>(&[&msg], &[&domain_sep])),
+            |b| b.iter(|| EdwardsPoint::encode_to_curve::<Sha512>(&[&msg], &[&domain_sep])),
         );
     }
 
@@ -100,7 +100,7 @@ mod edwards_benches {
         consttime_fixed_base_scalar_mul(&mut g);
         consttime_variable_base_scalar_mul(&mut g);
         vartime_double_base_scalar_mul(&mut g);
-        hash_to_curve(&mut g);
+        encode_to_curve(&mut g);
     }
 }
 

--- a/curve25519-dalek/src/backend/serial/u32/constants.rs
+++ b/curve25519-dalek/src/backend/serial/u32/constants.rs
@@ -78,12 +78,14 @@ pub(crate) const SQRT_M1: FieldElement2625 = FieldElement2625::from_limbs([
 pub(crate) const APLUS2_OVER_FOUR: FieldElement2625 =
     FieldElement2625::from_limbs([121666, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
 
+#[cfg(feature = "digest")]
 /// `MONTGOMERY_A` is equal to 486662, which is a constant of the curve equation
 /// for Curve25519 in its Montgomery form. (This is used internally within the
 /// Elligator map.)
 pub(crate) const MONTGOMERY_A: FieldElement2625 =
     FieldElement2625::from_limbs([486662, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
 
+#[cfg(feature = "digest")]
 /// `MONTGOMERY_A_NEG` is equal to -486662. (This is used internally within the
 /// Elligator map.)
 pub(crate) const MONTGOMERY_A_NEG: FieldElement2625 = FieldElement2625::from_limbs([

--- a/curve25519-dalek/src/backend/serial/u64/constants.rs
+++ b/curve25519-dalek/src/backend/serial/u64/constants.rs
@@ -108,11 +108,13 @@ pub(crate) const SQRT_M1: FieldElement51 = FieldElement51::from_limbs([
 pub(crate) const APLUS2_OVER_FOUR: FieldElement51 =
     FieldElement51::from_limbs([121666, 0, 0, 0, 0]);
 
+#[cfg(feature = "digest")]
 /// `MONTGOMERY_A` is equal to 486662, which is a constant of the curve equation
 /// for Curve25519 in its Montgomery form. (This is used internally within the
 /// Elligator map.)
 pub(crate) const MONTGOMERY_A: FieldElement51 = FieldElement51::from_limbs([486662, 0, 0, 0, 0]);
 
+#[cfg(feature = "digest")]
 /// `MONTGOMERY_A_NEG` is equal to -486662. (This is used internally within the
 /// Elligator map.)
 pub(crate) const MONTGOMERY_A_NEG: FieldElement51 = FieldElement51::from_limbs([

--- a/curve25519-dalek/src/edwards.rs
+++ b/curve25519-dalek/src/edwards.rs
@@ -674,11 +674,15 @@ impl EdwardsPoint {
     }
 
     #[cfg(feature = "digest")]
-    /// Perform encode to curve per RFC 9380, with explicit hash function and domain separator, `domain_sep`,
-    /// using the suite `edwards25519_XMD:SHA-512_ELL2_NU_`. The input is the concatenation of the
-    /// elements of `bytes`. Likewise for the domain separator with `domain_sep`. At least one
-    /// element of `domain_sep`, MUST be nonempty, and the concatenation MUST NOT exceed
-    /// 255 bytes.
+    /// Perform encode to curve per RFC 9380, with explicit hash function and domain separator
+    /// `domain_sep`, using the Twisted Edwards Elligator 2 method. The input is the concatenation
+    /// of the elements of `bytes`. Likewise for the domain separator with `domain_sep`. At least
+    /// one element of `domain_sep`, MUST be nonempty, and the concatenation MUST NOT exceed 255
+    /// bytes.
+    /// 
+    /// The specification names SHA-512 as an example of a secure hash to use with this function,
+    /// but you may use any 512-bit hash within reason (see the
+    /// [`spec`](https://www.rfc-editor.org/rfc/rfc9380.html#section-5.2) for details).
     ///
     /// # Warning
     /// `encode_to_curve` is a nonuniform encoding from byte strings to points in `G`. That is,
@@ -705,11 +709,15 @@ impl EdwardsPoint {
     }
 
     #[cfg(feature = "digest")]
-    /// Perform a hash to curve per RFC 9380, with explicit hash function and domain separator, `domain_sep`,
-    /// using the suite `edwards25519_XMD:SHA-512_ELL2_RO_`. The input is the concatenation of the
-    /// elements of `bytes`. Likewise for the domain separator with `domain_sep`. At least one
-    /// element of `domain_sep`, MUST be nonempty, and the concatenation MUST NOT exceed
+    /// Perform a hash to curve per RFC 9380, with explicit hash function and domain separator
+    /// `domain_sep`, using the Twisted Edwards Elligator 2 method. The input is the concatenation
+    /// of the elements of `bytes`. Likewise for the domain separator with `domain_sep`. At least
+    /// one element of `domain_sep`, MUST be nonempty, and the concatenation MUST NOT exceed
     /// 255 bytes.
+    ///
+    /// The specification names SHA-512 as an example of a secure hash to use with this function,
+    /// but you may use any 512-bit hash within reason (see the
+    /// [`spec`](https://www.rfc-editor.org/rfc/rfc9380.html#section-5.2) for details).
     ///
     /// # Panics
     /// Panics if `domain_sep.collect().len() == 0` or `> 255`

--- a/curve25519-dalek/src/edwards.rs
+++ b/curve25519-dalek/src/edwards.rs
@@ -2472,6 +2472,7 @@ mod test {
         )
     ];
 
+    #[cfg(all(feature = "alloc", feature = "digest"))]
     fn hex_str_to_fe(hex_str: &str) -> FieldElement {
         let mut bytes = hex::decode(hex_str).unwrap().to_vec();
         bytes.reverse();

--- a/curve25519-dalek/src/edwards.rs
+++ b/curve25519-dalek/src/edwards.rs
@@ -665,10 +665,12 @@ impl EdwardsPoint {
         let yd = FieldElement::conditional_select(&yd, &FieldElement::ONE, e);
         // 13. return (xn, xd, yn, yd)
 
-        let x = &xn * &xd.invert();
-        let y = &yn * &yd.invert();
-
-        AffinePoint { x, y }.to_edwards()
+        EdwardsPoint {
+            X: &xn * &yd,
+            Y: &xd * &yn,
+            Z: &xd * &yd,
+            T: &xn * &yn,
+        }
     }
 
     #[cfg(feature = "digest")]
@@ -2433,7 +2435,7 @@ mod test {
     }
 
     // Hash-to-curve test vectors from
-    // https://www.rfc-editor.org/rfc/rfc9380.html#name-edwards25519_xmdsha-512_ell2
+    // https://www.rfc-editor.org/rfc/rfc9380.html#appendix-J.5.2
     // These are of the form (input_msg, output_x, output_y)
     #[cfg(all(feature = "alloc", feature = "digest"))]
     const RFC_HASH_TO_CURVE_KAT_NU: &[(&[u8], &str, &str)] = &[
@@ -2472,7 +2474,7 @@ mod test {
 
     #[test]
     #[cfg(all(feature = "alloc", feature = "digest"))]
-    fn elligator_map_to_curve_test_vectors() {
+    fn elligator_encode_to_curve_test_vectors() {
         let dst = b"QUUX-V01-CS02-with-edwards25519_XMD:SHA-512_ELL2_NU_";
         for (index, vector) in RFC_HASH_TO_CURVE_KAT_NU.iter().enumerate() {
             let input = vector.0;
@@ -2500,7 +2502,7 @@ mod test {
     }
 
     // Hash-to-curve test vectors from
-    // https://www.rfc-editor.org/rfc/rfc9380.html#name-edwards25519_xmdsha-512_ell
+    // https://www.rfc-editor.org/rfc/rfc9380.html#appendix-J.5.1
     // These are of the form (input_msg, output_x, output_y, q0_x, q0_y, q1_x, q1_y, u0, u1)
     #[cfg(all(feature = "alloc", feature = "digest"))]
     const RFC_HASH_TO_CURVE_KAT_RO: &[(&[u8], &str, &str)] = &[

--- a/curve25519-dalek/src/edwards.rs
+++ b/curve25519-dalek/src/edwards.rs
@@ -678,6 +678,15 @@ impl EdwardsPoint {
     /// element of `domain_sep`, MUST be nonempty, and the concatenation MUST NOT exceed
     /// 255 bytes.
     ///
+    /// # Warning
+    /// `encode_to_curve` is a nonuniform encoding from byte strings to points in `G`. That is,
+    /// the distribution of its output is not uniformly random in `G`: the set of possible outputs
+    /// of encode_to_curve is only a fraction of the points in `G`, and some points in this set
+    /// are more likely to be output than others.
+    ///
+    /// If your application needs the distribution of the output to be statistically close to
+    /// uniform in `G`, use [hash_to_curve] instead.
+    ///
     /// # Panics
     /// Panics if `domain_sep.collect().len() == 0` or `> 255`
     pub fn encode_to_curve<D>(bytes: &[&[u8]], domain_sep: &[&[u8]]) -> EdwardsPoint

--- a/curve25519-dalek/src/edwards.rs
+++ b/curve25519-dalek/src/edwards.rs
@@ -635,7 +635,7 @@ impl EdwardsPoint {
     }
 
     #[cfg(feature = "digest")]
-    /// Perform hashing to curve, with explicit hash function and domain separator, `domain_sep`,
+    /// Perform map to curve, with explicit hash function and domain separator, `domain_sep`,
     /// using the suite `edwards25519_XMD:SHA-512_ELL2_NU_`. The input is the concatenation of the
     /// elements of `bytes`. Likewise for the domain separator with `domain_sep`. At least one
     /// element of `domain_sep`, MUST be nonempty, and the concatenation MUST NOT exceed
@@ -643,7 +643,7 @@ impl EdwardsPoint {
     ///
     /// # Panics
     /// Panics if `domain_sep.collect().len() == 0` or `> 255`
-    pub fn hash_to_curve<D>(bytes: &[&[u8]], domain_sep: &[&[u8]]) -> EdwardsPoint
+    pub fn encode_to_curve<D>(bytes: &[&[u8]], domain_sep: &[&[u8]]) -> EdwardsPoint
     where
         D: BlockSizeUser + Default + FixedOutput<OutputSize = U64> + HashMarker,
         D::BlockSize: IsGreater<D::OutputSize, Output = True>,
@@ -2448,7 +2448,7 @@ mod test {
                 }
             };
 
-            let computed = EdwardsPoint::hash_to_curve::<sha2::Sha512>(&[&input], &[dst]);
+            let computed = EdwardsPoint::encode_to_curve::<sha2::Sha512>(&[&input], &[dst]);
             assert_eq!(computed, expected_output, "Failed in test {}", index);
         }
     }

--- a/curve25519-dalek/src/edwards.rs
+++ b/curve25519-dalek/src/edwards.rs
@@ -688,34 +688,34 @@ impl EdwardsPoint {
         // For reference see
         // https://www.rfc-editor.org/rfc/rfc9380.html#name-elligator-2-method-2
 
-        let fe = FieldElement::hash_to_field::<D>(bytes, domain_sep);
-        let (M1, is_sq) = crate::montgomery::elligator_encode(&fe);
+        let fe = FieldElement::hash_to_field::<D, 1>(bytes, domain_sep);
+        let Q = Self::map_to_curve(fe[0]);
+        Q.mul_by_cofactor()
+    }
 
-        // The `to_edwards` conversion we're performing takes as input the sign of the Edwards
-        // `y` coordinate. However, the specification uses `is_sq` to determine the sign of the
-        // Montgomery `v` coordinate. Our approach reconciles this mismatch as follows:
-        //
-        // * We arbitrarily fix the sign of the Edwards `y` coordinate (we choose 0).
-        // * Using the Montgomery `u` coordinate and the Edwards `X` coordinate, we recover `v`.
-        // * We verify that the sign of `v` matches the expected one, i.e., `is_sq == mont_v.is_negative()`.
-        // * If it does not match, we conditionally negate to correct the sign.
-        //
-        // Note: This logic aligns with the RFC draft specification:
-        //     https://www.rfc-editor.org/rfc/rfc9380.html#name-elligator-2-method-2
-        // followed by the mapping
-        //     https://www.rfc-editor.org/rfc/rfc9380.html#name-mappings-for-twisted-edward
-        // The only difference is that our `elligator_encode` returns only the Montgomery `u` coordinate,
-        // so we apply this workaround to reconstruct and validate the sign.
+    #[cfg(feature = "digest")]
+    /// Perform a hash to curve, with explicit hash function and domain separator, `domain_sep`,
+    /// using the suite `edwards25519_XMD:SHA-512_ELL2_RO_`. The input is the concatenation of the
+    /// elements of `bytes`. Likewise for the domain separator with `domain_sep`. At least one
+    /// element of `domain_sep`, MUST be nonempty, and the concatenation MUST NOT exceed
+    /// 255 bytes.
+    ///
+    /// # Panics
+    /// Panics if `domain_sep.collect().len() == 0` or `> 255`
+    pub fn hash_to_curve<D>(bytes: &[&[u8]], domain_sep: &[&[u8]]) -> EdwardsPoint
+    where
+        D: BlockSizeUser + Default + FixedOutput<OutputSize = U64> + HashMarker,
+        D::BlockSize: IsGreater<D::OutputSize, Output = True>,
+    {
+        // For reference see
+        // https://www.rfc-editor.org/rfc/rfc9380.html#name-elligator-2-method-2
 
-        let mut E1_opt = M1
-            .to_edwards(0)
-            .expect("Montgomery conversion to Edwards point in Elligator failed");
+        let fe = FieldElement::hash_to_field::<D, 2>(bytes, domain_sep);
+        let Q0 = Self::map_to_curve(fe[0]);
+        let Q1 = Self::map_to_curve(fe[1]);
 
-        // Now we recover v, to ensure that we got the sign right.
-        let mont_v =
-            &(&ED25519_SQRTAM2 * &FieldElement::from_bytes(&M1.to_bytes())) * &E1_opt.X.invert();
-        E1_opt.X.conditional_negate(is_sq ^ mont_v.is_negative());
-        E1_opt.mul_by_cofactor()
+        let R = Q0 + Q1;
+        R.mul_by_cofactor()
     }
 
     /// Return an `EdwardsPoint` chosen uniformly at random using a user-provided RNG.
@@ -2427,7 +2427,7 @@ mod test {
     // https://www.rfc-editor.org/rfc/rfc9380.html#name-edwards25519_xmdsha-512_ell2
     // These are of the form (input_msg, output_x, output_y)
     #[cfg(all(feature = "alloc", feature = "digest"))]
-    const RFC_HASH_TO_CURVE_KAT: &[(&[u8], &str, &str)] = &[
+    const RFC_HASH_TO_CURVE_KAT_NU: &[(&[u8], &str, &str)] = &[
         (
             b"",
             "1ff2b70ecf862799e11b7ae744e3489aa058ce805dd323a936375a84695e76da",
@@ -2463,9 +2463,9 @@ mod test {
 
     #[test]
     #[cfg(all(feature = "alloc", feature = "digest"))]
-    fn elligator_hash_to_curve_test_vectors() {
+    fn elligator_map_to_curve_test_vectors() {
         let dst = b"QUUX-V01-CS02-with-edwards25519_XMD:SHA-512_ELL2_NU_";
-        for (index, vector) in RFC_HASH_TO_CURVE_KAT.iter().enumerate() {
+        for (index, vector) in RFC_HASH_TO_CURVE_KAT_NU.iter().enumerate() {
             let input = vector.0;
 
             let expected_output = {
@@ -2487,6 +2487,73 @@ mod test {
 
             let computed = EdwardsPoint::encode_to_curve::<sha2::Sha512>(&[&input], &[dst]);
             assert_eq!(computed, expected_output, "Failed in test {}", index);
+        }
+    }
+
+    // Hash-to-curve test vectors from
+    // https://www.rfc-editor.org/rfc/rfc9380.html#name-edwards25519_xmdsha-512_ell
+    // These are of the form (input_msg, output_x, output_y, q0_x, q0_y, q1_x, q1_y, u0, u1)
+    #[cfg(all(feature = "alloc", feature = "digest"))]
+    const RFC_HASH_TO_CURVE_KAT_RO: &[(&[u8], &str, &str)] = &[
+        (
+            b"",
+            "3c3da6925a3c3c268448dcabb47ccde5439559d9599646a8260e47b1e4822fc6",
+            "09a6c8561a0b22bef63124c588ce4c62ea83a3c899763af26d795302e115dc21",
+        ),
+
+        (
+            b"abc",
+            "608040b42285cc0d72cbb3985c6b04c935370c7361f4b7fbdb1ae7f8c1a8ecad",
+            "1a8395b88338f22e435bbd301183e7f20a5f9de643f11882fb237f88268a5531",
+        ),
+
+        (
+            b"abcdef0123456789",
+            "6d7fabf47a2dc03fe7d47f7dddd21082c5fb8f86743cd020f3fb147d57161472",
+            "53060a3d140e7fbcda641ed3cf42c88a75411e648a1add71217f70ea8ec561a6",
+        ),
+        (
+            b"q128_qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq\
+            qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq",
+            "5fb0b92acedd16f3bcb0ef83f5c7b7a9466b5f1e0d8d217421878ea3686f8524",
+            "2eca15e355fcfa39d2982f67ddb0eea138e2994f5956ed37b7f72eea5e89d2f7",
+        ),
+        (
+            b"a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "0efcfde5898a839b00997fbe40d2ebe950bc81181afbd5cd6b9618aa336c1e8c",
+            "6dc2fc04f266c5c27f236a80b14f92ccd051ef1ff027f26a07f8c0f327d8f995"
+        )
+    ];
+
+    #[test]
+    #[cfg(all(feature = "alloc", feature = "digest"))]
+    fn elligator_hash_to_curve_test_vectors() {
+        let dst = b"QUUX-V01-CS02-with-edwards25519_XMD:SHA-512_ELL2_RO_";
+        for (index, vector) in RFC_HASH_TO_CURVE_KAT_RO.iter().enumerate() {
+            let input = vector.0;
+
+            let hex_str_to_fe = |hex_str: &str| -> FieldElement {
+                let hex_bytes = hex::decode(hex_str).unwrap();
+                let mut string = hex_bytes.to_vec();
+                string.reverse();
+                FieldElement::from_bytes(&string.try_into().unwrap())
+            };
+
+            let expected_output = {
+                let x = hex_str_to_fe(vector.1);
+                let y = hex_str_to_fe(vector.2);
+
+                AffinePoint { x, y }.to_edwards()
+            };
+
+            let computed = EdwardsPoint::hash_to_curve::<sha2::Sha512>(&[&input], &[dst]);
+
+            assert_eq!(expected_output, computed, "Failed in test {}", index);
         }
     }
 }

--- a/curve25519-dalek/src/edwards.rs
+++ b/curve25519-dalek/src/edwards.rs
@@ -674,7 +674,7 @@ impl EdwardsPoint {
     }
 
     #[cfg(feature = "digest")]
-    /// Perform encode to curve, with explicit hash function and domain separator, `domain_sep`,
+    /// Perform encode to curve per RFC 9380, with explicit hash function and domain separator, `domain_sep`,
     /// using the suite `edwards25519_XMD:SHA-512_ELL2_NU_`. The input is the concatenation of the
     /// elements of `bytes`. Likewise for the domain separator with `domain_sep`. At least one
     /// element of `domain_sep`, MUST be nonempty, and the concatenation MUST NOT exceed
@@ -687,7 +687,7 @@ impl EdwardsPoint {
     /// are more likely to be output than others.
     ///
     /// If your application needs the distribution of the output to be statistically close to
-    /// uniform in `G`, use [hash_to_curve] instead.
+    /// uniform in `G`, use [Self::hash_to_curve] instead.
     ///
     /// # Panics
     /// Panics if `domain_sep.collect().len() == 0` or `> 255`
@@ -705,7 +705,7 @@ impl EdwardsPoint {
     }
 
     #[cfg(feature = "digest")]
-    /// Perform a hash to curve, with explicit hash function and domain separator, `domain_sep`,
+    /// Perform a hash to curve per RFC 9380, with explicit hash function and domain separator, `domain_sep`,
     /// using the suite `edwards25519_XMD:SHA-512_ELL2_RO_`. The input is the concatenation of the
     /// elements of `bytes`. Likewise for the domain separator with `domain_sep`. At least one
     /// element of `domain_sep`, MUST be nonempty, and the concatenation MUST NOT exceed

--- a/curve25519-dalek/src/edwards.rs
+++ b/curve25519-dalek/src/edwards.rs
@@ -679,7 +679,7 @@ impl EdwardsPoint {
     /// of the elements of `bytes`. Likewise for the domain separator with `domain_sep`. At least
     /// one element of `domain_sep`, MUST be nonempty, and the concatenation MUST NOT exceed 255
     /// bytes.
-    /// 
+    ///
     /// The specification names SHA-512 as an example of a secure hash to use with this function,
     /// but you may use any 512-bit hash within reason (see the
     /// [`spec`](https://www.rfc-editor.org/rfc/rfc9380.html#section-5.2) for details).

--- a/curve25519-dalek/src/field.rs
+++ b/curve25519-dalek/src/field.rs
@@ -778,7 +778,7 @@ mod test {
     }
 
     /// Hash to field test vectors from
-    /// https://www.rfc-editor.org/rfc/rfc9380.html#name-edwards25519_xmdsha-512_ell2
+    /// https://www.rfc-editor.org/rfc/rfc9380.html#appendix-J.5.2
     /// These are of the form (input_msg, output_field_elem)
     #[cfg(feature = "digest")]
     const RFC_HASH_TO_FIELD_KAT: &[(&[u8], &str)] = &[
@@ -825,7 +825,7 @@ mod test {
     }
 
     /// Hash to field test vectors from
-    /// https://www.rfc-editor.org/rfc/rfc9380.html#name-edwards25519_xmdsha-512_ell
+    /// https://www.rfc-editor.org/rfc/rfc9380.html#appendix-J.5.1
     /// These are of the form (input_msg, output_field_elem, output_field_elem)
     #[cfg(feature = "digest")]
     const RFC_HASH_TO_FIELD_KAT_2: &[(&[u8], &str, &str)] = &[

--- a/curve25519-dalek/src/field.rs
+++ b/curve25519-dalek/src/field.rs
@@ -409,7 +409,7 @@ impl FieldElement {
             "Domain separator MUST have nonzero length."
         );
 
-        // We statically allocate `hash_outputs` to its maximum permited length.
+        // We statically allocate `hash_outputs` to its maximum permitted length.
         let mut hash_outputs = [Array::<u8, D::OutputSize>::default(); 48 * 2];
         let b_0 = hasher.chain_update([domain_sep_len]).finalize();
 

--- a/curve25519-dalek/src/field.rs
+++ b/curve25519-dalek/src/field.rs
@@ -25,8 +25,6 @@
 
 #![allow(unused_qualifications)]
 
-use core::iter::once;
-
 use cfg_if::cfg_if;
 
 use subtle::Choice;
@@ -357,10 +355,10 @@ impl FieldElement {
 
     #[cfg(feature = "digest")]
     /// Perform hashing to a [`FieldElement`], per the
-    /// [`hash_to_curve`](https://www.rfc-editor.org/rfc/rfc9380.html#section-5.2) specification.
-    /// Uses the suite `edwards25519_XMD:SHA-512_ELL2_NU_`. The input is the concatenation of the
-    /// elements of `msg`. Likewise for the domain separator with `domain_sep`. At least one
-    /// element of `domain_sep`, MUST be nonempty, and the concatenation MUST NOT exceed 255 bytes.
+    /// [`hash_to_curve`](https://www.rfc-editor.org/rfc/rfc9380.html#section-5.2) specification,
+    /// using hash-based expansion (not XOF). The input is the concatenation of the elements of
+    /// `msg`. Likewise for the domain separator with `domain_sep`. At least one element of
+    /// `domain_sep`, MUST be nonempty, and the concatenation MUST NOT exceed 255 bytes.
     ///
     /// # Panics
     /// Panics if `domain_sep.collect().len() == 0` or `> 255`. Also panics if `COUNT > 2`.
@@ -416,6 +414,8 @@ fn expand_msg_xmd<'a, D>(
 where
     D: BlockSizeUser + Default + FixedOutput + HashMarker,
 {
+    use core::iter::once;
+
     // The notation we use in this function is the same as in the spec
     let len_in_bytes = u16::try_from(outlen).expect("outlen must not exceed 65535");
 

--- a/curve25519-dalek/src/field.rs
+++ b/curve25519-dalek/src/field.rs
@@ -355,7 +355,7 @@ impl FieldElement {
 
     #[cfg(feature = "digest")]
     /// Perform hashing to a [`FieldElement`], per the
-    /// [`hash_to_curve`](https://www.rfc-editor.org/rfc/rfc9380.html#section-5.2) specification.
+    /// [`encode_to_curve`](https://www.rfc-editor.org/rfc/rfc9380.html#section-5.2) specification.
     /// Uses the suite `edwards25519_XMD:SHA-512_ELL2_NU_`. The input is the concatenation of the
     /// elements of `bytes`. Likewise for the domain separator with `domain_sep`. At least one
     /// element of `domain_sep`, MUST be nonempty, and the concatenation MUST NOT exceed 255 bytes.

--- a/curve25519-dalek/src/montgomery.rs
+++ b/curve25519-dalek/src/montgomery.rs
@@ -253,11 +253,11 @@ impl MontgomeryPoint {
     }
 }
 
+#[cfg(feature = "digest")]
 /// Perform the Elligator2 mapping to a tuple `(xn, xd, yn, yd)` such that
 /// `(xn / xd, yn / yd)` is a point on curve25519.
 ///
 /// See <https://www.rfc-editor.org/rfc/rfc9380.html#name-elligator-2-method>
-//
 pub(crate) fn elligator_encode(
     u: &FieldElement,
 ) -> (FieldElement, FieldElement, FieldElement, FieldElement) {

--- a/curve25519-dalek/src/montgomery.rs
+++ b/curve25519-dalek/src/montgomery.rs
@@ -501,9 +501,6 @@ mod test {
     use super::*;
     use crate::constants;
 
-    #[cfg(feature = "alloc")]
-    use alloc::vec::Vec;
-
     use rand_core::{CryptoRng, RngCore, TryRngCore};
 
     #[test]
@@ -706,6 +703,7 @@ mod test {
     }
 
     #[cfg(feature = "alloc")]
+    #[cfg(feature = "digest")]
     const ELLIGATOR_CORRECT_OUTPUT: [u8; 32] = [
         0x5f, 0x35, 0x20, 0x00, 0x1c, 0x6c, 0x99, 0x36, 0xa3, 0x12, 0x06, 0xaf, 0xe7, 0xc7, 0xac,
         0x22, 0x4e, 0x88, 0x61, 0x61, 0x9b, 0xf9, 0x88, 0x72, 0x44, 0x49, 0x15, 0x89, 0x9d, 0x95,
@@ -716,6 +714,7 @@ mod test {
     #[cfg(feature = "alloc")]
     #[cfg(feature = "digest")]
     fn montgomery_elligator_correct() {
+        use alloc::vec::Vec;
         let bytes: Vec<u8> = (0u8..32u8).collect();
         let bits_in: [u8; 32] = (&bytes[..]).try_into().expect("Range invariant broken");
 

--- a/curve25519-dalek/src/montgomery.rs
+++ b/curve25519-dalek/src/montgomery.rs
@@ -54,7 +54,9 @@ use core::{
     ops::{Mul, MulAssign},
 };
 
-use crate::constants::{APLUS2_OVER_FOUR, MONTGOMERY_A, MONTGOMERY_A_NEG};
+use crate::constants::APLUS2_OVER_FOUR;
+#[cfg(feature = "digest")]
+use crate::constants::{MONTGOMERY_A, MONTGOMERY_A_NEG, SQRT_M1};
 use crate::edwards::{CompressedEdwardsY, EdwardsPoint};
 use crate::field::FieldElement;
 use crate::scalar::{Scalar, clamp_integer};
@@ -65,7 +67,6 @@ use subtle::Choice;
 use subtle::ConditionallySelectable;
 use subtle::ConstantTimeEq;
 
-use crate::constants;
 #[cfg(feature = "zeroize")]
 use zeroize::Zeroize;
 
@@ -300,7 +301,7 @@ pub(crate) fn elligator_encode(
     // 17. y11 = y11 * tv3
     let y11 = &y11 * &tv3;
     // 18. y12 = y11 * c3
-    let y12 = &y11 * &constants::SQRT_M1;
+    let y12 = &y11 * &SQRT_M1;
     // 19. tv2 = y11^2
     let tv2 = y11.square();
     // 20. tv2 = tv2 * gxd
@@ -316,7 +317,7 @@ pub(crate) fn elligator_encode(
     // 25. y21 = y21 * c2
     let y21 = &y21 * &c2;
     // 26. y22 = y21 * c3
-    let y22 = &y21 * &constants::SQRT_M1;
+    let y22 = &y21 * &SQRT_M1;
     // 27. gx2 = gx1 * tv1
     let gx2 = &gx1 * &tv1;
     // 28. tv2 = y21^2

--- a/curve25519-dalek/src/montgomery.rs
+++ b/curve25519-dalek/src/montgomery.rs
@@ -714,6 +714,7 @@ mod test {
 
     #[test]
     #[cfg(feature = "alloc")]
+    #[cfg(feature = "digest")]
     fn montgomery_elligator_correct() {
         let bytes: Vec<u8> = (0u8..32u8).collect();
         let bits_in: [u8; 32] = (&bytes[..]).try_into().expect("Range invariant broken");
@@ -725,6 +726,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "digest")]
     fn montgomery_elligator_zero_zero() {
         let zero = [0u8; 32];
         let fe = FieldElement::from_bytes(&zero);


### PR DESCRIPTION
Sorry for the misunderstanding - it was a long time I did the original PR 🙏  Here is a PR with the proper hash_to_curve implementation. 

When implementing, I did a stupid mistake that got me debugging for a couple of hours, and just to make sure that the issue was not the elligator (which it was not) I implemented the inline description of the draft. I found the function `pow_p58`, which is the one I thought was missing originally. Let me know if you prefer this inline version or the one we had before. Both work (turned out that the mistake was me hardcoding incorrect test vectors 🥲 )

The other important mention is that I've used `unsafe` code to be able to not use `alloc` in `hash_to_field`. I was trying several ways, but couldn't get anything better. I'm sure you've found similar issues in the past and you have a preferred way to handle these scenarios - let me know what you prefer.  

I'll be off for a couple of days, so if this is a rush, feel free to take over the PR. 

This fixes #785.