### PR TITLE
Use `TryRngCore` for `random_from_rng`

### DIFF
--- a/x25519-dalek/benches/x25519.rs
+++ b/x25519-dalek/benches/x25519.rs
@@ -13,18 +13,18 @@
 
 use criterion::{Criterion, criterion_group, criterion_main};
 
-use rand_core::{OsRng, TryRngCore};
+use rand_core::OsRng;
 
 use x25519_dalek::EphemeralSecret;
 use x25519_dalek::PublicKey;
 
 fn bench_diffie_hellman(c: &mut Criterion) {
-    let bob_secret = EphemeralSecret::random_from_rng(&mut OsRng.unwrap_err());
+    let bob_secret = EphemeralSecret::random_from_rng(&mut OsRng).unwrap();
     let bob_public = PublicKey::from(&bob_secret);
 
     c.bench_function("diffie_hellman", move |b| {
         b.iter_with_setup(
-            || EphemeralSecret::random_from_rng(&mut OsRng.unwrap_err()),
+            || EphemeralSecret::random_from_rng(&mut OsRng).unwrap(),
             |alice_secret| alice_secret.diffie_hellman(&bob_public),
         )
     });

--- a/x25519-dalek/src/x25519.rs
+++ b/x25519-dalek/src/x25519.rs
@@ -16,9 +16,7 @@
 
 use curve25519_dalek::{edwards::EdwardsPoint, montgomery::MontgomeryPoint, traits::IsIdentity};
 
-use rand_core::CryptoRng;
-#[cfg(feature = "os_rng")]
-use rand_core::TryRngCore;
+use rand_core::TryCryptoRng;
 
 #[cfg(feature = "zeroize")]
 use zeroize::{Zeroize, ZeroizeOnDrop};
@@ -87,17 +85,18 @@ impl EphemeralSecret {
     }
 
     /// Generate a new [`EphemeralSecret`] with the supplied RNG.
-    pub fn random_from_rng<R: CryptoRng + ?Sized>(csprng: &mut R) -> Self {
+    pub fn random_from_rng<R: TryCryptoRng + ?Sized>(csprng: &mut R) -> Result<Self, R::Error> {
         // The secret key is random bytes. Clamping is done later.
         let mut bytes = [0u8; 32];
-        csprng.fill_bytes(&mut bytes);
-        EphemeralSecret(bytes)
+        csprng.try_fill_bytes(&mut bytes)?;
+
+        Ok(EphemeralSecret(bytes))
     }
 
     /// Generate a new [`EphemeralSecret`].
     #[cfg(feature = "os_rng")]
     pub fn random() -> Self {
-        Self::random_from_rng(&mut rand_core::OsRng.unwrap_err())
+        Self::random_from_rng(&mut rand_core::OsRng).unwrap()
     }
 }
 
@@ -149,17 +148,18 @@ impl ReusableSecret {
     }
 
     /// Generate a new [`ReusableSecret`] with the supplied RNG.
-    pub fn random_from_rng<R: CryptoRng + ?Sized>(csprng: &mut R) -> Self {
+    pub fn random_from_rng<R: TryCryptoRng + ?Sized>(csprng: &mut R) -> Result<Self, R::Error> {
         // The secret key is random bytes. Clamping is done later.
         let mut bytes = [0u8; 32];
-        csprng.fill_bytes(&mut bytes);
-        ReusableSecret(bytes)
+        csprng.try_fill_bytes(&mut bytes)?;
+
+        Ok(ReusableSecret(bytes))
     }
 
     /// Generate a new [`ReusableSecret`].
     #[cfg(feature = "os_rng")]
     pub fn random() -> Self {
-        Self::random_from_rng(&mut rand_core::OsRng.unwrap_mut())
+        Self::random_from_rng(&mut rand_core::OsRng).unwrap()
     }
 }
 
@@ -210,17 +210,18 @@ impl StaticSecret {
     }
 
     /// Generate a new [`StaticSecret`] with the supplied RNG.
-    pub fn random_from_rng<R: CryptoRng + ?Sized>(csprng: &mut R) -> Self {
+    pub fn random_from_rng<R: TryCryptoRng + ?Sized>(csprng: &mut R) -> Result<Self, R::Error> {
         // The secret key is random bytes. Clamping is done later.
         let mut bytes = [0u8; 32];
-        csprng.fill_bytes(&mut bytes);
-        StaticSecret(bytes)
+        csprng.try_fill_bytes(&mut bytes)?;
+
+        Ok(StaticSecret(bytes))
     }
 
     /// Generate a new [`StaticSecret`].
     #[cfg(feature = "os_rng")]
     pub fn random() -> Self {
-        Self::random_from_rng(&mut rand_core::OsRng.unwrap_mut())
+        Self::random_from_rng(&mut rand_core::OsRng).unwrap()
     }
 
     /// Extract this key's bytes for serialization.
@@ -358,20 +359,19 @@ impl ZeroizeOnDrop for SharedSecret {}
 #[cfg_attr(not(feature = "static_secrets"), doc = "```ignore")]
 /// use rand_core::OsRng;
 /// use rand_core::RngCore;
-/// use rand_core::TryRngCore;
 ///
 /// use x25519_dalek::x25519;
 /// use x25519_dalek::StaticSecret;
 /// use x25519_dalek::PublicKey;
 ///
-/// let mut rng = OsRng.unwrap_err();
+/// let mut rng = OsRng;
 ///
 /// // Generate Alice's key pair.
-/// let alice_secret = StaticSecret::random_from_rng(&mut rng);
+/// let alice_secret = StaticSecret::random_from_rng(&mut rng).unwrap();
 /// let alice_public = PublicKey::from(&alice_secret);
 ///
 /// // Generate Bob's key pair.
-/// let bob_secret = StaticSecret::random_from_rng(&mut rng);
+/// let bob_secret = StaticSecret::random_from_rng(&mut rng).unwrap();
 /// let bob_public = PublicKey::from(&bob_secret);
 ///
 /// // Alice and Bob should now exchange their public keys.

--- a/x25519-dalek/tests/x25519_tests.rs
+++ b/x25519-dalek/tests/x25519_tests.rs
@@ -181,23 +181,23 @@ fn rfc7748_ladder_test2() {
 mod rand_core {
 
     use super::*;
-    use ::rand_core::{OsRng, TryRngCore};
+    use ::rand_core::OsRng;
 
     #[test]
     fn ephemeral_from_rng() {
-        EphemeralSecret::random_from_rng(&mut OsRng.unwrap_err());
+        EphemeralSecret::random_from_rng(&mut OsRng).unwrap();
     }
 
     #[test]
     #[cfg(feature = "reusable_secrets")]
     fn reusable_from_rng() {
-        ReusableSecret::random_from_rng(&mut OsRng.unwrap_err());
+        ReusableSecret::random_from_rng(&mut OsRng).unwrap();
     }
 
     #[test]
     #[cfg(feature = "static_secrets")]
     fn static_from_rng() {
-        StaticSecret::random_from_rng(&mut OsRng.unwrap_err());
+        StaticSecret::random_from_rng(&mut OsRng).unwrap();
     }
 }
 


### PR DESCRIPTION
With the update to `rand 0.9`, the `Rng` and `CryptoRng` traits gained fallible counter-parts: `TryRng` and `TryCryptoRng`. Randomess generation from sources such as the OS-based rng but also hardware rngs involve IO and can thus fail.

It appears to me that the APIs of `EphemeralSecret`, `ReusableSecret` as well as `StaticSecret` could be improved by relying on `TryCryptoRng` instead of of `CryptoRng`. This allows users of the `random_from_rng` function to gracefully handle this error (instead of panicking). The convenience `random` function retains its API; we simply now `unwrap` ourselves instead of using the `unwrap_err` adapter from `rand`.