### PR TITLE
Bump `rand_core` to v0.10.0-rc-6

### DIFF
--- a/curve25519-dalek/Cargo.toml
+++ b/curve25519-dalek/Cargo.toml
@@ -30,12 +30,12 @@ rustdoc-args = [
 all-features = true
 
 [dev-dependencies]
-sha2 = { version = "0.11.0-rc.3", default-features = false }
 bincode = "1"
 criterion = { version = "0.5", features = ["html_reports"] }
+getrandom = { version = "0.4.0-rc.1", features = ["sys_rng"] }
 hex = "0.4.2"
 proptest = "1"
-rand = "0.10.0-rc.7"
+sha2 = { version = "0.11.0-rc.4", default-features = false }
 
 [build-dependencies]
 rustc_version = "0.4.0"
@@ -47,10 +47,10 @@ required-features = ["alloc", "rand_core"]
 
 [dependencies]
 cfg-if = "1"
-ff = { version = "=0.14.0-pre.0", package = "rustcrypto-ff", default-features = false, optional = true }
-group = { version = "=0.14.0-pre.0", package = "rustcrypto-group", default-features = false, optional = true }
-rand_core = { version = "0.10.0-rc-5", default-features = false, optional = true }
-digest = { version = "0.11.0-rc.4", default-features = false, optional = true, features = [
+ff = { version = "=0.14.0-pre.1", package = "rustcrypto-ff", default-features = false, optional = true }
+group = { version = "=0.14.0-pre.1", package = "rustcrypto-group", default-features = false, optional = true }
+rand_core = { version = "0.10.0-rc-6", default-features = false, optional = true }
+digest = { version = "0.11.0-rc.8", default-features = false, optional = true, features = [
     "block-api",
 ] }
 subtle = { version = "2.6.0", default-features = false, features = [

--- a/curve25519-dalek/benches/dalek_benchmarks.rs
+++ b/curve25519-dalek/benches/dalek_benchmarks.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case)]
 
-use rand::{RngCore, TryRngCore, rng, rngs::SysRng};
+use getrandom::SysRng;
+use rand_core::{Rng, UnwrapErr};
 
 use criterion::{
     BatchSize, BenchmarkGroup, BenchmarkId, Criterion, criterion_main, measurement::Measurement,
@@ -31,7 +32,7 @@ mod edwards_benches {
                 BenchmarkId::new("Batch EdwardsPoint compression", batch_size),
                 &batch_size,
                 |b, &size| {
-                    let mut rng = SysRng.unwrap_err();
+                    let mut rng = UnwrapErr(SysRng);
                     let points: Vec<EdwardsPoint> =
                         (0..size).map(|_| EdwardsPoint::random(&mut rng)).collect();
                     b.iter(|| EdwardsPoint::compress_batch_alloc(&points));
@@ -64,7 +65,7 @@ mod edwards_benches {
 
     fn vartime_double_base_scalar_mul<M: Measurement>(c: &mut BenchmarkGroup<M>) {
         c.bench_function("Variable-time aA+bB, A variable, B fixed", |bench| {
-            let mut rng = rng();
+            let mut rng = UnwrapErr(SysRng);
             let A = EdwardsPoint::mul_base(&Scalar::random(&mut rng));
             bench.iter_batched(
                 || (Scalar::random(&mut rng), Scalar::random(&mut rng)),
@@ -76,7 +77,7 @@ mod edwards_benches {
 
     #[cfg(feature = "digest")]
     fn encode_to_curve<M: Measurement>(c: &mut BenchmarkGroup<M>) {
-        let mut rng = rng();
+        let mut rng = UnwrapErr(SysRng);
 
         let mut msg = [0u8; 32];
         let mut domain_sep = [0u8; 32];
@@ -91,7 +92,7 @@ mod edwards_benches {
 
     #[cfg(feature = "digest")]
     fn hash_to_curve<M: Measurement>(c: &mut BenchmarkGroup<M>) {
-        let mut rng = rng();
+        let mut rng = UnwrapErr(SysRng);
 
         let mut msg = [0u8; 32];
         let mut domain_sep = [0u8; 32];
@@ -130,12 +131,12 @@ mod multiscalar_benches {
     use curve25519_dalek::traits::VartimePrecomputedMultiscalarMul;
 
     fn construct_scalars(n: usize) -> Vec<Scalar> {
-        let mut rng = rng();
+        let mut rng = UnwrapErr(SysRng);
         (0..n).map(|_| Scalar::random(&mut rng)).collect()
     }
 
     fn construct_points(n: usize) -> Vec<EdwardsPoint> {
-        let mut rng = rng();
+        let mut rng = UnwrapErr(SysRng);
         (0..n)
             .map(|_| EdwardsPoint::mul_base(&Scalar::random(&mut rng)))
             .collect()
@@ -353,7 +354,7 @@ mod scalar_benches {
     use super::*;
 
     fn scalar_arith<M: Measurement>(c: &mut BenchmarkGroup<M>) {
-        let mut rng = rng();
+        let mut rng = UnwrapErr(SysRng);
 
         c.bench_function("Scalar inversion", |b| {
             let s = Scalar::from(897987897u64).invert();
@@ -388,7 +389,7 @@ mod scalar_benches {
                 BenchmarkId::new("Batch scalar inversion", *batch_size),
                 &batch_size,
                 |b, &&size| {
-                    let mut rng = SysRng.unwrap_err();
+                    let mut rng = UnwrapErr(SysRng);
                     let scalars: Vec<Scalar> =
                         (0..size).map(|_| Scalar::random(&mut rng)).collect();
                     b.iter(|| {

--- a/curve25519-dalek/src/lizard/lizard_ristretto.rs
+++ b/curve25519-dalek/src/lizard/lizard_ristretto.rs
@@ -220,7 +220,8 @@ impl RistrettoPoint {
 mod test {
     use super::*;
     use crate::{edwards::EdwardsPoint, ristretto::CompressedRistretto};
-    use rand_core::RngCore;
+    use getrandom::{SysRng, rand_core::UnwrapErr};
+    use rand_core::Rng;
     use sha2::Sha256;
 
     /// Return the coset self + E\[4\]
@@ -281,7 +282,7 @@ mod test {
     // Tests that lizard_decode of a random point is None
     #[test]
     fn lizard_invalid() {
-        let mut rng = rand::rng();
+        let mut rng = UnwrapErr(SysRng);
         for _ in 0..100 {
             let pt = RistrettoPoint::random(&mut rng);
             assert!(
@@ -297,7 +298,7 @@ mod test {
     // is the identity
     #[test]
     fn elligator_inv() {
-        let mut rng = rand::rng();
+        let mut rng = UnwrapErr(SysRng);
 
         for i in 0..100 {
             let mut fe_bytes = [0u8; 32];
@@ -342,7 +343,7 @@ mod test {
     // Tests that map_to_curve ○ map_to_curve_inverse is the identity
     #[test]
     fn map_to_curve_inverse() {
-        let mut rng = rand::rng();
+        let mut rng = UnwrapErr(SysRng);
 
         for _ in 0..100 {
             let mut input = [0u8; 32];
@@ -365,7 +366,7 @@ mod test {
     // return value in the first 8 elements
     #[test]
     fn map_pos_felem_to_curve_inverse() {
-        let mut rng = rand::rng();
+        let mut rng = UnwrapErr(SysRng);
 
         for _ in 0..100 {
             let mut input = [0u8; 32];

--- a/curve25519-dalek/src/montgomery.rs
+++ b/curve25519-dalek/src/montgomery.rs
@@ -514,10 +514,13 @@ impl Mul<&MontgomeryPoint> for &Scalar {
 mod test {
     use super::*;
     use crate::constants;
+    use getrandom::{
+        SysRng,
+        rand_core::{Rng, TryRng, UnwrapErr},
+    };
 
     #[cfg(feature = "rand_core")]
-    use rand::CryptoRng;
-    use rand::{RngCore, TryRngCore};
+    use rand_core::CryptoRng;
 
     #[test]
     fn identity_in_different_coordinates() {
@@ -622,7 +625,7 @@ mod test {
     #[cfg(feature = "rand_core")]
     #[test]
     fn montgomery_ladder_matches_edwards_scalarmult() {
-        let mut csprng = rand::rngs::SysRng.unwrap_err();
+        let mut csprng = UnwrapErr(SysRng);
 
         for _ in 0..100 {
             let p_edwards = rand_prime_order_point(&mut csprng);
@@ -641,7 +644,7 @@ mod test {
     #[cfg(feature = "rand_core")]
     #[test]
     fn montgomery_mul_bits_be() {
-        let mut csprng = rand::rngs::SysRng.unwrap_err();
+        let mut csprng = UnwrapErr(SysRng);
 
         for _ in 0..100 {
             // Make a random prime-order point P
@@ -666,7 +669,7 @@ mod test {
     // integers b₁, b₂ and random (curve or twist) point P.
     #[test]
     fn montgomery_mul_bits_be_twist() {
-        let mut csprng = rand::rngs::SysRng.unwrap_err();
+        let mut csprng = UnwrapErr(SysRng);
 
         for _ in 0..100 {
             // Make a random point P on the curve or its twist
@@ -699,7 +702,7 @@ mod test {
     /// Check that mul_base_clamped and mul_clamped agree
     #[test]
     fn mul_base_clamped() {
-        let mut csprng = rand::rngs::SysRng;
+        let mut csprng = UnwrapErr(SysRng);
 
         // Test agreement on a large integer. Even after clamping, this is not reduced mod l.
         let a_bytes = [0xff; 32];

--- a/curve25519-dalek/src/ristretto.rs
+++ b/curve25519-dalek/src/ristretto.rs
@@ -180,7 +180,7 @@ use crate::field::FieldElement;
 #[cfg(feature = "group")]
 use {
     group::{GroupEncoding, cofactor::CofactorGroup, prime::PrimeGroup},
-    rand_core::TryRngCore,
+    rand_core::TryRng,
     subtle::CtOption,
 };
 
@@ -543,12 +543,12 @@ impl RistrettoPoint {
     #[cfg_attr(feature = "rand_core", doc = "```")]
     #[cfg_attr(not(feature = "rand_core"), doc = "```ignore")]
     /// # use curve25519_dalek::ristretto::RistrettoPoint;
-    /// use rand::{rngs::SysRng, TryRngCore};
+    /// use getrandom::{SysRng, rand_core::UnwrapErr};
     ///
     /// # // Need fn main() here in comment so the doctest compiles
     /// # // See https://doc.rust-lang.org/book/documentation.html#documentation-as-tests
     /// # fn main() {
-    /// let mut rng = SysRng.unwrap_err();
+    /// let mut rng = UnwrapErr(SysRng);
     ///
     /// let points: Vec<RistrettoPoint> =
     ///     (0..32).map(|_| RistrettoPoint::random(&mut rng)).collect();
@@ -1179,7 +1179,7 @@ impl Debug for RistrettoPoint {
 impl group::Group for RistrettoPoint {
     type Scalar = Scalar;
 
-    fn try_from_rng<R: TryRngCore + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+    fn try_from_rng<R: TryRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
         // NOTE: this is duplicated due to different `rng` bounds
         let mut uniform_bytes = [0u8; 64];
         rng.try_fill_bytes(&mut uniform_bytes)?;
@@ -1275,10 +1275,10 @@ impl Zeroize for RistrettoPoint {
 mod test {
     use super::*;
     use crate::edwards::CompressedEdwardsY;
+    #[cfg(feature = "rand_core")]
+    use getrandom::{SysRng, rand_core::UnwrapErr};
     #[cfg(feature = "group")]
     use proptest::prelude::*;
-    #[cfg(feature = "rand_core")]
-    use rand::{TryRngCore, rngs::SysRng};
 
     #[test]
     #[cfg(feature = "serde")]
@@ -1472,7 +1472,7 @@ mod test {
     #[cfg(feature = "rand_core")]
     #[test]
     fn four_torsion_random() {
-        let mut rng = SysRng.unwrap_err();
+        let mut rng = UnwrapErr(SysRng);
         let P = RistrettoPoint::mul_base(&Scalar::random(&mut rng));
         let P_coset = P.coset4();
         for point in P_coset {
@@ -1483,7 +1483,7 @@ mod test {
     #[cfg(feature = "rand_core")]
     #[test]
     fn random_roundtrip() {
-        let mut rng = SysRng.unwrap_err();
+        let mut rng = UnwrapErr(SysRng);
         for _ in 0..100 {
             let P = RistrettoPoint::mul_base(&Scalar::random(&mut rng));
             let compressed_P = P.compress();
@@ -1546,7 +1546,7 @@ mod test {
     #[test]
     #[cfg(all(feature = "alloc", feature = "rand_core"))]
     fn vartime_precomputed_vs_nonprecomputed_multiscalar() {
-        let mut rng = rand::rng();
+        let mut rng = UnwrapErr(SysRng);
 
         let static_scalars = (0..128)
             .map(|_| Scalar::random(&mut rng))
@@ -1597,7 +1597,7 @@ mod test {
     #[test]
     #[cfg(all(feature = "alloc", feature = "rand_core"))]
     fn partial_precomputed_mixed_multiscalar_empty() {
-        let mut rng = rand::rng();
+        let mut rng = UnwrapErr(SysRng);
 
         let n_static = 16;
         let n_dynamic = 8;
@@ -1640,7 +1640,7 @@ mod test {
     #[test]
     #[cfg(all(feature = "alloc", feature = "rand_core"))]
     fn partial_precomputed_mixed_multiscalar() {
-        let mut rng = rand::rng();
+        let mut rng = UnwrapErr(SysRng);
 
         let n_static = 16;
         let n_dynamic = 8;
@@ -1685,7 +1685,7 @@ mod test {
     #[test]
     #[cfg(all(feature = "alloc", feature = "rand_core"))]
     fn partial_precomputed_multiscalar() {
-        let mut rng = rand::rng();
+        let mut rng = UnwrapErr(SysRng);
 
         let n_static = 16;
 
@@ -1714,7 +1714,7 @@ mod test {
     #[test]
     #[cfg(all(feature = "alloc", feature = "rand_core"))]
     fn partial_precomputed_multiscalar_empty() {
-        let mut rng = rand::rng();
+        let mut rng = UnwrapErr(SysRng);
 
         let n_static = 16;
 

--- a/ed25519-dalek/Cargo.toml
+++ b/ed25519-dalek/Cargo.toml
@@ -32,13 +32,13 @@ curve25519-dalek = { version = "=5.0.0-pre.4", default-features = false, feature
     "digest",
 ] }
 ed25519 = { version = "3.0.0-rc.2", default-features = false }
-signature = { version = "3.0.0-rc.5", optional = true, default-features = false }
-sha2 = { version = "0.11.0-rc.3", default-features = false }
+signature = { version = "3.0.0-rc.9", optional = true, default-features = false }
+sha2 = { version = "0.11.0-rc.4", default-features = false }
 subtle = { version = "2.3.0", default-features = false }
 
 # optional features
-keccak = { version = "0.2.0-rc.0", default-features = false, optional = true }
-rand_core = { version = "0.10.0-rc-5", default-features = false, optional = true }
+keccak = { version = "0.2.0-rc.1", default-features = false, optional = true }
+rand_core = { version = "0.10.0-rc-6", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, optional = true }
 zeroize = { version = "1.5", default-features = false, optional = true }
 
@@ -50,14 +50,15 @@ curve25519-dalek = { version = "=5.0.0-pre.4", default-features = false, feature
 x25519-dalek = { version = "=3.0.0-pre.4", default-features = false, features = [
     "static_secrets",
 ] }
-blake2 = "0.11.0-rc.3"
-sha3 = "0.11.0-rc.3"
+blake2 = "0.11.0-rc.4"
+chacha20 = { version = "0.10.0-rc.9", default-features = false, features = ["rng"] }
+sha3 = "0.11.0-rc.4"
+getrandom = { version = "0.4.0-rc.1", features = ["sys_rng"] }
 hex = "0.4"
 bincode = "1.0"
 serde_json = "1.0"
 criterion = { version = "0.5", features = ["html_reports"] }
 hex-literal = "1"
-rand = { version = "0.10.0-rc.7", features = ["chacha"] }
 serde = { version = "1.0", features = ["derive"] }
 strobe-rs = "0.5"
 toml = { version = "0.9" }

--- a/ed25519-dalek/benches/ed25519_benchmarks.rs
+++ b/ed25519-dalek/benches/ed25519_benchmarks.rs
@@ -14,8 +14,8 @@ mod ed25519_benches {
     use ed25519_dalek::Signature;
     use ed25519_dalek::Signer;
     use ed25519_dalek::SigningKey;
-    use rand::prelude::ThreadRng;
-    use rand::rng;
+    use rand_core::prelude::ThreadRng;
+    use rand_core::rng;
 
     fn sign(c: &mut Criterion) {
         let mut csprng: ThreadRng = rng();

--- a/ed25519-dalek/src/batch/transcript.rs
+++ b/ed25519-dalek/src/batch/transcript.rs
@@ -156,7 +156,7 @@ impl TranscriptRngBuilder {
     /// transcript data.
     pub fn finalize<R>(mut self, rng: &mut R) -> TranscriptRng
     where
-        R: rand_core::RngCore + rand_core::CryptoRng,
+        R: rand_core::Rng + rand_core::CryptoRng,
     {
         let random_bytes = {
             let mut bytes = [0u8; 32];
@@ -186,7 +186,7 @@ pub struct TranscriptRng {
     strobe: Strobe128,
 }
 
-impl rand_core::TryRngCore for TranscriptRng {
+impl rand_core::TryRng for TranscriptRng {
     type Error = Infallible;
 
     fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
@@ -309,8 +309,9 @@ mod tests {
 
     #[test]
     fn transcript_rng_is_bound_to_transcript_and_witnesses() {
+        use chacha20::ChaCha8Rng;
         use curve25519_dalek::scalar::Scalar;
-        use rand::{SeedableRng, rngs::ChaCha8Rng};
+        use rand_core::SeedableRng;
 
         // Check that the TranscriptRng is bound to the transcript and
         // the witnesses.  This is done by producing a sequence of

--- a/ed25519-dalek/src/context.rs
+++ b/ed25519-dalek/src/context.rs
@@ -23,11 +23,10 @@ use crate::{InternalError, SignatureError};
 /// # fn main() {
 /// use ed25519_dalek::{Signature, SigningKey, VerifyingKey, Sha512};
 /// # use curve25519_dalek::digest::Digest;
-/// # use rand::rngs::SysRng;
-/// # use rand_core::TryRngCore;
+/// # use getrandom::{SysRng, rand_core::{TryRng, UnwrapErr}};
 /// use ed25519_dalek::{DigestSigner, DigestVerifier};
 ///
-/// # let mut csprng = SysRng.unwrap_err();
+/// # let mut csprng = UnwrapErr(SysRng);
 /// # let signing_key = SigningKey::generate(&mut csprng);
 /// # let verifying_key = signing_key.verifying_key();
 /// let context_str = b"Local Channel 3";
@@ -91,13 +90,14 @@ mod test {
 
     use crate::{Signature, SigningKey, VerifyingKey};
     use curve25519_dalek::digest::Digest;
-    use rand::{TryRngCore, rngs::SysRng};
+    use getrandom::SysRng;
+    use rand_core::UnwrapErr;
     use sha2::Sha512;
     use signature::{DigestSigner, DigestVerifier};
 
     #[test]
     fn context_correctness() {
-        let mut csprng = SysRng.unwrap_err();
+        let mut csprng = UnwrapErr(SysRng);
         let signing_key: SigningKey = SigningKey::generate(&mut csprng);
         let verifying_key: VerifyingKey = signing_key.verifying_key();
 

--- a/ed25519-dalek/src/hazmat.rs
+++ b/ed25519-dalek/src/hazmat.rs
@@ -258,7 +258,10 @@ mod test {
 
     use super::*;
 
-    use rand::{CryptoRng, TryRngCore, rngs::SysRng};
+    use getrandom::{
+        SysRng,
+        rand_core::{CryptoRng, UnwrapErr},
+    };
 
     // Pick distinct, non-spec 512-bit hash functions for message and sig-context hashing
     type CtxDigest = blake2::Blake2b512;
@@ -278,7 +281,7 @@ mod test {
     #[test]
     fn sign_verify_nonspec() {
         // Generate the keypair
-        let mut rng = SysRng.unwrap_err();
+        let mut rng = UnwrapErr(SysRng);
         let esk = ExpandedSecretKey::random(&mut rng);
         let vk = VerifyingKey::from(&esk);
 
@@ -297,7 +300,7 @@ mod test {
         use curve25519_dalek::digest::Digest;
 
         // Generate the keypair
-        let mut rng = SysRng.unwrap_err();
+        let mut rng = UnwrapErr(SysRng);
         let esk = ExpandedSecretKey::random(&mut rng);
         let vk = VerifyingKey::from(&esk);
 
@@ -317,7 +320,7 @@ mod test {
     #[test]
     fn sign_byupdate() {
         // Generate the keypair
-        let mut rng = SysRng.unwrap_err();
+        let mut rng = UnwrapErr(SysRng);
         let esk = ExpandedSecretKey::random(&mut rng);
         let vk = VerifyingKey::from(&esk);
 

--- a/ed25519-dalek/src/lib.rs
+++ b/ed25519-dalek/src/lib.rs
@@ -22,12 +22,12 @@
 #![cfg_attr(not(feature = "rand_core"), doc = "```ignore")]
 //! # fn main() {
 //! // $ cargo add ed25519_dalek --features rand_core
-//! use rand::rngs::SysRng;
-//! use rand_core::TryRngCore;
+//! use getrandom::{SysRng, rand_core::UnwrapErr};
+//! use rand_core::TryRng;
 //! use ed25519_dalek::SigningKey;
 //! use ed25519_dalek::Signature;
 //!
-//! let mut csprng = SysRng.unwrap_err();
+//! let mut csprng = UnwrapErr(SysRng);
 //! let signing_key: SigningKey = SigningKey::generate(&mut csprng);
 //! # }
 //! ```
@@ -37,10 +37,9 @@
 #![cfg_attr(feature = "rand_core", doc = "```")]
 #![cfg_attr(not(feature = "rand_core"), doc = "```ignore")]
 //! # fn main() {
-//! # use rand::rngs::SysRng;
-//! # use rand_core::TryRngCore;
+//! # use getrandom::{SysRng, rand_core::{TryRng, UnwrapErr}};
 //! # use ed25519_dalek::SigningKey;
-//! # let mut csprng = SysRng.unwrap_err();
+//! # let mut csprng = UnwrapErr(SysRng);
 //! # let signing_key: SigningKey = SigningKey::generate(&mut csprng);
 //! use ed25519_dalek::{Signature, Signer};
 //! let message: &[u8] = b"This is a test of the tsunami alert system.";
@@ -54,10 +53,9 @@
 #![cfg_attr(feature = "rand_core", doc = "```")]
 #![cfg_attr(not(feature = "rand_core"), doc = "```ignore")]
 //! # fn main() {
-//! # use rand::rngs::SysRng;
-//! # use rand_core::TryRngCore;
+//! # use getrandom::{SysRng, rand_core::{TryRng, UnwrapErr}};
 //! # use ed25519_dalek::{SigningKey, Signature, Signer};
-//! # let mut csprng = SysRng.unwrap_err();
+//! # let mut csprng = UnwrapErr(SysRng);
 //! # let signing_key: SigningKey = SigningKey::generate(&mut csprng);
 //! # let message: &[u8] = b"This is a test of the tsunami alert system.";
 //! # let signature: Signature = signing_key.sign(message);
@@ -72,13 +70,12 @@
 #![cfg_attr(feature = "rand_core", doc = "```")]
 #![cfg_attr(not(feature = "rand_core"), doc = "```ignore")]
 //! # fn main() {
-//! # use rand::rngs::SysRng;
-//! # use rand_core::TryRngCore;
+//! # use getrandom::{SysRng, rand_core::{TryRng, UnwrapErr}};
 //! # use ed25519_dalek::SigningKey;
 //! # use ed25519_dalek::Signature;
 //! # use ed25519_dalek::Signer;
 //! use ed25519_dalek::{VerifyingKey, Verifier};
-//! # let mut csprng = SysRng.unwrap_err();
+//! # let mut csprng = UnwrapErr(SysRng);
 //! # let signing_key: SigningKey = SigningKey::generate(&mut csprng);
 //! # let message: &[u8] = b"This is a test of the tsunami alert system.";
 //! # let signature: Signature = signing_key.sign(message);
@@ -99,11 +96,10 @@
 #![cfg_attr(feature = "rand_core", doc = "```")]
 #![cfg_attr(not(feature = "rand_core"), doc = "```ignore")]
 //! # fn main() {
-//! # use rand::rngs::SysRng;
-//! # use rand_core::TryRngCore;
+//! # use getrandom::{SysRng, rand_core::{TryRng, UnwrapErr}};
 //! # use ed25519_dalek::{SigningKey, Signature, Signer, VerifyingKey};
 //! use ed25519_dalek::{PUBLIC_KEY_LENGTH, SECRET_KEY_LENGTH, KEYPAIR_LENGTH, SIGNATURE_LENGTH};
-//! # let mut csprng = SysRng.unwrap_err();
+//! # let mut csprng = UnwrapErr(SysRng);
 //! # let signing_key: SigningKey = SigningKey::generate(&mut csprng);
 //! # let message: &[u8] = b"This is a test of the tsunami alert system.";
 //! # let signature: Signature = signing_key.sign(message);
@@ -120,12 +116,11 @@
 #![cfg_attr(feature = "rand_core", doc = "```")]
 #![cfg_attr(not(feature = "rand_core"), doc = "```ignore")]
 //! # use core::convert::{TryFrom, TryInto};
-//! # use rand::rngs::SysRng;
-//! # use rand_core::TryRngCore;
+//! # use getrandom::{SysRng, rand_core::{TryRng, UnwrapErr}};
 //! # use ed25519_dalek::{SigningKey, Signature, Signer, VerifyingKey, SecretKey, SignatureError};
 //! # use ed25519_dalek::{PUBLIC_KEY_LENGTH, SECRET_KEY_LENGTH, KEYPAIR_LENGTH, SIGNATURE_LENGTH};
 //! # fn do_test() -> Result<(SigningKey, VerifyingKey, Signature), SignatureError> {
-//! # let mut csprng = SysRng.unwrap_err();
+//! # let mut csprng = UnwrapErr(SysRng);
 //! # let signing_key_orig: SigningKey = SigningKey::generate(&mut csprng);
 //! # let message: &[u8] = b"This is a test of the tsunami alert system.";
 //! # let signature_orig: Signature = signing_key_orig.sign(message);
@@ -198,11 +193,10 @@
 #![cfg_attr(all(feature = "rand_core", feature = "serde"), doc = "```")]
 #![cfg_attr(not(all(feature = "rand_core", feature = "serde")), doc = "```ignore")]
 //! # fn main() {
-//! # use rand::rngs::SysRng;
-//! # use rand_core::TryRngCore;
+//! # use getrandom::{SysRng, rand_core::{TryRng, UnwrapErr}};
 //! # use ed25519_dalek::{SigningKey, Signature, Signer, Verifier, VerifyingKey};
 //! use bincode::serialize;
-//! # let mut csprng = SysRng.unwrap_err();
+//! # let mut csprng = UnwrapErr(SysRng);
 //! # let signing_key: SigningKey = SigningKey::generate(&mut csprng);
 //! # let message: &[u8] = b"This is a test of the tsunami alert system.";
 //! # let signature: Signature = signing_key.sign(message);
@@ -220,13 +214,12 @@
 #![cfg_attr(all(feature = "rand_core", feature = "serde"), doc = "```")]
 #![cfg_attr(not(all(feature = "rand_core", feature = "serde")), doc = "```ignore")]
 //! # fn main() {
-//! # use rand::rngs::SysRng;
-//! # use rand_core::TryRngCore;
+//! # use getrandom::{SysRng, rand_core::{TryRng, UnwrapErr}};
 //! # use ed25519_dalek::{SigningKey, Signature, Signer, Verifier, VerifyingKey};
 //! # use bincode::serialize;
 //! use bincode::deserialize;
 //!
-//! # let mut csprng = SysRng.unwrap_err();
+//! # let mut csprng = UnwrapErr(SysRng);
 //! # let signing_key: SigningKey = SigningKey::generate(&mut csprng);
 //! let message: &[u8] = b"This is a test of the tsunami alert system.";
 //! # let signature: Signature = signing_key.sign(message);

--- a/ed25519-dalek/src/signing.rs
+++ b/ed25519-dalek/src/signing.rs
@@ -189,11 +189,10 @@ impl SigningKey {
     #[cfg_attr(feature = "rand_core", doc = "```")]
     #[cfg_attr(not(feature = "rand_core"), doc = "```ignore")]
     /// # fn main() {
-    /// use rand::rngs::SysRng;
-    /// use rand_core::TryRngCore;
+    /// use getrandom::{SysRng, rand_core::{TryRng, UnwrapErr}};
     /// use ed25519_dalek::{Signature, SigningKey};
     ///
-    /// let mut csprng = SysRng.unwrap_err();
+    /// let mut csprng = UnwrapErr(SysRng);
     /// let signing_key: SigningKey = SigningKey::generate(&mut csprng);
     /// # }
     /// ```
@@ -242,11 +241,10 @@ impl SigningKey {
     /// use ed25519_dalek::SigningKey;
     /// use ed25519_dalek::Signature;
     /// use sha2::Sha512;
-    /// use rand::rngs::SysRng;
-    /// use rand_core::TryRngCore;
+    /// use getrandom::{SysRng, rand_core::{TryRng, UnwrapErr}};
     ///
     /// # fn main() {
-    /// let mut csprng = SysRng.unwrap_err();
+    /// let mut csprng = UnwrapErr(SysRng);
     /// let signing_key: SigningKey = SigningKey::generate(&mut csprng);
     /// let message: &[u8] = b"All I want is to pet all of the dogs.";
     ///
@@ -288,11 +286,10 @@ impl SigningKey {
     /// # use ed25519_dalek::Signature;
     /// # use ed25519_dalek::SignatureError;
     /// # use sha2::Sha512;
-    /// # use rand::rngs::SysRng;
-    /// # use rand_core::TryRngCore;
+    /// # use getrandom::{SysRng, rand_core::{TryRng, UnwrapErr}};
     /// #
     /// # fn do_test() -> Result<Signature, SignatureError> {
-    /// # let mut csprng = SysRng.unwrap_err();
+    /// # let mut csprng = UnwrapErr(SysRng);
     /// # let signing_key: SigningKey = SigningKey::generate(&mut csprng);
     /// # let message: &[u8] = b"All I want is to pet all of the dogs.";
     /// # let mut prehashed: Sha512 = Sha512::new();
@@ -368,11 +365,10 @@ impl SigningKey {
     /// use ed25519_dalek::Signature;
     /// use ed25519_dalek::SignatureError;
     /// use sha2::Sha512;
-    /// use rand::rngs::SysRng;
-    /// use rand_core::TryRngCore;
+    /// use getrandom::{SysRng, rand_core::{TryRng, UnwrapErr}};
     ///
     /// # fn do_test() -> Result<(), SignatureError> {
-    /// let mut csprng = SysRng.unwrap_err();
+    /// let mut csprng = UnwrapErr(SysRng);
     /// let signing_key: SigningKey = SigningKey::generate(&mut csprng);
     /// let message: &[u8] = b"All I want is to pet all of the dogs.";
     ///
@@ -790,7 +786,7 @@ impl<'d> Deserialize<'d> for SigningKey {
             type Value = SigningKey;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                write!(formatter, concat!("An ed25519 signing (private) key"))
+                write!(formatter, "An ed25519 signing (private) key")
             }
 
             fn visit_bytes<E: serde::de::Error>(self, bytes: &[u8]) -> Result<Self::Value, E> {

--- a/ed25519-dalek/src/verifying.rs
+++ b/ed25519-dalek/src/verifying.rs
@@ -710,7 +710,7 @@ impl<'d> Deserialize<'d> for VerifyingKey {
             type Value = VerifyingKey;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                write!(formatter, concat!("An ed25519 verifying (public) key"))
+                write!(formatter, "An ed25519 verifying (public) key")
             }
 
             fn visit_bytes<E: serde::de::Error>(self, bytes: &[u8]) -> Result<Self::Value, E> {

--- a/ed25519-dalek/tests/ed25519.rs
+++ b/ed25519-dalek/tests/ed25519.rs
@@ -20,6 +20,7 @@ use hex_literal::hex;
 #[cfg(test)]
 mod vectors {
     use super::*;
+    use getrandom::{SysRng, rand_core::UnwrapErr};
 
     use curve25519_dalek::{
         constants::ED25519_BASEPOINT_POINT,
@@ -27,7 +28,6 @@ mod vectors {
         scalar::Scalar,
         traits::IsIdentity,
     };
-    use rand::TryRngCore;
 
     #[cfg(not(feature = "digest"))]
     use sha2::{Sha512, digest::Digest};
@@ -183,7 +183,7 @@ mod vectors {
 
     // Pick a random Scalar
     fn non_null_scalar() -> Scalar {
-        let mut rng = rand::rngs::SysRng.unwrap_err();
+        let mut rng = UnwrapErr(SysRng);
         let mut s_candidate = Scalar::random(&mut rng);
         while s_candidate == Scalar::ZERO {
             s_candidate = Scalar::random(&mut rng);
@@ -295,7 +295,7 @@ mod vectors {
 #[cfg(feature = "rand_core")]
 mod integrations {
     use super::*;
-    use rand::{TryRngCore, rngs::SysRng};
+    use getrandom::{SysRng, rand_core::UnwrapErr};
     use std::collections::HashMap;
 
     #[test]
@@ -305,7 +305,7 @@ mod integrations {
         let good: &[u8] = "test message".as_bytes();
         let bad: &[u8] = "wrong message".as_bytes();
 
-        let mut csprng = SysRng.unwrap_err();
+        let mut csprng = UnwrapErr(SysRng);
 
         let signing_key: SigningKey = SigningKey::generate(&mut csprng);
         let verifying_key = signing_key.verifying_key();
@@ -346,7 +346,7 @@ mod integrations {
     fn sign_verify_digest_equivalence() {
         // TestSignVerify
 
-        let mut csprng = SysRng.unwrap_err();
+        let mut csprng = UnwrapErr(SysRng);
 
         let good: &[u8] = "test message".as_bytes();
         let bad: &[u8] = "wrong message".as_bytes();
@@ -391,7 +391,7 @@ mod integrations {
         let good: &[u8] = b"test message";
         let bad: &[u8] = b"wrong message";
 
-        let mut csprng = SysRng.unwrap_err();
+        let mut csprng = UnwrapErr(SysRng);
 
         // ugh… there's no `impl Copy for Sha512`… i hope we can all agree these are the same hashes
         let mut prehashed_good1: Sha512 = Sha512::default();
@@ -466,7 +466,7 @@ mod integrations {
             b"Fuck dumbin' it down, spit ice, skip jewellery: Molotov cocktails on me like accessories.",
             b"Hey, I never cared about your bucks, so if I run up with a mask on, probably got a gas can too.",
             b"And I'm not here to fill 'er up. Nope, we came to riot, here to incite, we don't want any of your stuff.", ];
-        let mut csprng = SysRng.unwrap_err();
+        let mut csprng = UnwrapErr(SysRng);
         let mut signing_keys: Vec<SigningKey> = Vec::new();
         let mut signatures: Vec<Signature> = Vec::new();
 
@@ -485,7 +485,7 @@ mod integrations {
 
     #[test]
     fn public_key_hash_trait_check() {
-        let mut csprng = SysRng.unwrap_err();
+        let mut csprng = UnwrapErr(SysRng);
         let secret: SigningKey = SigningKey::generate(&mut csprng);
         let public_from_secret: VerifyingKey = (&secret).into();
 
@@ -512,7 +512,7 @@ mod integrations {
 
     #[test]
     fn montgomery_and_edwards_conversion() {
-        let mut rng = rand::rngs::SysRng.unwrap_err();
+        let mut rng = UnwrapErr(SysRng);
         let signing_key = SigningKey::generate(&mut rng);
         let verifying_key = signing_key.verifying_key();
 

--- a/x25519-dalek/Cargo.toml
+++ b/x25519-dalek/Cargo.toml
@@ -43,17 +43,17 @@ all-features = true
 
 [dependencies]
 curve25519-dalek = { version = "=5.0.0-pre.4", default-features = false }
-rand_core = { version = "0.10.0-rc-5", default-features = false }
+rand_core = { version = "0.10.0-rc-6", default-features = false }
 
 # optional dependencies
-getrandom = { version = "0.4.0-rc.0", optional = true }
+getrandom = { version = "0.4.0-rc.1", optional = true }
 serde = { version = "1", default-features = false, optional = true, features = ["derive"] }
 zeroize = { version = "1", default-features = false, optional = true }
 
 [dev-dependencies]
 bincode = "1"
 criterion = "0.5"
-rand = "0.10.0-rc.7"
+getrandom = { version = "0.4.0-rc.1", features = ["sys_rng"] }
 
 [[bench]]
 name = "x25519"

--- a/x25519-dalek/README.md
+++ b/x25519-dalek/README.md
@@ -51,9 +51,9 @@ loudly meows `bob_public` back to Alice.  Alice now computes her
 shared secret with Bob by doing:
 
 ```rust
-# use rand::{rngs::SysRng, TryRngCore};
+# use getrandom::{SysRng, rand_core::UnwrapErr};
 # use x25519_dalek::{EphemeralSecret, PublicKey};
-# let mut rng = SysRng.unwrap_err();
+# let mut rng = UnwrapErr(SysRng);
 # let alice_secret = EphemeralSecret::random_from_rng(&mut rng);
 # let alice_public = PublicKey::from(&alice_secret);
 # let bob_secret = EphemeralSecret::random_from_rng(&mut rng);
@@ -64,9 +64,9 @@ let alice_shared_secret = alice_secret.diffie_hellman(&bob_public);
 Similarly, Bob computes a shared secret by doing:
 
 ```rust
-# use rand::{rngs::SysRng, TryRngCore};
+# use getrandom::{SysRng, rand_core::UnwrapErr};
 # use x25519_dalek::{EphemeralSecret, PublicKey};
-# let mut rng = SysRng.unwrap_err();
+# let mut rng = UnwrapErr(SysRng);
 # let alice_secret = EphemeralSecret::random_from_rng(&mut rng);
 # let alice_public = PublicKey::from(&alice_secret);
 # let bob_secret = EphemeralSecret::random_from_rng(&mut rng);
@@ -77,9 +77,9 @@ let bob_shared_secret = bob_secret.diffie_hellman(&alice_public);
 These secrets are the same:
 
 ```rust
-# use rand::{rngs::SysRng, TryRngCore};
+# use getrandom::{SysRng, rand_core::UnwrapErr};
 # use x25519_dalek::{EphemeralSecret, PublicKey};
-# let mut rng = SysRng.unwrap_err();
+# let mut rng = UnwrapErr(SysRng);
 # let alice_secret = EphemeralSecret::random_from_rng(&mut rng);
 # let alice_public = PublicKey::from(&alice_secret);
 # let bob_secret = EphemeralSecret::random_from_rng(&mut rng);

--- a/x25519-dalek/benches/x25519.rs
+++ b/x25519-dalek/benches/x25519.rs
@@ -13,25 +13,25 @@
 
 use criterion::{Criterion, criterion_group, criterion_main};
 
-use rand::{TryRngCore, rngs::SysRng};
+use getrandom::{SysRng, rand_core::UnwrapErr};
 
 use x25519_dalek::EphemeralSecret;
 use x25519_dalek::PublicKey;
 
 fn bench_diffie_hellman(c: &mut Criterion) {
-    let bob_secret = EphemeralSecret::random_from_rng(&mut SysRng.unwrap_err());
+    let bob_secret = EphemeralSecret::random_from_rng(&mut UnwrapErr(SysRng));
     let bob_public = PublicKey::from(&bob_secret);
 
     c.bench_function("diffie_hellman", move |b| {
         b.iter_with_setup(
-            || EphemeralSecret::random_from_rng(&mut SysRng.unwrap_err()),
+            || EphemeralSecret::random_from_rng(&mut UnwrapErr(SysRng)),
             |alice_secret| alice_secret.diffie_hellman(&bob_public),
         )
     });
 }
 
 fn bench_pubkey_constructor(c: &mut Criterion) {
-    let bob_secret = EphemeralSecret::random_from_rng(&mut SysRng.unwrap_err());
+    let bob_secret = EphemeralSecret::random_from_rng(&mut UnwrapErr(SysRng));
 
     c.bench_function("PublicKey::from", move |b| {
         b.iter(|| PublicKey::from(&bob_secret))

--- a/x25519-dalek/src/x25519.rs
+++ b/x25519-dalek/src/x25519.rs
@@ -363,13 +363,13 @@ impl ZeroizeOnDrop for SharedSecret {}
 /// # Example
 #[cfg_attr(feature = "static_secrets", doc = "```")]
 #[cfg_attr(not(feature = "static_secrets"), doc = "```ignore")]
-/// use rand::{rngs::SysRng, RngCore, TryRngCore};
+/// use getrandom::{SysRng, rand_core::UnwrapErr};
 ///
 /// use x25519_dalek::x25519;
 /// use x25519_dalek::StaticSecret;
 /// use x25519_dalek::PublicKey;
 ///
-/// let mut rng = SysRng.unwrap_err();
+/// let mut rng = UnwrapErr(SysRng);
 ///
 /// // Generate Alice's key pair.
 /// let alice_secret = StaticSecret::random_from_rng(&mut rng);

--- a/x25519-dalek/tests/x25519_tests.rs
+++ b/x25519-dalek/tests/x25519_tests.rs
@@ -239,26 +239,26 @@ fn rfc7748_ladder_test2() {
     );
 }
 
-mod os_rng {
+mod sys_rng {
 
     use super::*;
-    use rand::{TryRngCore, rngs::SysRng};
+    use ::getrandom::{SysRng, rand_core::UnwrapErr};
 
     #[test]
     fn ephemeral_from_rng() {
-        EphemeralSecret::random_from_rng(&mut SysRng.unwrap_err());
+        EphemeralSecret::random_from_rng(&mut UnwrapErr(SysRng));
     }
 
     #[test]
     #[cfg(feature = "reusable_secrets")]
     fn reusable_from_rng() {
-        ReusableSecret::random_from_rng(&mut SysRng.unwrap_err());
+        ReusableSecret::random_from_rng(&mut UnwrapErr(SysRng));
     }
 
     #[test]
     #[cfg(feature = "static_secrets")]
     fn static_from_rng() {
-        StaticSecret::random_from_rng(&mut SysRng.unwrap_err());
+        StaticSecret::random_from_rng(&mut UnwrapErr(SysRng));
     }
 }
 


### PR DESCRIPTION
This also rips out `rand`: it's just acting as a facade for what we're using that complicates these sorts of upgrades.