### PR TITLE
Bump RustCrypto dependencies

### DIFF
--- a/curve25519-dalek/Cargo.toml
+++ b/curve25519-dalek/Cargo.toml
@@ -37,7 +37,7 @@ features = [
 ]
 
 [dev-dependencies]
-sha2 = { version = "0.11.0-rc.0", default-features = false }
+sha2 = { version = "0.11.0-rc.2", default-features = false }
 bincode = "1"
 criterion = { version = "0.5", features = ["html_reports"] }
 hex = "0.4.2"
@@ -58,7 +58,7 @@ cfg-if = "1"
 ff = { version = "=0.14.0-pre.0", default-features = false, optional = true }
 group = { version = "=0.14.0-pre.0", default-features = false, optional = true }
 rand_core = { version = "0.9", default-features = false, optional = true }
-digest = { version = "0.11.0-rc.0", default-features = false, optional = true, features = [
+digest = { version = "0.11.0-rc.1", default-features = false, optional = true, features = [
     "block-api",
 ] }
 subtle = { version = "2.6.0", default-features = false, features = [

--- a/ed25519-dalek/Cargo.toml
+++ b/ed25519-dalek/Cargo.toml
@@ -31,13 +31,13 @@ features = ["batch", "digest", "hazmat", "pem", "serde"]
 curve25519-dalek = { version = "=5.0.0-pre.0", default-features = false, features = [
     "digest",
 ] }
-ed25519 = { version = "=3.0.0-pre.0", default-features = false }
-signature = { version = "3.0.0-rc.2", optional = true, default-features = false }
-sha2 = { version = "0.11.0-rc.0", default-features = false }
+ed25519 = { version = "3.0.0-rc.0", default-features = false }
+signature = { version = "3.0.0-rc.3", optional = true, default-features = false }
+sha2 = { version = "0.11.0-rc.2", default-features = false }
 subtle = { version = "2.3.0", default-features = false }
 
 # optional features
-keccak = { version = "0.1", default-features = false, optional = true }
+keccak = { version = "0.2.0-pre.0", default-features = false, optional = true }
 rand_core = { version = "0.9", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, optional = true }
 zeroize = { version = "1.5", default-features = false, optional = true }
@@ -50,8 +50,8 @@ curve25519-dalek = { version = "=5.0.0-pre.0", default-features = false, feature
 x25519-dalek = { version = "=3.0.0-pre.0", default-features = false, features = [
     "static_secrets",
 ] }
-blake2 = "0.11.0-rc.0"
-sha3 = "0.11.0-rc.0"
+blake2 = "0.11.0-rc.2"
+sha3 = "0.11.0-rc.2"
 hex = "0.4"
 bincode = "1.0"
 serde_json = "1.0"


### PR DESCRIPTION
Updates the following dependencies (which now use `hybrid-array` v0.4 instead of v0.3):

- `blake2` v0.11.0-rc.2
- `digest` v0.11.0-rc.1
- `ed25519` v3.0.0-rc.0
- `sha2` v0.11.0-rc.2
- `sha3` v0.11.0-rc.2
- `signature` v3.0.0-rc.3