### PR TITLE
Cut `pre.1` prereleases

### DIFF
--- a/curve25519-dalek/CHANGELOG.md
+++ b/curve25519-dalek/CHANGELOG.md
@@ -9,6 +9,7 @@ major series.
 
 * Rename `Scalar::batch_invert` -> `Scalar::invert_batch` for consistency. Also make it no-alloc.
 * Add an allocating batch inversion called `Scalar::invert_batch_alloc`.
+* Add `Scalar::div_by_2`
 
 ## 5.0.0-pre.0
 

--- a/curve25519-dalek/Cargo.toml
+++ b/curve25519-dalek/Cargo.toml
@@ -4,7 +4,7 @@ name = "curve25519-dalek"
 # - update CHANGELOG
 # - update README if required by semver
 # - if README was updated, also update module documentation in src/lib.rs
-version = "5.0.0-pre.0"
+version = "5.0.0-pre.1"
 edition = "2024"
 rust-version = "1.85.0"
 authors = [

--- a/curve25519-dalek/README.md
+++ b/curve25519-dalek/README.md
@@ -52,7 +52,7 @@ curve25519-dalek = ">= 5.0, < 5.2"
 | `zeroize`          |    ✓     | Enables [`Zeroize`][zeroize-trait] for all scalar and curve point types. |
 | `precomputed-tables` |    ✓     | Includes precomputed basepoint multiplication tables. This speeds up `EdwardsPoint::mul_base` and `RistrettoPoint::mul_base` by ~4x, at the cost of ~30KB added to the code size. |
 | `rand_core`        |          | Enables `Scalar::random` and `RistrettoPoint::random`. This is an optional dependency whose version is not subject to SemVer. See [below](#public-api-semver-exemptions) for more details. |
-| `digest`           |          | Enables `RistrettoPoint::{from_hash, hash_from_bytes}` and `Scalar::{from_hash, hash_from_bytes}`. This is an optional dependency whose version is not subject to SemVer. See [below](#public-api-semver-exemptions) for more details. |
+| `digest`           |          | Enables `RistrettoPoint::{from_hash, hash_from_bytes}` and `Scalar::{from_hash, hash_from_bytes}`. Also enables hash-to-curve methods `EdwardsPoint::{encode_to_curve, hash_to_curve}`. This is an optional dependency whose version is not subject to SemVer. See [below](#public-api-semver-exemptions) for more details. |
 | `serde`            |          | Enables `serde` serialization/deserialization for all the point and scalar types. |
 | `legacy_compatibility`|       | Enables `Scalar::from_bits`, which allows the user to build unreduced scalars whose arithmetic is broken. Do not use this unless you know what you're doing. |
 | `group`            |          | Enables external `group` and `ff` crate traits. |

--- a/ed25519-dalek/Cargo.toml
+++ b/ed25519-dalek/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ed25519-dalek"
-version = "3.0.0-pre.0"
+version = "3.0.0-pre.1"
 edition = "2024"
 authors = [
     "isis lovecruft <isis@patternsinthevoid.net>",
@@ -28,7 +28,7 @@ rustdoc-args = [
 features = ["batch", "digest", "hazmat", "pem", "serde"]
 
 [dependencies]
-curve25519-dalek = { version = "=5.0.0-pre.0", default-features = false, features = [
+curve25519-dalek = { version = "=5.0.0-pre.1", default-features = false, features = [
     "digest",
 ] }
 ed25519 = { version = "3.0.0-rc.0", default-features = false }
@@ -37,21 +37,21 @@ sha2 = { version = "0.11.0-rc.2", default-features = false }
 subtle = { version = "2.3.0", default-features = false }
 
 # optional features
-keccak = { version = "0.2.0-pre.0", default-features = false, optional = true }
+keccak = { version = "0.2.0-rc.0", default-features = false, optional = true }
 rand_core = { version = "0.9", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, optional = true }
 zeroize = { version = "1.5", default-features = false, optional = true }
 
 [dev-dependencies]
-curve25519-dalek = { version = "=5.0.0-pre.0", default-features = false, features = [
+curve25519-dalek = { version = "=5.0.0-pre.1", default-features = false, features = [
     "digest",
     "rand_core",
 ] }
-x25519-dalek = { version = "=3.0.0-pre.0", default-features = false, features = [
+x25519-dalek = { version = "=3.0.0-pre.1", default-features = false, features = [
     "static_secrets",
 ] }
 blake2 = "0.11.0-rc.2"
-sha3 = "0.11.0-rc.2"
+sha3 = "0.11.0-rc.3"
 hex = "0.4"
 bincode = "1.0"
 serde_json = "1.0"

--- a/x25519-dalek/Cargo.toml
+++ b/x25519-dalek/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 # - update html_root_url
 # - update CHANGELOG
 # - if any changes were made to README.md, mirror them in src/lib.rs docs
-version = "3.0.0-pre.0"
+version = "3.0.0-pre.1"
 authors = [
     "Isis Lovecruft <isis@patternsinthevoid.net>",
     "DebugSteven <debugsteven@gmail.com>",
@@ -42,7 +42,7 @@ rustdoc-args = [
 features = ["os_rng", "reusable_secrets", "serde", "static_secrets"]
 
 [dependencies]
-curve25519-dalek = { version = "=5.0.0-pre.0", default-features = false }
+curve25519-dalek = { version = "=5.0.0-pre.1", default-features = false }
 rand_core = { version = "0.9", default-features = false }
 serde = { version = "1", default-features = false, optional = true, features = [
     "derive",


### PR DESCRIPTION
These prereleases included updated RustCrypto dependencies which notably migrate from `hybrid-array` v0.3 to v0.4