### PR TITLE
[WIP] ed25519: add `verify_consensus` implementing ZIP-215

### DIFF
--- a/ed25519-dalek/src/verifying/stream.rs
+++ b/ed25519-dalek/src/verifying/stream.rs
@@ -34,7 +34,7 @@ impl StreamVerifier {
     /// Finalize verifier and check against candidate signature.
     #[allow(non_snake_case)]
     pub fn finalize_and_verify(self) -> Result<(), SignatureError> {
-        let expected_R = self.cr.finish();
+        let expected_R = self.cr.finish().compress();
 
         if expected_R == self.sig_R {
             Ok(())


### PR DESCRIPTION
Adds a new verification method implementing the [ZIP-215] verification criteria for Ed25519 signatures.

TODO: test vectors

[ZIP-215]: https://zips.z.cash/zip-0215