### PR TITLE
ed25519-dalek: Fix README feature matrix

### DIFF
--- a/ed25519-dalek/README.md
+++ b/ed25519-dalek/README.md
@@ -17,7 +17,7 @@ This crate is `#[no_std]` compatible with `default-features = false`.
 
 | Feature                | Default? | Description |
 | :---                   | :---     | :---        |
-| `alloc`                | ✓        | When `pkcs8` is enabled, implements `EncodePrivateKey`/`EncodePublicKey` for `SigningKey`/`VerifyingKey`, respectively. |
+| `alloc`                |          | When `pkcs8` is enabled, implements `EncodePrivateKey`/`EncodePublicKey` for `SigningKey`/`VerifyingKey`, respectively. |
 | `fast`                 | ✓        | Enables the use of precomputed tables for curve arithmetic. Makes key generation, signing, and verifying faster. |
 | `zeroize`              | ✓        | Implements `Zeroize` and `ZeroizeOnDrop` for `SigningKey` |
 | `rand_core`            |          | Enables `SigningKey::generate` |


### PR DESCRIPTION
`alloc` feature is not enabled by `default` feature for `ed25519-dalek`:

https://github.com/dalek-cryptography/curve25519-dalek/blob/eb7df8080520b9be6f5696b9eff9293005c4950e/ed25519-dalek/Cargo.toml#L72