### PR TITLE
Bump `rand_core` to v0.10.0-rc-3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,7 @@ opt-level = 2
 curve25519-dalek-derive = { path = "./curve25519-dalek-derive" }
 curve25519-dalek = { path = "./curve25519-dalek" }
 x25519-dalek = { path = "./x25519-dalek" }
+
+# https://github.com/rust-random/rand/pull/1697
+rand = { git = "https://github.com/rust-random/rand", rev = "99ae06fb348e5c5fee0fe41d2201bd4cbb107635" }
+getrandom = { git = "https://github.com/rust-random/getrandom.git", rev = "f67c70110f706f80d7dd6fa52e38d0920754fe2c" }

--- a/curve25519-dalek/Cargo.toml
+++ b/curve25519-dalek/Cargo.toml
@@ -50,7 +50,7 @@ required-features = ["alloc", "rand_core"]
 cfg-if = "1"
 ff = { version = "=0.14.0-pre.0", package = "rustcrypto-ff", default-features = false, optional = true }
 group = { version = "=0.14.0-pre.0", package = "rustcrypto-group", default-features = false, optional = true }
-rand_core = { version = "0.10.0-rc-2", default-features = false, optional = true }
+rand_core = { version = "0.10.0-rc-3", default-features = false, optional = true }
 digest = { version = "0.11.0-rc.4", default-features = false, optional = true, features = [
     "block-api",
 ] }

--- a/curve25519-dalek/benches/dalek_benchmarks.rs
+++ b/curve25519-dalek/benches/dalek_benchmarks.rs
@@ -1,6 +1,6 @@
 #![allow(non_snake_case)]
 
-use rand::{RngCore, TryRngCore, rng, rngs::OsRng};
+use rand::{RngCore, TryRngCore, rng, rngs::SysRng};
 
 use criterion::{
     BatchSize, BenchmarkGroup, BenchmarkId, Criterion, criterion_main, measurement::Measurement,
@@ -31,7 +31,7 @@ mod edwards_benches {
                 BenchmarkId::new("Batch EdwardsPoint compression", batch_size),
                 &batch_size,
                 |b, &size| {
-                    let mut rng = OsRng.unwrap_err();
+                    let mut rng = SysRng.unwrap_err();
                     let points: Vec<EdwardsPoint> =
                         (0..size).map(|_| EdwardsPoint::random(&mut rng)).collect();
                     b.iter(|| EdwardsPoint::compress_batch_alloc(&points));
@@ -301,7 +301,7 @@ mod ristretto_benches {
                 BenchmarkId::new("Batch Ristretto double-and-encode", *batch_size),
                 &batch_size,
                 |b, &&size| {
-                    let mut rng = OsRng;
+                    let mut rng = SysRng;
                     let points: Vec<RistrettoPoint> = (0..size)
                         .map(|_| RistrettoPoint::try_from_rng(&mut rng).unwrap())
                         .collect();
@@ -388,7 +388,7 @@ mod scalar_benches {
                 BenchmarkId::new("Batch scalar inversion", *batch_size),
                 &batch_size,
                 |b, &&size| {
-                    let mut rng = OsRng.unwrap_err();
+                    let mut rng = SysRng.unwrap_err();
                     let scalars: Vec<Scalar> =
                         (0..size).map(|_| Scalar::random(&mut rng)).collect();
                     b.iter(|| {

--- a/curve25519-dalek/src/edwards.rs
+++ b/curve25519-dalek/src/edwards.rs
@@ -2080,7 +2080,7 @@ mod test {
     /// Check that mul_base_clamped and mul_clamped agree
     #[test]
     fn mul_base_clamped() {
-        let mut csprng = rand::rngs::OsRng;
+        let mut csprng = rand::rngs::SysRng;
 
         // Make a random curve point in the curve. Give it torsion to make things interesting.
         #[cfg(feature = "precomputed-tables")]

--- a/curve25519-dalek/src/montgomery.rs
+++ b/curve25519-dalek/src/montgomery.rs
@@ -622,7 +622,7 @@ mod test {
     #[cfg(feature = "rand_core")]
     #[test]
     fn montgomery_ladder_matches_edwards_scalarmult() {
-        let mut csprng = rand::rngs::OsRng.unwrap_err();
+        let mut csprng = rand::rngs::SysRng.unwrap_err();
 
         for _ in 0..100 {
             let p_edwards = rand_prime_order_point(&mut csprng);
@@ -641,7 +641,7 @@ mod test {
     #[cfg(feature = "rand_core")]
     #[test]
     fn montgomery_mul_bits_be() {
-        let mut csprng = rand::rngs::OsRng.unwrap_err();
+        let mut csprng = rand::rngs::SysRng.unwrap_err();
 
         for _ in 0..100 {
             // Make a random prime-order point P
@@ -666,7 +666,7 @@ mod test {
     // integers b₁, b₂ and random (curve or twist) point P.
     #[test]
     fn montgomery_mul_bits_be_twist() {
-        let mut csprng = rand::rngs::OsRng.unwrap_err();
+        let mut csprng = rand::rngs::SysRng.unwrap_err();
 
         for _ in 0..100 {
             // Make a random point P on the curve or its twist
@@ -699,7 +699,7 @@ mod test {
     /// Check that mul_base_clamped and mul_clamped agree
     #[test]
     fn mul_base_clamped() {
-        let mut csprng = rand::rngs::OsRng;
+        let mut csprng = rand::rngs::SysRng;
 
         // Test agreement on a large integer. Even after clamping, this is not reduced mod l.
         let a_bytes = [0xff; 32];

--- a/curve25519-dalek/src/ristretto.rs
+++ b/curve25519-dalek/src/ristretto.rs
@@ -543,12 +543,12 @@ impl RistrettoPoint {
     #[cfg_attr(feature = "rand_core", doc = "```")]
     #[cfg_attr(not(feature = "rand_core"), doc = "```ignore")]
     /// # use curve25519_dalek::ristretto::RistrettoPoint;
-    /// use rand::{rngs::OsRng, TryRngCore};
+    /// use rand::{rngs::SysRng, TryRngCore};
     ///
     /// # // Need fn main() here in comment so the doctest compiles
     /// # // See https://doc.rust-lang.org/book/documentation.html#documentation-as-tests
     /// # fn main() {
-    /// let mut rng = OsRng.unwrap_err();
+    /// let mut rng = SysRng.unwrap_err();
     ///
     /// let points: Vec<RistrettoPoint> =
     ///     (0..32).map(|_| RistrettoPoint::random(&mut rng)).collect();
@@ -1278,7 +1278,7 @@ mod test {
     #[cfg(feature = "group")]
     use proptest::prelude::*;
     #[cfg(feature = "rand_core")]
-    use rand::{TryRngCore, rngs::OsRng};
+    use rand::{TryRngCore, rngs::SysRng};
 
     #[test]
     #[cfg(feature = "serde")]
@@ -1472,7 +1472,7 @@ mod test {
     #[cfg(feature = "rand_core")]
     #[test]
     fn four_torsion_random() {
-        let mut rng = OsRng.unwrap_err();
+        let mut rng = SysRng.unwrap_err();
         let P = RistrettoPoint::mul_base(&Scalar::random(&mut rng));
         let P_coset = P.coset4();
         for point in P_coset {
@@ -1483,7 +1483,7 @@ mod test {
     #[cfg(feature = "rand_core")]
     #[test]
     fn random_roundtrip() {
-        let mut rng = OsRng.unwrap_err();
+        let mut rng = SysRng.unwrap_err();
         for _ in 0..100 {
             let P = RistrettoPoint::mul_base(&Scalar::random(&mut rng));
             let compressed_P = P.compress();
@@ -1496,7 +1496,7 @@ mod test {
     #[cfg(all(feature = "alloc", feature = "rand_core", feature = "group"))]
     fn double_and_compress_1024_random_points() {
         use group::Group;
-        let mut rng = OsRng;
+        let mut rng = SysRng;
 
         let mut points: Vec<RistrettoPoint> = (0..1024)
             .map(|_| RistrettoPoint::try_from_rng(&mut rng).unwrap())

--- a/curve25519-dalek/src/scalar.rs
+++ b/curve25519-dalek/src/scalar.rs
@@ -583,9 +583,9 @@ impl Scalar {
     /// # fn main() {
     /// use curve25519_dalek::scalar::Scalar;
     ///
-    /// use rand::{rngs::OsRng, TryRngCore};
+    /// use rand::{rngs::SysRng, TryRngCore};
     ///
-    /// let mut csprng = OsRng.unwrap_err();
+    /// let mut csprng = SysRng.unwrap_err();
     /// let a: Scalar = Scalar::random(&mut csprng);
     /// # }
     #[cfg(feature = "rand_core")]

--- a/ed25519-dalek/Cargo.toml
+++ b/ed25519-dalek/Cargo.toml
@@ -38,7 +38,7 @@ subtle = { version = "2.3.0", default-features = false }
 
 # optional features
 keccak = { version = "0.2.0-rc.0", default-features = false, optional = true }
-rand_core = { version = "0.10.0-rc-2", default-features = false, optional = true }
+rand_core = { version = "0.10.0-rc-3", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, optional = true }
 zeroize = { version = "1.5", default-features = false, optional = true }
 

--- a/ed25519-dalek/src/batch.rs
+++ b/ed25519-dalek/src/batch.rs
@@ -50,11 +50,11 @@ struct ZeroRng;
 
 impl rand_core::RngCore for ZeroRng {
     fn next_u32(&mut self) -> u32 {
-        rand_core::le::next_u32_via_fill(self)
+        rand_core::utils::next_word_via_fill(self)
     }
 
     fn next_u64(&mut self) -> u64 {
-        rand_core::le::next_u64_via_fill(self)
+        rand_core::utils::next_word_via_fill(self)
     }
 
     /// A no-op function which leaves the destination bytes for randomness unchanged.
@@ -124,11 +124,11 @@ fn gen_u128<R: RngCore>(rng: &mut R) -> u128 {
 /// use ed25519_dalek::{
 ///     verify_batch, SigningKey, VerifyingKey, Signer, Signature,
 /// };
-/// use rand::rngs::OsRng;
+/// use rand::rngs::SysRng;
 /// use rand_core::TryRngCore;
 ///
 /// # fn main() {
-/// let mut csprng = OsRng.unwrap_err();
+/// let mut csprng = SysRng.unwrap_err();
 /// let signing_keys: Vec<_> = (0..64).map(|_| SigningKey::generate(&mut csprng)).collect();
 /// let msg: &[u8] = b"They're good dogs Brant";
 /// let messages: Vec<_> = (0..64).map(|_| msg).collect();

--- a/ed25519-dalek/src/batch/transcript.rs
+++ b/ed25519-dalek/src/batch/transcript.rs
@@ -187,11 +187,11 @@ pub struct TranscriptRng {
 
 impl rand_core::RngCore for TranscriptRng {
     fn next_u32(&mut self) -> u32 {
-        rand_core::le::next_u32_via_fill(self)
+        rand_core::utils::next_word_via_fill(self)
     }
 
     fn next_u64(&mut self) -> u64 {
-        rand_core::le::next_u64_via_fill(self)
+        rand_core::utils::next_word_via_fill(self)
     }
 
     fn fill_bytes(&mut self, dest: &mut [u8]) {

--- a/ed25519-dalek/src/context.rs
+++ b/ed25519-dalek/src/context.rs
@@ -23,11 +23,11 @@ use crate::{InternalError, SignatureError};
 /// # fn main() {
 /// use ed25519_dalek::{Signature, SigningKey, VerifyingKey, Sha512};
 /// # use curve25519_dalek::digest::Digest;
-/// # use rand::rngs::OsRng;
+/// # use rand::rngs::SysRng;
 /// # use rand_core::TryRngCore;
 /// use ed25519_dalek::{DigestSigner, DigestVerifier};
 ///
-/// # let mut csprng = OsRng.unwrap_err();
+/// # let mut csprng = SysRng.unwrap_err();
 /// # let signing_key = SigningKey::generate(&mut csprng);
 /// # let verifying_key = signing_key.verifying_key();
 /// let context_str = b"Local Channel 3";
@@ -91,13 +91,13 @@ mod test {
 
     use crate::{Signature, SigningKey, VerifyingKey};
     use curve25519_dalek::digest::Digest;
-    use rand::{TryRngCore, rngs::OsRng};
+    use rand::{TryRngCore, rngs::SysRng};
     use sha2::Sha512;
     use signature::{DigestSigner, DigestVerifier};
 
     #[test]
     fn context_correctness() {
-        let mut csprng = OsRng.unwrap_err();
+        let mut csprng = SysRng.unwrap_err();
         let signing_key: SigningKey = SigningKey::generate(&mut csprng);
         let verifying_key: VerifyingKey = signing_key.verifying_key();
 

--- a/ed25519-dalek/src/hazmat.rs
+++ b/ed25519-dalek/src/hazmat.rs
@@ -258,7 +258,7 @@ mod test {
 
     use super::*;
 
-    use rand::{CryptoRng, TryRngCore, rngs::OsRng};
+    use rand::{CryptoRng, TryRngCore, rngs::SysRng};
 
     // Pick distinct, non-spec 512-bit hash functions for message and sig-context hashing
     type CtxDigest = blake2::Blake2b512;
@@ -278,7 +278,7 @@ mod test {
     #[test]
     fn sign_verify_nonspec() {
         // Generate the keypair
-        let mut rng = OsRng.unwrap_err();
+        let mut rng = SysRng.unwrap_err();
         let esk = ExpandedSecretKey::random(&mut rng);
         let vk = VerifyingKey::from(&esk);
 
@@ -297,7 +297,7 @@ mod test {
         use curve25519_dalek::digest::Digest;
 
         // Generate the keypair
-        let mut rng = OsRng.unwrap_err();
+        let mut rng = SysRng.unwrap_err();
         let esk = ExpandedSecretKey::random(&mut rng);
         let vk = VerifyingKey::from(&esk);
 
@@ -317,7 +317,7 @@ mod test {
     #[test]
     fn sign_byupdate() {
         // Generate the keypair
-        let mut rng = OsRng.unwrap_err();
+        let mut rng = SysRng.unwrap_err();
         let esk = ExpandedSecretKey::random(&mut rng);
         let vk = VerifyingKey::from(&esk);
 

--- a/ed25519-dalek/src/lib.rs
+++ b/ed25519-dalek/src/lib.rs
@@ -22,12 +22,12 @@
 #![cfg_attr(not(feature = "rand_core"), doc = "```ignore")]
 //! # fn main() {
 //! // $ cargo add ed25519_dalek --features rand_core
-//! use rand::rngs::OsRng;
+//! use rand::rngs::SysRng;
 //! use rand_core::TryRngCore;
 //! use ed25519_dalek::SigningKey;
 //! use ed25519_dalek::Signature;
 //!
-//! let mut csprng = OsRng.unwrap_err();
+//! let mut csprng = SysRng.unwrap_err();
 //! let signing_key: SigningKey = SigningKey::generate(&mut csprng);
 //! # }
 //! ```
@@ -37,10 +37,10 @@
 #![cfg_attr(feature = "rand_core", doc = "```")]
 #![cfg_attr(not(feature = "rand_core"), doc = "```ignore")]
 //! # fn main() {
-//! # use rand::rngs::OsRng;
+//! # use rand::rngs::SysRng;
 //! # use rand_core::TryRngCore;
 //! # use ed25519_dalek::SigningKey;
-//! # let mut csprng = OsRng.unwrap_err();
+//! # let mut csprng = SysRng.unwrap_err();
 //! # let signing_key: SigningKey = SigningKey::generate(&mut csprng);
 //! use ed25519_dalek::{Signature, Signer};
 //! let message: &[u8] = b"This is a test of the tsunami alert system.";
@@ -54,10 +54,10 @@
 #![cfg_attr(feature = "rand_core", doc = "```")]
 #![cfg_attr(not(feature = "rand_core"), doc = "```ignore")]
 //! # fn main() {
-//! # use rand::rngs::OsRng;
+//! # use rand::rngs::SysRng;
 //! # use rand_core::TryRngCore;
 //! # use ed25519_dalek::{SigningKey, Signature, Signer};
-//! # let mut csprng = OsRng.unwrap_err();
+//! # let mut csprng = SysRng.unwrap_err();
 //! # let signing_key: SigningKey = SigningKey::generate(&mut csprng);
 //! # let message: &[u8] = b"This is a test of the tsunami alert system.";
 //! # let signature: Signature = signing_key.sign(message);
@@ -72,13 +72,13 @@
 #![cfg_attr(feature = "rand_core", doc = "```")]
 #![cfg_attr(not(feature = "rand_core"), doc = "```ignore")]
 //! # fn main() {
-//! # use rand::rngs::OsRng;
+//! # use rand::rngs::SysRng;
 //! # use rand_core::TryRngCore;
 //! # use ed25519_dalek::SigningKey;
 //! # use ed25519_dalek::Signature;
 //! # use ed25519_dalek::Signer;
 //! use ed25519_dalek::{VerifyingKey, Verifier};
-//! # let mut csprng = OsRng.unwrap_err();
+//! # let mut csprng = SysRng.unwrap_err();
 //! # let signing_key: SigningKey = SigningKey::generate(&mut csprng);
 //! # let message: &[u8] = b"This is a test of the tsunami alert system.";
 //! # let signature: Signature = signing_key.sign(message);
@@ -99,11 +99,11 @@
 #![cfg_attr(feature = "rand_core", doc = "```")]
 #![cfg_attr(not(feature = "rand_core"), doc = "```ignore")]
 //! # fn main() {
-//! # use rand::rngs::OsRng;
+//! # use rand::rngs::SysRng;
 //! # use rand_core::TryRngCore;
 //! # use ed25519_dalek::{SigningKey, Signature, Signer, VerifyingKey};
 //! use ed25519_dalek::{PUBLIC_KEY_LENGTH, SECRET_KEY_LENGTH, KEYPAIR_LENGTH, SIGNATURE_LENGTH};
-//! # let mut csprng = OsRng.unwrap_err();
+//! # let mut csprng = SysRng.unwrap_err();
 //! # let signing_key: SigningKey = SigningKey::generate(&mut csprng);
 //! # let message: &[u8] = b"This is a test of the tsunami alert system.";
 //! # let signature: Signature = signing_key.sign(message);
@@ -120,12 +120,12 @@
 #![cfg_attr(feature = "rand_core", doc = "```")]
 #![cfg_attr(not(feature = "rand_core"), doc = "```ignore")]
 //! # use core::convert::{TryFrom, TryInto};
-//! # use rand::rngs::OsRng;
+//! # use rand::rngs::SysRng;
 //! # use rand_core::TryRngCore;
 //! # use ed25519_dalek::{SigningKey, Signature, Signer, VerifyingKey, SecretKey, SignatureError};
 //! # use ed25519_dalek::{PUBLIC_KEY_LENGTH, SECRET_KEY_LENGTH, KEYPAIR_LENGTH, SIGNATURE_LENGTH};
 //! # fn do_test() -> Result<(SigningKey, VerifyingKey, Signature), SignatureError> {
-//! # let mut csprng = OsRng.unwrap_err();
+//! # let mut csprng = SysRng.unwrap_err();
 //! # let signing_key_orig: SigningKey = SigningKey::generate(&mut csprng);
 //! # let message: &[u8] = b"This is a test of the tsunami alert system.";
 //! # let signature_orig: Signature = signing_key_orig.sign(message);
@@ -198,11 +198,11 @@
 #![cfg_attr(all(feature = "rand_core", feature = "serde"), doc = "```")]
 #![cfg_attr(not(all(feature = "rand_core", feature = "serde")), doc = "```ignore")]
 //! # fn main() {
-//! # use rand::rngs::OsRng;
+//! # use rand::rngs::SysRng;
 //! # use rand_core::TryRngCore;
 //! # use ed25519_dalek::{SigningKey, Signature, Signer, Verifier, VerifyingKey};
 //! use bincode::serialize;
-//! # let mut csprng = OsRng.unwrap_err();
+//! # let mut csprng = SysRng.unwrap_err();
 //! # let signing_key: SigningKey = SigningKey::generate(&mut csprng);
 //! # let message: &[u8] = b"This is a test of the tsunami alert system.";
 //! # let signature: Signature = signing_key.sign(message);
@@ -220,13 +220,13 @@
 #![cfg_attr(all(feature = "rand_core", feature = "serde"), doc = "```")]
 #![cfg_attr(not(all(feature = "rand_core", feature = "serde")), doc = "```ignore")]
 //! # fn main() {
-//! # use rand::rngs::OsRng;
+//! # use rand::rngs::SysRng;
 //! # use rand_core::TryRngCore;
 //! # use ed25519_dalek::{SigningKey, Signature, Signer, Verifier, VerifyingKey};
 //! # use bincode::serialize;
 //! use bincode::deserialize;
 //!
-//! # let mut csprng = OsRng.unwrap_err();
+//! # let mut csprng = SysRng.unwrap_err();
 //! # let signing_key: SigningKey = SigningKey::generate(&mut csprng);
 //! let message: &[u8] = b"This is a test of the tsunami alert system.";
 //! # let signature: Signature = signing_key.sign(message);

--- a/ed25519-dalek/src/signing.rs
+++ b/ed25519-dalek/src/signing.rs
@@ -189,18 +189,18 @@ impl SigningKey {
     #[cfg_attr(feature = "rand_core", doc = "```")]
     #[cfg_attr(not(feature = "rand_core"), doc = "```ignore")]
     /// # fn main() {
-    /// use rand::rngs::OsRng;
+    /// use rand::rngs::SysRng;
     /// use rand_core::TryRngCore;
     /// use ed25519_dalek::{Signature, SigningKey};
     ///
-    /// let mut csprng = OsRng.unwrap_err();
+    /// let mut csprng = SysRng.unwrap_err();
     /// let signing_key: SigningKey = SigningKey::generate(&mut csprng);
     /// # }
     /// ```
     ///
     /// # Input
     ///
-    /// A CSPRNG with a `fill_bytes()` method, e.g. `rand_os::OsRng`.
+    /// A CSPRNG with a `fill_bytes()` method, e.g. `rand_os::SysRng`.
     #[cfg(feature = "rand_core")]
     pub fn generate<R: CryptoRng + ?Sized>(csprng: &mut R) -> SigningKey {
         let mut secret = SecretKey::default();
@@ -242,11 +242,11 @@ impl SigningKey {
     /// use ed25519_dalek::SigningKey;
     /// use ed25519_dalek::Signature;
     /// use sha2::Sha512;
-    /// use rand::rngs::OsRng;
+    /// use rand::rngs::SysRng;
     /// use rand_core::TryRngCore;
     ///
     /// # fn main() {
-    /// let mut csprng = OsRng.unwrap_err();
+    /// let mut csprng = SysRng.unwrap_err();
     /// let signing_key: SigningKey = SigningKey::generate(&mut csprng);
     /// let message: &[u8] = b"All I want is to pet all of the dogs.";
     ///
@@ -288,11 +288,11 @@ impl SigningKey {
     /// # use ed25519_dalek::Signature;
     /// # use ed25519_dalek::SignatureError;
     /// # use sha2::Sha512;
-    /// # use rand::rngs::OsRng;
+    /// # use rand::rngs::SysRng;
     /// # use rand_core::TryRngCore;
     /// #
     /// # fn do_test() -> Result<Signature, SignatureError> {
-    /// # let mut csprng = OsRng.unwrap_err();
+    /// # let mut csprng = SysRng.unwrap_err();
     /// # let signing_key: SigningKey = SigningKey::generate(&mut csprng);
     /// # let message: &[u8] = b"All I want is to pet all of the dogs.";
     /// # let mut prehashed: Sha512 = Sha512::new();
@@ -368,11 +368,11 @@ impl SigningKey {
     /// use ed25519_dalek::Signature;
     /// use ed25519_dalek::SignatureError;
     /// use sha2::Sha512;
-    /// use rand::rngs::OsRng;
+    /// use rand::rngs::SysRng;
     /// use rand_core::TryRngCore;
     ///
     /// # fn do_test() -> Result<(), SignatureError> {
-    /// let mut csprng = OsRng.unwrap_err();
+    /// let mut csprng = SysRng.unwrap_err();
     /// let signing_key: SigningKey = SigningKey::generate(&mut csprng);
     /// let message: &[u8] = b"All I want is to pet all of the dogs.";
     ///

--- a/ed25519-dalek/tests/ed25519.rs
+++ b/ed25519-dalek/tests/ed25519.rs
@@ -183,7 +183,7 @@ mod vectors {
 
     // Pick a random Scalar
     fn non_null_scalar() -> Scalar {
-        let mut rng = rand::rngs::OsRng.unwrap_err();
+        let mut rng = rand::rngs::SysRng.unwrap_err();
         let mut s_candidate = Scalar::random(&mut rng);
         while s_candidate == Scalar::ZERO {
             s_candidate = Scalar::random(&mut rng);
@@ -295,7 +295,7 @@ mod vectors {
 #[cfg(feature = "rand_core")]
 mod integrations {
     use super::*;
-    use rand::{TryRngCore, rngs::OsRng};
+    use rand::{TryRngCore, rngs::SysRng};
     use std::collections::HashMap;
 
     #[test]
@@ -305,7 +305,7 @@ mod integrations {
         let good: &[u8] = "test message".as_bytes();
         let bad: &[u8] = "wrong message".as_bytes();
 
-        let mut csprng = OsRng.unwrap_err();
+        let mut csprng = SysRng.unwrap_err();
 
         let signing_key: SigningKey = SigningKey::generate(&mut csprng);
         let verifying_key = signing_key.verifying_key();
@@ -346,7 +346,7 @@ mod integrations {
     fn sign_verify_digest_equivalence() {
         // TestSignVerify
 
-        let mut csprng = OsRng.unwrap_err();
+        let mut csprng = SysRng.unwrap_err();
 
         let good: &[u8] = "test message".as_bytes();
         let bad: &[u8] = "wrong message".as_bytes();
@@ -391,7 +391,7 @@ mod integrations {
         let good: &[u8] = b"test message";
         let bad: &[u8] = b"wrong message";
 
-        let mut csprng = OsRng.unwrap_err();
+        let mut csprng = SysRng.unwrap_err();
 
         // ugh… there's no `impl Copy for Sha512`… i hope we can all agree these are the same hashes
         let mut prehashed_good1: Sha512 = Sha512::default();
@@ -466,7 +466,7 @@ mod integrations {
             b"Fuck dumbin' it down, spit ice, skip jewellery: Molotov cocktails on me like accessories.",
             b"Hey, I never cared about your bucks, so if I run up with a mask on, probably got a gas can too.",
             b"And I'm not here to fill 'er up. Nope, we came to riot, here to incite, we don't want any of your stuff.", ];
-        let mut csprng = OsRng.unwrap_err();
+        let mut csprng = SysRng.unwrap_err();
         let mut signing_keys: Vec<SigningKey> = Vec::new();
         let mut signatures: Vec<Signature> = Vec::new();
 
@@ -485,7 +485,7 @@ mod integrations {
 
     #[test]
     fn public_key_hash_trait_check() {
-        let mut csprng = OsRng.unwrap_err();
+        let mut csprng = SysRng.unwrap_err();
         let secret: SigningKey = SigningKey::generate(&mut csprng);
         let public_from_secret: VerifyingKey = (&secret).into();
 
@@ -512,7 +512,7 @@ mod integrations {
 
     #[test]
     fn montgomery_and_edwards_conversion() {
-        let mut rng = rand::rngs::OsRng.unwrap_err();
+        let mut rng = rand::rngs::SysRng.unwrap_err();
         let signing_key = SigningKey::generate(&mut rng);
         let verifying_key = signing_key.verifying_key();
 

--- a/x25519-dalek/Cargo.toml
+++ b/x25519-dalek/Cargo.toml
@@ -43,7 +43,7 @@ all-features = true
 
 [dependencies]
 curve25519-dalek = { version = "=5.0.0-pre.3", default-features = false }
-rand_core = { version = "0.10.0-rc-2", default-features = false }
+rand_core = { version = "0.10.0-rc-3", default-features = false }
 
 # optional dependencies
 getrandom = { version = "0.3", optional = true }

--- a/x25519-dalek/README.md
+++ b/x25519-dalek/README.md
@@ -51,9 +51,9 @@ loudly meows `bob_public` back to Alice.  Alice now computes her
 shared secret with Bob by doing:
 
 ```rust
-# use rand::{rngs::OsRng, TryRngCore};
+# use rand::{rngs::SysRng, TryRngCore};
 # use x25519_dalek::{EphemeralSecret, PublicKey};
-# let mut rng = OsRng.unwrap_err();
+# let mut rng = SysRng.unwrap_err();
 # let alice_secret = EphemeralSecret::random_from_rng(&mut rng);
 # let alice_public = PublicKey::from(&alice_secret);
 # let bob_secret = EphemeralSecret::random_from_rng(&mut rng);
@@ -64,9 +64,9 @@ let alice_shared_secret = alice_secret.diffie_hellman(&bob_public);
 Similarly, Bob computes a shared secret by doing:
 
 ```rust
-# use rand::{rngs::OsRng, TryRngCore};
+# use rand::{rngs::SysRng, TryRngCore};
 # use x25519_dalek::{EphemeralSecret, PublicKey};
-# let mut rng = OsRng.unwrap_err();
+# let mut rng = SysRng.unwrap_err();
 # let alice_secret = EphemeralSecret::random_from_rng(&mut rng);
 # let alice_public = PublicKey::from(&alice_secret);
 # let bob_secret = EphemeralSecret::random_from_rng(&mut rng);
@@ -77,9 +77,9 @@ let bob_shared_secret = bob_secret.diffie_hellman(&alice_public);
 These secrets are the same:
 
 ```rust
-# use rand::{rngs::OsRng, TryRngCore};
+# use rand::{rngs::SysRng, TryRngCore};
 # use x25519_dalek::{EphemeralSecret, PublicKey};
-# let mut rng = OsRng.unwrap_err();
+# let mut rng = SysRng.unwrap_err();
 # let alice_secret = EphemeralSecret::random_from_rng(&mut rng);
 # let alice_public = PublicKey::from(&alice_secret);
 # let bob_secret = EphemeralSecret::random_from_rng(&mut rng);

--- a/x25519-dalek/benches/x25519.rs
+++ b/x25519-dalek/benches/x25519.rs
@@ -13,25 +13,25 @@
 
 use criterion::{Criterion, criterion_group, criterion_main};
 
-use rand::{TryRngCore, rngs::OsRng};
+use rand::{TryRngCore, rngs::SysRng};
 
 use x25519_dalek::EphemeralSecret;
 use x25519_dalek::PublicKey;
 
 fn bench_diffie_hellman(c: &mut Criterion) {
-    let bob_secret = EphemeralSecret::random_from_rng(&mut OsRng.unwrap_err());
+    let bob_secret = EphemeralSecret::random_from_rng(&mut SysRng.unwrap_err());
     let bob_public = PublicKey::from(&bob_secret);
 
     c.bench_function("diffie_hellman", move |b| {
         b.iter_with_setup(
-            || EphemeralSecret::random_from_rng(&mut OsRng.unwrap_err()),
+            || EphemeralSecret::random_from_rng(&mut SysRng.unwrap_err()),
             |alice_secret| alice_secret.diffie_hellman(&bob_public),
         )
     });
 }
 
 fn bench_pubkey_constructor(c: &mut Criterion) {
-    let bob_secret = EphemeralSecret::random_from_rng(&mut OsRng.unwrap_err());
+    let bob_secret = EphemeralSecret::random_from_rng(&mut SysRng.unwrap_err());
 
     c.bench_function("PublicKey::from", move |b| {
         b.iter(|| PublicKey::from(&bob_secret))

--- a/x25519-dalek/src/x25519.rs
+++ b/x25519-dalek/src/x25519.rs
@@ -363,13 +363,13 @@ impl ZeroizeOnDrop for SharedSecret {}
 /// # Example
 #[cfg_attr(feature = "static_secrets", doc = "```")]
 #[cfg_attr(not(feature = "static_secrets"), doc = "```ignore")]
-/// use rand::{rngs::OsRng, RngCore, TryRngCore};
+/// use rand::{rngs::SysRng, RngCore, TryRngCore};
 ///
 /// use x25519_dalek::x25519;
 /// use x25519_dalek::StaticSecret;
 /// use x25519_dalek::PublicKey;
 ///
-/// let mut rng = OsRng.unwrap_err();
+/// let mut rng = SysRng.unwrap_err();
 ///
 /// // Generate Alice's key pair.
 /// let alice_secret = StaticSecret::random_from_rng(&mut rng);

--- a/x25519-dalek/tests/x25519_tests.rs
+++ b/x25519-dalek/tests/x25519_tests.rs
@@ -242,23 +242,23 @@ fn rfc7748_ladder_test2() {
 mod os_rng {
 
     use super::*;
-    use rand::{TryRngCore, rngs::OsRng};
+    use rand::{TryRngCore, rngs::SysRng};
 
     #[test]
     fn ephemeral_from_rng() {
-        EphemeralSecret::random_from_rng(&mut OsRng.unwrap_err());
+        EphemeralSecret::random_from_rng(&mut SysRng.unwrap_err());
     }
 
     #[test]
     #[cfg(feature = "reusable_secrets")]
     fn reusable_from_rng() {
-        ReusableSecret::random_from_rng(&mut OsRng.unwrap_err());
+        ReusableSecret::random_from_rng(&mut SysRng.unwrap_err());
     }
 
     #[test]
     #[cfg(feature = "static_secrets")]
     fn static_from_rng() {
-        StaticSecret::random_from_rng(&mut OsRng.unwrap_err());
+        StaticSecret::random_from_rng(&mut SysRng.unwrap_err());
     }
 }
 


### PR DESCRIPTION
Most of the changes in this PR are actually from the associated `rand` crate updates which are happening in rust-random/rand#1697, notably `OsRng` has been renamed to `SysRng` (and is now provided by the `getrandom` crate).

We do use some `rand_core` APIs in a few places though, like the STROBE implementation, where this migrates from `rand_core::le` to `rand_core::utils`.