### PR TITLE
fix: correct typo in batch verification malleability comment

### DIFF
--- a/ed25519-dalek/src/batch.rs
+++ b/ed25519-dalek/src/batch.rs
@@ -113,7 +113,7 @@ fn gen_u128<R: RngCore>(rng: &mut R) -> u128 {
 ///
 /// The latter prevents a malleability attack wherein an adversary, without access
 /// to the signing key(s), can take any valid signature, `(s,R)`, and swap
-/// `s` with `s' = -z1`.  This doesn't constitute a signature forgery, merely
+/// `s` with `s' = -s`.  This doesn't constitute a signature forgery, merely
 /// a vulnerability, as the resulting signature will not pass single
 /// signature verification.  (Thanks to Github users @real_or_random and
 /// @jonasnick for pointing out this malleability issue.)


### PR DESCRIPTION
Fix typo in batch verification malleability attack documentation

- Replace 'z1' with 's' in line 116 comment
- The variable 'z1' is not used anywhere in the codebase
- The correct notation should be 's' = -s' for malleability attack description
- This aligns with standard cryptographic notation and code consistency