### PR TITLE
Add fixed-array `Scalar` batch inversion

### DIFF
--- a/curve25519-dalek/CHANGELOG.md
+++ b/curve25519-dalek/CHANGELOG.md
@@ -5,6 +5,11 @@ major series.
 
 ## 5.x series
 
+## 5.0.0-pre.1
+
+* Rename `Scalar::batch_invert` -> `Scalar::invert_batch` for consistency. Also make it no-alloc.
+* Add an allocating batch inversion called `Scalar::invert_batch_alloc`.
+
 ## 5.0.0-pre.0
 
 * Update edition to 2024

--- a/curve25519-dalek/benches/dalek_benchmarks.rs
+++ b/curve25519-dalek/benches/dalek_benchmarks.rs
@@ -377,7 +377,7 @@ mod scalar_benches {
                         (0..size).map(|_| Scalar::random(&mut rng)).collect();
                     b.iter(|| {
                         let mut s = scalars.clone();
-                        Scalar::batch_invert(&mut s);
+                        Scalar::batch_alloc_invert(&mut s);
                     });
                 },
             );

--- a/curve25519-dalek/benches/dalek_benchmarks.rs
+++ b/curve25519-dalek/benches/dalek_benchmarks.rs
@@ -377,7 +377,7 @@ mod scalar_benches {
                         (0..size).map(|_| Scalar::random(&mut rng)).collect();
                     b.iter(|| {
                         let mut s = scalars.clone();
-                        Scalar::batch_alloc_invert(&mut s);
+                        Scalar::invert_batch_alloc(&mut s);
                     });
                 },
             );


### PR DESCRIPTION
Current `Scalar::batch_invert()` allocates some scratch space as a `Vec`. This PR adds a method to do batch inversion without allocation and not requiring `alloc`.

To that effect I renamed `Scalar::batch_invert()` to `Scalar::batch_alloc_invert()`. The new method, taking the old ones name, `Scalar::batch_invert()` now takes a `const N` specifying the size for the scratch space and its argument `&mut [Scalar; N]`.