### PR TITLE
chore(deps): bump `signature` to `3.0.0-rc.2`

### DIFF
--- a/ed25519-dalek/Cargo.toml
+++ b/ed25519-dalek/Cargo.toml
@@ -32,7 +32,7 @@ curve25519-dalek = { version = "=5.0.0-pre.0", path = "../curve25519-dalek", def
     "digest",
 ] }
 ed25519 = { version = "=3.0.0-pre.0", default-features = false }
-signature = { version = "=3.0.0-rc.1", optional = true, default-features = false }
+signature = { version = "3.0.0-rc.2", optional = true, default-features = false }
 sha2 = { version = "0.11.0-rc.0", default-features = false }
 subtle = { version = "2.3.0", default-features = false }
 


### PR DESCRIPTION
This also relax the dependency to use future RC versions of signature