### PR TITLE
Add allocation-free `MultiscalarMul` method

### DIFF
--- a/curve25519-dalek/benches/dalek_benchmarks.rs
+++ b/curve25519-dalek/benches/dalek_benchmarks.rs
@@ -139,7 +139,7 @@ mod multiscalar_benches {
                     // rerandomize the scalars for every call just in case.
                     b.iter_batched(
                         || construct_scalars(size),
-                        |scalars| EdwardsPoint::multiscalar_mul(&scalars, &points),
+                        |scalars| EdwardsPoint::multiscalar_alloc_mul(&scalars, &points),
                         BatchSize::SmallInput,
                     );
                 },

--- a/curve25519-dalek/src/backend/mod.rs
+++ b/curve25519-dalek/src/backend/mod.rs
@@ -36,6 +36,7 @@
 
 use crate::EdwardsPoint;
 use crate::Scalar;
+use crate::traits::MultiscalarMul;
 
 pub mod serial;
 
@@ -192,29 +193,50 @@ impl VartimePrecomputedStraus {
 }
 
 #[allow(missing_docs)]
+pub fn straus_multiscalar_mul<const N: usize>(
+    scalars: &[Scalar; N],
+    points: &[EdwardsPoint; N],
+) -> EdwardsPoint {
+    match get_selected_backend() {
+        #[cfg(curve25519_dalek_backend = "simd")]
+        BackendKind::Avx2 => {
+            vector::scalar_mul::straus::spec_avx2::Straus::multiscalar_mul(scalars, points)
+        }
+        #[cfg(all(curve25519_dalek_backend = "unstable_avx512", nightly))]
+        BackendKind::Avx512 => {
+            vector::scalar_mul::straus::spec_avx512ifma_avx512vl::Straus::multiscalar_mul(
+                scalars, points,
+            )
+        }
+        BackendKind::Serial => serial::scalar_mul::straus::Straus::multiscalar_mul(scalars, points),
+    }
+}
+
+#[allow(missing_docs)]
 #[cfg(feature = "alloc")]
-pub fn straus_multiscalar_mul<I, J>(scalars: I, points: J) -> EdwardsPoint
+pub fn straus_multiscalar_alloc_mul<I, J>(scalars: I, points: J) -> EdwardsPoint
 where
     I: IntoIterator,
     I::Item: core::borrow::Borrow<Scalar>,
     J: IntoIterator,
     J::Item: core::borrow::Borrow<EdwardsPoint>,
 {
-    use crate::traits::MultiscalarMul;
-
     match get_selected_backend() {
         #[cfg(curve25519_dalek_backend = "simd")]
         BackendKind::Avx2 => {
-            vector::scalar_mul::straus::spec_avx2::Straus::multiscalar_mul::<I, J>(scalars, points)
-        }
-        #[cfg(all(curve25519_dalek_backend = "unstable_avx512", nightly))]
-        BackendKind::Avx512 => {
-            vector::scalar_mul::straus::spec_avx512ifma_avx512vl::Straus::multiscalar_mul::<I, J>(
+            vector::scalar_mul::straus::spec_avx2::Straus::multiscalar_alloc_mul::<I, J>(
                 scalars, points,
             )
         }
+        #[cfg(all(curve25519_dalek_backend = "unstable_avx512", nightly))]
+        BackendKind::Avx512 => {
+            vector::scalar_mul::straus::spec_avx512ifma_avx512vl::Straus::multiscalar_alloc_mul::<
+                I,
+                J,
+            >(scalars, points)
+        }
         BackendKind::Serial => {
-            serial::scalar_mul::straus::Straus::multiscalar_mul::<I, J>(scalars, points)
+            serial::scalar_mul::straus::Straus::multiscalar_alloc_mul::<I, J>(scalars, points)
         }
     }
 }

--- a/curve25519-dalek/src/backend/serial/scalar_mul/mod.rs
+++ b/curve25519-dalek/src/backend/serial/scalar_mul/mod.rs
@@ -23,7 +23,6 @@ pub mod variable_base;
 #[allow(missing_docs)]
 pub mod vartime_double_base;
 
-#[cfg(feature = "alloc")]
 pub mod straus;
 
 #[cfg(feature = "alloc")]

--- a/curve25519-dalek/src/backend/serial/scalar_mul/straus.rs
+++ b/curve25519-dalek/src/backend/serial/scalar_mul/straus.rs
@@ -13,15 +13,20 @@
 
 #![allow(non_snake_case)]
 
+#[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
+#[cfg(feature = "alloc")]
 use core::borrow::Borrow;
-use core::cmp::Ordering;
 
+use crate::backend::serial::curve_models::ProjectiveNielsPoint;
 use crate::edwards::EdwardsPoint;
 use crate::scalar::Scalar;
+use crate::traits::Identity;
 use crate::traits::MultiscalarMul;
+#[cfg(feature = "alloc")]
 use crate::traits::VartimeMultiscalarMul;
+use crate::window::LookupTable;
 
 /// Perform multiscalar multiplication by the interleaved window
 /// method, also known as Straus' method (since it was apparently
@@ -49,68 +54,26 @@ pub struct Straus {}
 impl MultiscalarMul for Straus {
     type Point = EdwardsPoint;
 
-    /// Constant-time Straus using a fixed window of size \\(4\\).
-    ///
-    /// Our goal is to compute
-    /// \\[
-    /// Q = s_1 P_1 + \cdots + s_n P_n.
-    /// \\]
-    ///
-    /// For each point \\( P_i \\), precompute a lookup table of
-    /// \\[
-    /// P_i, 2P_i, 3P_i, 4P_i, 5P_i, 6P_i, 7P_i, 8P_i.
-    /// \\]
-    ///
-    /// For each scalar \\( s_i \\), compute its radix-\\(2^4\\)
-    /// signed digits \\( s_{i,j} \\), i.e.,
-    /// \\[
-    ///    s_i = s_{i,0} + s_{i,1} 16^1 + ... + s_{i,63} 16^{63},
-    /// \\]
-    /// with \\( -8 \leq s_{i,j} < 8 \\).  Since \\( 0 \leq |s_{i,j}|
-    /// \leq 8 \\), we can retrieve \\( s_{i,j} P_i \\) from the
-    /// lookup table with a conditional negation: using signed
-    /// digits halves the required table size.
-    ///
-    /// Then as in the single-base fixed window case, we have
-    /// \\[
-    /// \begin{aligned}
-    /// s_i P_i &= P_i (s_{i,0} +     s_{i,1} 16^1 + \cdots +     s_{i,63} 16^{63})   \\\\
-    /// s_i P_i &= P_i s_{i,0} + P_i s_{i,1} 16^1 + \cdots + P_i s_{i,63} 16^{63}     \\\\
-    /// s_i P_i &= P_i s_{i,0} + 16(P_i s_{i,1} + 16( \cdots +16P_i s_{i,63})\cdots )
-    /// \end{aligned}
-    /// \\]
-    /// so each \\( s_i P_i \\) can be computed by alternately adding
-    /// a precomputed multiple \\( P_i s_{i,j} \\) of \\( P_i \\) and
-    /// repeatedly doubling.
-    ///
-    /// Now consider the two-dimensional sum
-    /// \\[
-    /// \begin{aligned}
-    /// s\_1 P\_1 &=& P\_1 s\_{1,0} &+& 16 (P\_1 s\_{1,1} &+& 16 ( \cdots &+& 16 P\_1 s\_{1,63}&) \cdots ) \\\\
-    ///     +     & &      +        & &      +            & &             & &     +            &           \\\\
-    /// s\_2 P\_2 &=& P\_2 s\_{2,0} &+& 16 (P\_2 s\_{2,1} &+& 16 ( \cdots &+& 16 P\_2 s\_{2,63}&) \cdots ) \\\\
-    ///     +     & &      +        & &      +            & &             & &     +            &           \\\\
-    /// \vdots    & &  \vdots       & &   \vdots          & &             & &  \vdots          &           \\\\
-    ///     +     & &      +        & &      +            & &             & &     +            &           \\\\
-    /// s\_n P\_n &=& P\_n s\_{n,0} &+& 16 (P\_n s\_{n,1} &+& 16 ( \cdots &+& 16 P\_n s\_{n,63}&) \cdots )
-    /// \end{aligned}
-    /// \\]
-    /// The sum of the left-hand column is the result \\( Q \\); by
-    /// computing the two-dimensional sum on the right column-wise,
-    /// top-to-bottom, then right-to-left, we need to multiply by \\(
-    /// 16\\) only once per column, sharing the doublings across all
-    /// of the input points.
-    fn multiscalar_mul<I, J>(scalars: I, points: J) -> EdwardsPoint
+    fn multiscalar_mul<const N: usize>(
+        scalars: &[Scalar; N],
+        points: &[EdwardsPoint; N],
+    ) -> EdwardsPoint {
+        let lookup_tables: [_; N] =
+            core::array::from_fn(|index| LookupTable::<ProjectiveNielsPoint>::from(&points[index]));
+
+        let scalar_digits: [_; N] = core::array::from_fn(|index| scalars[index].as_radix_16());
+
+        multiscalar_mul(&scalar_digits, &lookup_tables)
+    }
+
+    #[cfg(feature = "alloc")]
+    fn multiscalar_alloc_mul<I, J>(scalars: I, points: J) -> EdwardsPoint
     where
         I: IntoIterator,
         I::Item: Borrow<Scalar>,
         J: IntoIterator,
         J::Item: Borrow<EdwardsPoint>,
     {
-        use crate::backend::serial::curve_models::ProjectiveNielsPoint;
-        use crate::traits::Identity;
-        use crate::window::LookupTable;
-
         let lookup_tables: Vec<_> = points
             .into_iter()
             .map(|point| LookupTable::<ProjectiveNielsPoint>::from(point.borrow()))
@@ -125,25 +88,86 @@ impl MultiscalarMul for Straus {
             .map(|s| s.borrow().as_radix_16())
             .collect();
 
-        let mut Q = EdwardsPoint::identity();
-        for j in (0..64).rev() {
-            Q = Q.mul_by_pow_2(4);
-            let it = scalar_digits.iter().zip(lookup_tables.iter());
-            for (s_i, lookup_table_i) in it {
-                // R_i = s_{i,j} * P_i
-                let R_i = lookup_table_i.select(s_i[j]);
-                // Q = Q + R_i
-                Q = (&Q + &R_i).as_extended();
-            }
-        }
+        let Q = multiscalar_mul(&scalar_digits, &lookup_tables);
 
         #[cfg(feature = "zeroize")]
-        zeroize::Zeroize::zeroize(&mut scalar_digits);
+        zeroize::Zeroize::zeroize(&mut scalar_digits.iter_mut());
 
         Q
     }
 }
 
+/// Constant-time Straus using a fixed window of size \\(4\\).
+///
+/// Our goal is to compute
+/// \\[
+/// Q = s_1 P_1 + \cdots + s_n P_n.
+/// \\]
+///
+/// For each point \\( P_i \\), precompute a lookup table of
+/// \\[
+/// P_i, 2P_i, 3P_i, 4P_i, 5P_i, 6P_i, 7P_i, 8P_i.
+/// \\]
+///
+/// For each scalar \\( s_i \\), compute its radix-\\(2^4\\)
+/// signed digits \\( s_{i,j} \\), i.e.,
+/// \\[
+///    s_i = s_{i,0} + s_{i,1} 16^1 + ... + s_{i,63} 16^{63},
+/// \\]
+/// with \\( -8 \leq s_{i,j} < 8 \\).  Since \\( 0 \leq |s_{i,j}|
+/// \leq 8 \\), we can retrieve \\( s_{i,j} P_i \\) from the
+/// lookup table with a conditional negation: using signed
+/// digits halves the required table size.
+///
+/// Then as in the single-base fixed window case, we have
+/// \\[
+/// \begin{aligned}
+/// s_i P_i &= P_i (s_{i,0} +     s_{i,1} 16^1 + \cdots +     s_{i,63} 16^{63})   \\\\
+/// s_i P_i &= P_i s_{i,0} + P_i s_{i,1} 16^1 + \cdots + P_i s_{i,63} 16^{63}     \\\\
+/// s_i P_i &= P_i s_{i,0} + 16(P_i s_{i,1} + 16( \cdots +16P_i s_{i,63})\cdots )
+/// \end{aligned}
+/// \\]
+/// so each \\( s_i P_i \\) can be computed by alternately adding
+/// a precomputed multiple \\( P_i s_{i,j} \\) of \\( P_i \\) and
+/// repeatedly doubling.
+///
+/// Now consider the two-dimensional sum
+/// \\[
+/// \begin{aligned}
+/// s\_1 P\_1 &=& P\_1 s\_{1,0} &+& 16 (P\_1 s\_{1,1} &+& 16 ( \cdots &+& 16 P\_1 s\_{1,63}&) \cdots ) \\\\
+///     +     & &      +        & &      +            & &             & &     +            &           \\\\
+/// s\_2 P\_2 &=& P\_2 s\_{2,0} &+& 16 (P\_2 s\_{2,1} &+& 16 ( \cdots &+& 16 P\_2 s\_{2,63}&) \cdots ) \\\\
+///     +     & &      +        & &      +            & &             & &     +            &           \\\\
+/// \vdots    & &  \vdots       & &   \vdots          & &             & &  \vdots          &           \\\\
+///     +     & &      +        & &      +            & &             & &     +            &           \\\\
+/// s\_n P\_n &=& P\_n s\_{n,0} &+& 16 (P\_n s\_{n,1} &+& 16 ( \cdots &+& 16 P\_n s\_{n,63}&) \cdots )
+/// \end{aligned}
+/// \\]
+/// The sum of the left-hand column is the result \\( Q \\); by
+/// computing the two-dimensional sum on the right column-wise,
+/// top-to-bottom, then right-to-left, we need to multiply by \\(
+/// 16\\) only once per column, sharing the doublings across all
+/// of the input points.
+fn multiscalar_mul(
+    scalar_digits: &[[i8; 64]],
+    lookup_tables: &[LookupTable<ProjectiveNielsPoint>],
+) -> EdwardsPoint {
+    let mut Q = EdwardsPoint::identity();
+    for j in (0..64).rev() {
+        Q = Q.mul_by_pow_2(4);
+        let it = scalar_digits.iter().zip(lookup_tables.iter());
+        for (s_i, lookup_table_i) in it {
+            // R_i = s_{i,j} * P_i
+            let R_i = lookup_table_i.select(s_i[j]);
+            // Q = Q + R_i
+            Q = (&Q + &R_i).as_extended();
+        }
+    }
+
+    Q
+}
+
+#[cfg(feature = "alloc")]
 impl VartimeMultiscalarMul for Straus {
     type Point = EdwardsPoint;
 
@@ -167,6 +191,7 @@ impl VartimeMultiscalarMul for Straus {
         };
         use crate::traits::Identity;
         use crate::window::NafLookupTable5;
+        use core::cmp::Ordering;
 
         let nafs: Vec<_> = scalars
             .into_iter()

--- a/curve25519-dalek/src/backend/vector/scalar_mul/mod.rs
+++ b/curve25519-dalek/src/backend/vector/scalar_mul/mod.rs
@@ -18,7 +18,6 @@ pub mod variable_base;
 pub mod vartime_double_base;
 
 #[allow(missing_docs)]
-#[cfg(feature = "alloc")]
 pub mod straus;
 
 #[allow(missing_docs)]

--- a/curve25519-dalek/src/backend/vector/scalar_mul/straus.rs
+++ b/curve25519-dalek/src/backend/vector/scalar_mul/straus.rs
@@ -20,13 +20,11 @@
 )]
 pub mod spec {
 
+    #[cfg(feature = "alloc")]
     use alloc::vec::Vec;
 
+    #[cfg(feature = "alloc")]
     use core::borrow::Borrow;
-    use core::cmp::Ordering;
-
-    #[cfg(feature = "zeroize")]
-    use zeroize::Zeroizing;
 
     #[for_target_feature("avx2")]
     use crate::backend::vector::avx2::{CachedPoint, ExtendedPoint};
@@ -36,8 +34,10 @@ pub mod spec {
 
     use crate::edwards::EdwardsPoint;
     use crate::scalar::Scalar;
-    use crate::traits::{Identity, MultiscalarMul, VartimeMultiscalarMul};
-    use crate::window::{LookupTable, NafLookupTable5};
+    #[cfg(feature = "alloc")]
+    use crate::traits::VartimeMultiscalarMul;
+    use crate::traits::{Identity, MultiscalarMul};
+    use crate::window::LookupTable;
 
     /// Multiscalar multiplication using interleaved window / Straus'
     /// method.  See the `Straus` struct in the serial backend for more
@@ -52,7 +52,22 @@ pub mod spec {
     impl MultiscalarMul for Straus {
         type Point = EdwardsPoint;
 
-        fn multiscalar_mul<I, J>(scalars: I, points: J) -> EdwardsPoint
+        fn multiscalar_mul<const N: usize>(
+            scalars: &[Scalar; N],
+            points: &[EdwardsPoint; N],
+        ) -> EdwardsPoint {
+            // Construct a lookup table of [P,2P,3P,4P,5P,6P,7P,8P]
+            // for each input point P
+            let lookup_tables: [_; N] =
+                core::array::from_fn(|index| LookupTable::<CachedPoint>::from(&points[index]));
+
+            let scalar_digits: [_; N] = core::array::from_fn(|index| scalars[index].as_radix_16());
+
+            multiscalar_mul(&scalar_digits, &lookup_tables)
+        }
+
+        #[cfg(feature = "alloc")]
+        fn multiscalar_alloc_mul<I, J>(scalars: I, points: J) -> EdwardsPoint
         where
             I: IntoIterator,
             I::Item: Borrow<Scalar>,
@@ -72,21 +87,29 @@ pub mod spec {
                 .collect();
             // Pass ownership to a `Zeroizing` wrapper
             #[cfg(feature = "zeroize")]
-            let scalar_digits_vec = Zeroizing::new(scalar_digits_vec);
+            let scalar_digits_vec = zeroize::Zeroizing::new(scalar_digits_vec);
 
-            let mut Q = ExtendedPoint::identity();
-            for j in (0..64).rev() {
-                Q = Q.mul_by_pow_2(4);
-                let it = scalar_digits_vec.iter().zip(lookup_tables.iter());
-                for (s_i, lookup_table_i) in it {
-                    // Q = Q + s_{i,j} * P_i
-                    Q = &Q + &lookup_table_i.select(s_i[j]);
-                }
-            }
-            Q.into()
+            multiscalar_mul(&scalar_digits_vec, &lookup_tables)
         }
     }
 
+    fn multiscalar_mul(
+        scalar_digits: &[[i8; 64]],
+        lookup_tables: &[LookupTable<CachedPoint>],
+    ) -> EdwardsPoint {
+        let mut Q = ExtendedPoint::identity();
+        for j in (0..64).rev() {
+            Q = Q.mul_by_pow_2(4);
+            let it = scalar_digits.iter().zip(lookup_tables.iter());
+            for (s_i, lookup_table_i) in it {
+                // Q = Q + s_{i,j} * P_i
+                Q = &Q + &lookup_table_i.select(s_i[j]);
+            }
+        }
+        Q.into()
+    }
+
+    #[cfg(feature = "alloc")]
     impl VartimeMultiscalarMul for Straus {
         type Point = EdwardsPoint;
 
@@ -96,6 +119,9 @@ pub mod spec {
             I::Item: Borrow<Scalar>,
             J: IntoIterator<Item = Option<EdwardsPoint>>,
         {
+            use crate::window::NafLookupTable5;
+            use core::cmp::Ordering;
+
             let nafs: Vec<_> = scalars
                 .into_iter()
                 .map(|c| c.borrow().non_adjacent_form(5))

--- a/curve25519-dalek/src/edwards.rs
+++ b/curve25519-dalek/src/edwards.rs
@@ -154,7 +154,6 @@ use crate::traits::{Identity, IsIdentity};
 
 use affine::AffinePoint;
 
-#[cfg(feature = "alloc")]
 use crate::traits::MultiscalarMul;
 #[cfg(feature = "alloc")]
 use crate::traits::{VartimeMultiscalarMul, VartimePrecomputedMultiscalarMul};
@@ -895,11 +894,18 @@ impl EdwardsPoint {
 // These use the iterator's size hint and the target settings to
 // forward to a specific backend implementation.
 
-#[cfg(feature = "alloc")]
 impl MultiscalarMul for EdwardsPoint {
     type Point = EdwardsPoint;
 
-    fn multiscalar_mul<I, J>(scalars: I, points: J) -> EdwardsPoint
+    fn multiscalar_mul<const N: usize>(
+        scalars: &[Scalar; N],
+        points: &[Self::Point; N],
+    ) -> Self::Point {
+        crate::backend::straus_multiscalar_mul(scalars, points)
+    }
+
+    #[cfg(feature = "alloc")]
+    fn multiscalar_alloc_mul<I, J>(scalars: I, points: J) -> EdwardsPoint
     where
         I: IntoIterator,
         I::Item: Borrow<Scalar>,
@@ -923,7 +929,7 @@ impl MultiscalarMul for EdwardsPoint {
         // size-dependent algorithm dispatch, use this as the hint.
         let _size = s_lo;
 
-        crate::backend::straus_multiscalar_mul(scalars, points)
+        crate::backend::straus_multiscalar_alloc_mul(scalars, points)
     }
 }
 
@@ -2196,7 +2202,7 @@ mod test {
         let Gs = xs.iter().map(EdwardsPoint::mul_base).collect::<Vec<_>>();
 
         // Compute H1 = <xs, Gs> (consttime)
-        let H1 = EdwardsPoint::multiscalar_mul(&xs, &Gs);
+        let H1 = EdwardsPoint::multiscalar_alloc_mul(&xs, &Gs);
         // Compute H2 = <xs, Gs> (vartime)
         let H2 = EdwardsPoint::vartime_multiscalar_mul(&xs, &Gs);
         // Compute H3 = <xs, Gs> = sum(xi^2) * B
@@ -2353,7 +2359,7 @@ mod test {
                 &[A_SCALAR, B_SCALAR],
                 &[A, constants::ED25519_BASEPOINT_POINT],
             );
-            let result_consttime = EdwardsPoint::multiscalar_mul(
+            let result_consttime = EdwardsPoint::multiscalar_alloc_mul(
                 &[A_SCALAR, B_SCALAR],
                 &[A, constants::ED25519_BASEPOINT_POINT],
             );

--- a/curve25519-dalek/src/ristretto.rs
+++ b/curve25519-dalek/src/ristretto.rs
@@ -206,9 +206,9 @@ use crate::scalar::Scalar;
 
 #[cfg(feature = "precomputed-tables")]
 use crate::traits::BasepointTable;
-use crate::traits::Identity;
+use crate::traits::{Identity, MultiscalarMul};
 #[cfg(feature = "alloc")]
-use crate::traits::{MultiscalarMul, VartimeMultiscalarMul, VartimePrecomputedMultiscalarMul};
+use crate::traits::{VartimeMultiscalarMul, VartimePrecomputedMultiscalarMul};
 
 // ------------------------------------------------------------------------
 // Compressed points
@@ -1007,11 +1007,19 @@ define_mul_variants!(LHS = Scalar, RHS = RistrettoPoint, Output = RistrettoPoint
 // These use iterator combinators to unwrap the underlying points and
 // forward to the EdwardsPoint implementations.
 
-#[cfg(feature = "alloc")]
 impl MultiscalarMul for RistrettoPoint {
     type Point = RistrettoPoint;
 
-    fn multiscalar_mul<I, J>(scalars: I, points: J) -> RistrettoPoint
+    fn multiscalar_mul<const N: usize>(
+        scalars: &[Scalar; N],
+        points: &[Self::Point; N],
+    ) -> Self::Point {
+        let extended_points: [_; N] = core::array::from_fn(|index| points[index].0);
+        RistrettoPoint(EdwardsPoint::multiscalar_mul(scalars, &extended_points))
+    }
+
+    #[cfg(feature = "alloc")]
+    fn multiscalar_alloc_mul<I, J>(scalars: I, points: J) -> RistrettoPoint
     where
         I: IntoIterator,
         I::Item: Borrow<Scalar>,
@@ -1019,7 +1027,10 @@ impl MultiscalarMul for RistrettoPoint {
         J::Item: Borrow<RistrettoPoint>,
     {
         let extended_points = points.into_iter().map(|P| P.borrow().0);
-        RistrettoPoint(EdwardsPoint::multiscalar_mul(scalars, extended_points))
+        RistrettoPoint(EdwardsPoint::multiscalar_alloc_mul(
+            scalars,
+            extended_points,
+        ))
     }
 }
 

--- a/curve25519-dalek/src/traits.rs
+++ b/curve25519-dalek/src/traits.rs
@@ -95,6 +95,52 @@ pub trait MultiscalarMul {
     /// iterators returning either `Scalar`s or `&Scalar`s.
     ///
     /// ```
+    /// use curve25519_dalek::constants;
+    /// use curve25519_dalek::traits::MultiscalarMul;
+    /// use curve25519_dalek::ristretto::RistrettoPoint;
+    /// use curve25519_dalek::scalar::Scalar;
+    ///
+    /// // Some scalars
+    /// let a = Scalar::from(87329482u64);
+    /// let b = Scalar::from(37264829u64);
+    /// let c = Scalar::from(98098098u64);
+    ///
+    /// // Some points
+    /// let P = constants::RISTRETTO_BASEPOINT_POINT;
+    /// let Q = P + P;
+    /// let R = P + Q;
+    ///
+    /// // A1 = a*P + b*Q + c*R
+    /// let abc = [a,b,c];
+    /// let A1 = RistrettoPoint::multiscalar_mul(&abc, &[P,Q,R]);
+    ///
+    /// // A2 = (-a)*P + (-b)*Q + (-c)*R
+    /// let minus_abc = abc.map(|x| -x);
+    /// let A2 = RistrettoPoint::multiscalar_mul(&minus_abc, &[P,Q,R]);
+    ///
+    /// assert_eq!(A1.compress(), (-A2).compress());
+    /// ```
+    fn multiscalar_mul<const N: usize>(
+        scalars: &[Scalar; N],
+        points: &[Self::Point; N],
+    ) -> Self::Point;
+
+    /// Given an iterator of (possibly secret) scalars and an iterator of
+    /// public points, compute
+    /// $$
+    /// Q = c\_1 P\_1 + \cdots + c\_n P\_n.
+    /// $$
+    ///
+    /// It is an error to call this function with two iterators of different lengths.
+    ///
+    /// # Examples
+    ///
+    /// The trait bound aims for maximum flexibility: the inputs must be
+    /// convertible to iterators (`I: IntoIter`), and the iterator's items
+    /// must be `Borrow<Scalar>` (or `Borrow<Point>`), to allow
+    /// iterators returning either `Scalar`s or `&Scalar`s.
+    ///
+    /// ```
     /// # #[cfg(feature = "alloc")]
     /// # {
     /// use curve25519_dalek::constants;
@@ -114,18 +160,19 @@ pub trait MultiscalarMul {
     ///
     /// // A1 = a*P + b*Q + c*R
     /// let abc = [a,b,c];
-    /// let A1 = RistrettoPoint::multiscalar_mul(&abc, &[P,Q,R]);
+    /// let A1 = RistrettoPoint::multiscalar_alloc_mul(&abc, &[P,Q,R]);
     /// // Note: (&abc).into_iter(): Iterator<Item=&Scalar>
     ///
     /// // A2 = (-a)*P + (-b)*Q + (-c)*R
     /// let minus_abc = abc.iter().map(|x| -x);
-    /// let A2 = RistrettoPoint::multiscalar_mul(minus_abc, &[P,Q,R]);
+    /// let A2 = RistrettoPoint::multiscalar_alloc_mul(minus_abc, &[P,Q,R]);
     /// // Note: minus_abc.into_iter(): Iterator<Item=Scalar>
     ///
     /// assert_eq!(A1.compress(), (-A2).compress());
     /// # }
     /// ```
-    fn multiscalar_mul<I, J>(scalars: I, points: J) -> Self::Point
+    #[cfg(feature = "alloc")]
+    fn multiscalar_alloc_mul<I, J>(scalars: I, points: J) -> Self::Point
     where
         I: IntoIterator,
         I::Item: Borrow<Scalar>,


### PR DESCRIPTION
This renames `MultiscalarMul::multiscalar_mul()` to `multiscalar_alloc_mul()` and adds a new `multiscalar_mul()` method taking fixed-sized arrays. This enables the usage of allocation-free multiscalar multiplication.

To that end the following changes were made:
- Backend implementations were refactored so both `multiscalar_mul()` and `multiscalar_alloc_mul()` can share the same code.
- `straus` module is now exposed without the `alloc` crate feature.
- `MultiscalarMul::multiscalar_alloc_mul()` is now guarded behind `cfg(feature = "alloc")`. If we intend users to implement `MultiscalarMul` on their own custom curves having a required trait method behind a crate feature is pretty bad UX.

This could be extended to cover `VartimeMultiscalarMul` and `VartimePrecomputedMultiscalarMul`, but I don't have a use-case personally.
The new fixed-array method also looses a lot of the flexibility the new `multiscalar_alloc_mul()` offers. I'm happy to sync that flexibility, but it would require calling it like so: `RistrettoPoint::multiscalar_mul::<12, _, _>(...)`. Basically the compiler can't infer `const N`.

This change isn't exactly small and wasn't discussed beforehand. I'm fully prepared to consider any large changes to implement this feature.