### PR TITLE
Convert more tests to Proptest

### DIFF
--- a/curve25519-dalek/Cargo.toml
+++ b/curve25519-dalek/Cargo.toml
@@ -41,7 +41,8 @@ sha2 = { version = "0.11.0-rc.2", default-features = false }
 bincode = "1"
 criterion = { version = "0.5", features = ["html_reports"] }
 hex = "0.4.2"
-proptest = "1"
+proptest = { version = "1", features = ["attr-macro"] }
+proptest-derive = "0.6"
 rand = "0.9"
 rand_core = { version = "0.9", default-features = false, features = ["os_rng"] }
 


### PR DESCRIPTION
To make the code cleaner I implemented `Arbitrary` for various types where appropriate. The implementation is a bit naive because it simply maps by reducing instead of properly having a min/max implementation via a custom `ValueTree`.

I also switched to the newer `#[property_test]` instead of `proptest!`.

Follow-up from https://github.com/dalek-cryptography/curve25519-dalek/pull/806.