### PR TITLE
ff FieldElement

### DIFF
--- a/curve25519-dalek/README.md
+++ b/curve25519-dalek/README.md
@@ -55,7 +55,7 @@ curve25519-dalek = ">= 5.0, < 5.2"
 | `digest`           |          | Enables `RistrettoPoint::{from_hash, hash_from_bytes}` and `Scalar::{from_hash, hash_from_bytes}`. This is an optional dependency whose version is not subject to SemVer. See [below](#public-api-semver-exemptions) for more details. |
 | `serde`            |          | Enables `serde` serialization/deserialization for all the point and scalar types. |
 | `legacy_compatibility`|       | Enables `Scalar::from_bits`, which allows the user to build unreduced scalars whose arithmetic is broken. Do not use this unless you know what you're doing. |
-| `group`            |          | Enables external `group` and `ff` crate traits. |
+| `group`            |          | Enables external `group` and `ff` crate traits, exposing an implementation of the Ed25519 field. |
 | `group-bits`       |          | Enables `group` and impls `ff::PrimeFieldBits` for `Scalar`.  |
 
 To disable the default features when using `curve25519-dalek` as a dependency,

--- a/curve25519-dalek/src/field.rs
+++ b/curve25519-dalek/src/field.rs
@@ -581,6 +581,13 @@ mod group {
         }
     }
 
+    #[cfg(feature = "zeroize")]
+    impl zeroize::Zeroize for FfFieldElement {
+        fn zeroize(&mut self) {
+            self.0.zeroize();
+        }
+    }
+
     impl Field for FfFieldElement {
         const ZERO: Self = Self(FieldElement::ZERO);
         const ONE: Self = Self(FieldElement::ONE);

--- a/curve25519-dalek/src/field.rs
+++ b/curve25519-dalek/src/field.rs
@@ -49,35 +49,39 @@ cfg_if! {
         /// \\( \mathbb Z / (2\^{255} - 19)\\).
         ///
         /// The `FieldElement` type is an alias for one of the platform-specific
-        /// implementations.
+        /// implementations. Its size and internals are not guaranteed to have
+        /// any specific properties and are not covered by semver.
         ///
         /// Using formally-verified field arithmetic from fiat-crypto.
         #[cfg(curve25519_dalek_bits = "32")]
-        pub(crate) type FieldElement = backend::serial::fiat_u32::field::FieldElement2625;
+        pub type FieldElement = backend::serial::fiat_u32::field::FieldElement2625;
 
         /// A `FieldElement` represents an element of the field
         /// \\( \mathbb Z / (2\^{255} - 19)\\).
         ///
         /// The `FieldElement` type is an alias for one of the platform-specific
-        /// implementations.
+        /// implementations. Its size and internals are not guaranteed to have
+        /// any specific properties and are not covered by semver.
         ///
         /// Using formally-verified field arithmetic from fiat-crypto.
         #[cfg(curve25519_dalek_bits = "64")]
-        pub(crate) type FieldElement = backend::serial::fiat_u64::field::FieldElement51;
+        pub type FieldElement = backend::serial::fiat_u64::field::FieldElement51;
     } else if #[cfg(curve25519_dalek_bits = "64")] {
         /// A `FieldElement` represents an element of the field
         /// \\( \mathbb Z / (2\^{255} - 19)\\).
         ///
         /// The `FieldElement` type is an alias for one of the platform-specific
-        /// implementations.
-        pub(crate) type FieldElement = backend::serial::u64::field::FieldElement51;
+        /// implementations. Its size and internals are not guaranteed to have
+        /// any specific properties and are not covered by semver.
+        pub type FieldElement = backend::serial::u64::field::FieldElement51;
     } else {
         /// A `FieldElement` represents an element of the field
         /// \\( \mathbb Z / (2\^{255} - 19)\\).
         ///
         /// The `FieldElement` type is an alias for one of the platform-specific
-        /// implementations.
-        pub(crate) type FieldElement = backend::serial::u32::field::FieldElement2625;
+        /// implementations. Its size and internals are not guaranteed to have
+        /// any specific properties and are not covered by semver.
+        pub type FieldElement = backend::serial::u32::field::FieldElement2625;
     }
 }
 
@@ -411,7 +415,7 @@ impl FieldElement {
 }
 
 #[cfg(feature = "group")]
-mod group_support {
+mod group {
     use super::*;
     use core::{
         iter::{Product, Sum},

--- a/curve25519-dalek/src/field.rs
+++ b/curve25519-dalek/src/field.rs
@@ -438,7 +438,11 @@ mod group {
 
     impl Debug for FfFieldElement {
         fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-            write!(f, "FfFieldElement{{\n\tbytes: {:?},\n}}", &self.0.to_bytes())
+            write!(
+                f,
+                "FfFieldElement{{\n\tbytes: {:?},\n}}",
+                &self.0.to_bytes()
+            )
         }
     }
 

--- a/curve25519-dalek/src/field.rs
+++ b/curve25519-dalek/src/field.rs
@@ -508,8 +508,9 @@ mod group {
 
     impl Neg for FfFieldElement {
         type Output = Self;
-        fn neg(self) -> Self {
-            FfFieldElement::ZERO - self
+        fn neg(mut self) -> Self {
+            self.0.negate();
+            Self(FieldElement::from_bytes(&self.0.to_bytes()))
         }
     }
 

--- a/curve25519-dalek/src/field.rs
+++ b/curve25519-dalek/src/field.rs
@@ -104,7 +104,7 @@ impl ConstantTimeEq for FieldElement {
 
 impl FieldElement {
     /// Load a `FieldElement` from 64 bytes, by reducing modulo q.
-    #[cfg(feature = "digest")]
+    #[cfg(any(feature = "digest", feature = "group"))]
     pub(crate) fn from_bytes_wide(bytes: &[u8; 64]) -> Self {
         let mut fl = [0u8; 32];
         let mut gl = [0u8; 32];
@@ -600,6 +600,23 @@ mod group {
             16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0,
         ]);
+    }
+
+    #[cfg(feature = "group-bits")]
+    impl ff::PrimeFieldBits for FieldElement {
+        type ReprBits = [u8; 32];
+
+        fn to_le_bits(&self) -> ff::FieldBits<Self::ReprBits> {
+            self.to_repr().into()
+        }
+
+        fn char_le_bits() -> ff::FieldBits<Self::ReprBits> {
+            [
+                127, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+                255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 237,
+            ]
+            .into()
+        }
     }
 }
 

--- a/curve25519-dalek/src/lib.rs
+++ b/curve25519-dalek/src/lib.rs
@@ -92,7 +92,8 @@ pub(crate) mod backend;
 pub(crate) mod window;
 
 pub use crate::{
-    edwards::EdwardsPoint, montgomery::MontgomeryPoint, ristretto::RistrettoPoint, scalar::Scalar,
+    edwards::EdwardsPoint, field::FieldElement, montgomery::MontgomeryPoint,
+    ristretto::RistrettoPoint, scalar::Scalar,
 };
 
 // Build time diagnostics for validation

--- a/curve25519-dalek/src/lib.rs
+++ b/curve25519-dalek/src/lib.rs
@@ -30,6 +30,7 @@
     unused_lifetimes,
     unused_qualifications
 )]
+#![cfg_attr(feature = "group", allow(clippy::op_ref))]
 
 //------------------------------------------------------------------------
 // External dependencies:

--- a/curve25519-dalek/src/lib.rs
+++ b/curve25519-dalek/src/lib.rs
@@ -30,7 +30,6 @@
     unused_lifetimes,
     unused_qualifications
 )]
-#![cfg_attr(feature = "group", allow(clippy::op_ref))]
 
 //------------------------------------------------------------------------
 // External dependencies:
@@ -92,7 +91,7 @@ pub(crate) mod backend;
 pub(crate) mod window;
 
 pub use crate::{
-    edwards::EdwardsPoint, field::FieldElement, montgomery::MontgomeryPoint,
+    edwards::EdwardsPoint, field::FfFieldElement as FieldElement, montgomery::MontgomeryPoint,
     ristretto::RistrettoPoint, scalar::Scalar,
 };
 


### PR DESCRIPTION
Provides a FieldElement backed by the underlying curve25519-dalek implementation.

Unfortunately, the underlying implementation is unsafe to directly expose, which can be near-immediately observed when tested. The solution here is to only rely on the underlying implementation for a minimal amount of operations, encoding and decoding at each step to effect a reduction.

Note there is a `reduce` function provided by each backend, yet their type signatures are non-uniform so they could not be called as an alternative to `to_repr/from_repr`. That would be an acceptable alternative.

[This branch](https://github.com/kayabaNerve/curve25519-dalek/tree/ff-group-tests) includes a test over the newly introduced wrapper, which defers to a library I wrote to test implementers off the ff/group APIs. While I did not introduce it as a dev-dependency, this ad-hoc offering is suitable to:
1) Verify baseline correctness
2) Observe how the wrapper fails when the `to_repr/from_repr` calls after every operation are removed

Resolves #389.