### PR TITLE
Bump `digest` and `sha2` to v0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1047,12 +1047,12 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.11.0-rc.5"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c5f3b1e2dc8aad28310d8410bd4d7e180eca65fca176c52ab00d364475d0024"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures 0.3.0",
  "digest",
 ]
 

--- a/curve25519-dalek/Cargo.toml
+++ b/curve25519-dalek/Cargo.toml
@@ -35,7 +35,7 @@ criterion = { version = "0.5", features = ["html_reports"] }
 getrandom = { version = "0.4", features = ["sys_rng"] }
 hex = "0.4.2"
 proptest = "1"
-sha2 = { version = "0.11.0-rc.5", default-features = false }
+sha2 = { version = "0.11", default-features = false }
 
 [build-dependencies]
 rustc_version = "0.4.0"
@@ -50,9 +50,7 @@ cfg-if = "1"
 ff = { version = "0.14.0-rc.0", package = "rustcrypto-ff", default-features = false, optional = true }
 group = { version = "0.14.0-rc.0", package = "rustcrypto-group", default-features = false, optional = true }
 rand_core = { version = "0.10", default-features = false, optional = true }
-digest = { version = "0.11.0-rc.11", default-features = false, optional = true, features = [
-    "block-api",
-] }
+digest = { version = "0.11", default-features = false, optional = true, features = ["block-api"] }
 subtle = { version = "2.6.0", default-features = false, features = [
     "const-generics",
 ] }

--- a/ed25519-dalek/Cargo.toml
+++ b/ed25519-dalek/Cargo.toml
@@ -33,7 +33,7 @@ curve25519-dalek = { version = "=5.0.0-pre.6", default-features = false, feature
 ] }
 ed25519 = { version = "3.0.0-rc.4", default-features = false }
 signature = { version = "3.0.0-rc.10", optional = true, default-features = false }
-sha2 = { version = "0.11.0-rc.5", default-features = false }
+sha2 = { version = "0.11", default-features = false }
 subtle = { version = "2.3.0", default-features = false }
 
 # optional features


### PR DESCRIPTION
Release PRs:
- `digest`: RustCrypto/traits#2300
- `sha2`: RustCrypto/hashes#806