### PR TITLE
workspace: use a global patch.crates-io to avoid duplicates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,7 @@ resolver = "2"
 [profile.dev]
 opt-level = 2
 
+[patch.crates-io]
+curve25519-dalek-derive = { path = "./curve25519-dalek-derive" }
+curve25519-dalek = { path = "./curve25519-dalek" }
+x25519-dalek = { path = "./x25519-dalek" }

--- a/curve25519-dalek/Cargo.toml
+++ b/curve25519-dalek/Cargo.toml
@@ -84,7 +84,7 @@ group-bits = ["group", "ff/bits"]
 digest = ["dep:digest"]
 
 [target.'cfg(all(not(curve25519_dalek_backend = "fiat"), not(curve25519_dalek_backend = "serial"), target_arch = "x86_64"))'.dependencies]
-curve25519-dalek-derive = { version = "0.1", path = "../curve25519-dalek-derive" }
+curve25519-dalek-derive = "0.1"
 
 [lints.rust.unexpected_cfgs]
 level = "warn"

--- a/ed25519-dalek/Cargo.toml
+++ b/ed25519-dalek/Cargo.toml
@@ -28,7 +28,7 @@ rustdoc-args = [
 features = ["batch", "digest", "hazmat", "pem", "serde"]
 
 [dependencies]
-curve25519-dalek = { version = "=5.0.0-pre.0", path = "../curve25519-dalek", default-features = false, features = [
+curve25519-dalek = { version = "=5.0.0-pre.0", default-features = false, features = [
     "digest",
 ] }
 ed25519 = { version = "=3.0.0-pre.0", default-features = false }
@@ -43,11 +43,11 @@ serde = { version = "1.0", default-features = false, optional = true }
 zeroize = { version = "1.5", default-features = false, optional = true }
 
 [dev-dependencies]
-curve25519-dalek = { version = "=5.0.0-pre.0", path = "../curve25519-dalek", default-features = false, features = [
+curve25519-dalek = { version = "=5.0.0-pre.0", default-features = false, features = [
     "digest",
     "rand_core",
 ] }
-x25519-dalek = { version = "=3.0.0-pre.0", path = "../x25519-dalek", default-features = false, features = [
+x25519-dalek = { version = "=3.0.0-pre.0", default-features = false, features = [
     "static_secrets",
 ] }
 blake2 = "0.11.0-rc.0"

--- a/x25519-dalek/Cargo.toml
+++ b/x25519-dalek/Cargo.toml
@@ -42,7 +42,7 @@ rustdoc-args = [
 features = ["os_rng", "reusable_secrets", "serde", "static_secrets"]
 
 [dependencies]
-curve25519-dalek = { version = "=5.0.0-pre.0", path = "../curve25519-dalek", default-features = false }
+curve25519-dalek = { version = "=5.0.0-pre.0", default-features = false }
 rand_core = { version = "0.9", default-features = false }
 serde = { version = "1", default-features = false, optional = true, features = [
     "derive",


### PR DESCRIPTION
When pulling crates via git (to grab non-released yet fixes or otherwise), the `path = "../"` in each crate crates duplicates unless you pull the whole tree in your local `[patch.crates-io]`.

This creates issues in downstream packaging (nix, ...) where a crate version can only appear once.
Those are somewhat difficult to diagnose.

Using a `[patch.crates-io]` in the workspace serves the same purpose but does not create the duplication in consumers' tree.