### PR TITLE
ed25519-dalek: pass KeyError::Invalid to pkcs8::Error::KeyMalformed

### DIFF
--- a/ed25519-dalek/src/signing.rs
+++ b/ed25519-dalek/src/signing.rs
@@ -717,10 +717,6 @@ impl TryFrom<&pkcs8::KeypairBytes> for SigningKey {
         let signing_key = SigningKey::from_bytes(&pkcs8_key.secret_key);
 
         // Validate the public key in the PKCS#8 document if present.
-        // `pkcs8::Error::KeyMalformed` was changed to a tuple variant
-        // `KeyMalformed(KeyError)` upstream; the bare reference is now a
-        // function pointer rather than an `Error` value. Pass
-        // `KeyError::Invalid` to construct an `Error`.
         if let Some(public_bytes) = &pkcs8_key.public_key {
             let expected_verifying_key = VerifyingKey::from_bytes(public_bytes.as_ref())
                 .map_err(|_| pkcs8::Error::KeyMalformed(pkcs8::KeyError::Invalid))?;

--- a/ed25519-dalek/src/signing.rs
+++ b/ed25519-dalek/src/signing.rs
@@ -716,13 +716,17 @@ impl TryFrom<&pkcs8::KeypairBytes> for SigningKey {
     fn try_from(pkcs8_key: &pkcs8::KeypairBytes) -> pkcs8::Result<Self> {
         let signing_key = SigningKey::from_bytes(&pkcs8_key.secret_key);
 
-        // Validate the public key in the PKCS#8 document if present
+        // Validate the public key in the PKCS#8 document if present.
+        // `pkcs8::Error::KeyMalformed` was changed to a tuple variant
+        // `KeyMalformed(KeyError)` upstream; the bare reference is now a
+        // function pointer rather than an `Error` value. Pass
+        // `KeyError::Invalid` to construct an `Error`.
         if let Some(public_bytes) = &pkcs8_key.public_key {
             let expected_verifying_key = VerifyingKey::from_bytes(public_bytes.as_ref())
-                .map_err(|_| pkcs8::Error::KeyMalformed)?;
+                .map_err(|_| pkcs8::Error::KeyMalformed(pkcs8::KeyError::Invalid))?;
 
             if signing_key.verifying_key() != expected_verifying_key {
-                return Err(pkcs8::Error::KeyMalformed);
+                return Err(pkcs8::Error::KeyMalformed(pkcs8::KeyError::Invalid));
             }
         }
 


### PR DESCRIPTION
## Summary

`pkcs8::Error::KeyMalformed` is a tuple variant `KeyMalformed(KeyError)` in current `pkcs8`. The two bare references in `ed25519-dalek/src/signing.rs` were function pointers (`fn(KeyError) -> Error`) rather than `Error` values, so the code fails to compile on stable Rust:

```
error[E0277]: `?` couldn't convert the error to `pkcs8::Error`
error[E0308]: mismatched types — expected `Error`, found enum constructor
```

This PR passes `KeyError::Invalid` to the tuple variant. Mirrors the fix already on master in the parent `ed25519` crate (`RustCrypto/signatures`, `ed25519/src/pkcs8.rs`, [permalink](https://github.com/RustCrypto/signatures/blob/master/ed25519/src/pkcs8.rs#L172)).

## Test plan

- Compiles `cargo check -p ed25519-dalek --features pkcs8` cleanly with the workspace patched to use `ed25519` master:
  ```toml
  [patch.crates-io]
  ed25519 = { git = "https://github.com/RustCrypto/signatures.git", branch = "master" }
  ```
- That patch is **not** included in this PR — it only verifies the diff against the unreleased ed25519 fix.
- No behavioural change: the failure path now constructs an explicit `Error::KeyMalformed(KeyError::Invalid)` instead of relying on a (broken) unit-variant reference.

## Dependency note

`pkcs8::KeyError` is re-exported from `ed25519::pkcs8` on `RustCrypto/signatures` master, but **not** in the published `ed25519 3.0.0-rc.4` that the workspace currently depends on. This PR therefore requires bumping the `ed25519` dep to a release that re-exports `KeyError` (or to a git ref of master) before it will compile against published deps. I'm happy to either:
1. Wait for `ed25519` rc.5 / 3.0.0 release, then add a follow-up PR bumping the dep.
2. Bump the dep to a git ref now in this same PR.

Let me know which you prefer; happy to update.

## References

- `RustCrypto/signatures#1315` — root-cause issue
- `n0-computer/iroh#4192` — downstream impact (iroh fails to compile because of this)

🤖 Filed via Claude Code
