### PR TITLE
ed25519-dalek: bump `keccak` to v0.2.0-rc.0

### DIFF
--- a/ed25519-dalek/Cargo.toml
+++ b/ed25519-dalek/Cargo.toml
@@ -37,7 +37,7 @@ sha2 = { version = "0.11.0-rc.2", default-features = false }
 subtle = { version = "2.3.0", default-features = false }
 
 # optional features
-keccak = { version = "0.2.0-pre.0", default-features = false, optional = true }
+keccak = { version = "0.2.0-rc.0", default-features = false, optional = true }
 rand_core = { version = "0.9", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, optional = true }
 zeroize = { version = "1.5", default-features = false, optional = true }
@@ -51,7 +51,7 @@ x25519-dalek = { version = "=3.0.0-pre.0", default-features = false, features = 
     "static_secrets",
 ] }
 blake2 = "0.11.0-rc.2"
-sha3 = "0.11.0-rc.2"
+sha3 = "0.11.0-rc.3"
 hex = "0.4"
 bincode = "1.0"
 serde_json = "1.0"


### PR DESCRIPTION
Also bumps `sha3` (in `dev-dependencies`) to v0.11.0-rc.3