### PR TITLE
doc: benchmarks depend on the `digest` features

### DIFF
--- a/curve25519-dalek/README.md
+++ b/curve25519-dalek/README.md
@@ -238,9 +238,9 @@ when the whole program is compiled with the appropriate `target_feature`s.
 Benchmarks are run using [`criterion.rs`][criterion]:
 
 ```sh
-cargo bench --features "rand_core"
+cargo bench --features "rand_core,digest"
 export RUSTFLAGS='-C target_cpu=native'
-cargo +nightly bench --features "rand_core"
+cargo +nightly bench --features "rand_core,digest"
 ```
 
 Performance is a secondary goal behind correctness, safety, and


### PR DESCRIPTION
Benchmarks don't run with just `rand_core`