### PR TITLE
bump rustcrypto dependencies to released versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,9 +96,9 @@ dependencies = [
 
 [[package]]
 name = "blake2"
-version = "0.11.0-rc.5"
+version = "0.11.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52965399b470437fc7f4d4b51134668dbc96573fea6f1b83318a420e4605745"
+checksum = "061f1a09225e328e1ffbb378d2d49923c0ca5fee19fb5ac1cc9c1e9d52b93690"
 dependencies = [
  "digest",
 ]
@@ -340,9 +340,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.8.0-rc.10"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c1d73e9668ea6b6a28172aa55f3ebec38507131ce179051c8033b5c6037653"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
 dependencies = [
  "const-oid",
  "pem-rfc7468",
@@ -363,9 +363,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "3.0.0-rc.4"
+version = "3.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e914c7c52decb085cea910552e24c63ac019e3ab8bf001ff736da9a9d9d890"
+checksum = "5bf8e9f747a3618916ed918759c99ddc9de22888782edba712c0a856a09ed42d"
 dependencies = [
  "pkcs8",
  "serde",
@@ -682,9 +682,9 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.11.0-rc.10"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b226d2cc389763951db8869584fd800cbbe2962bf454e2edeb5172b31ee99774"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
 dependencies = [
  "der",
  "spki",
@@ -896,9 +896,9 @@ dependencies = [
 
 [[package]]
 name = "rustcrypto-ff"
-version = "0.14.0-rc.0"
+version = "0.14.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5db129183b2c139d7d87d08be57cba626c715789db17aec65c8866bfd767d1f"
+checksum = "fd2a8adb347447693cd2ba0d218c4b66c62da9b0a5672b17b981e4291ec65ff6"
 dependencies = [
  "bitvec",
  "rand_core 0.10.0",
@@ -923,9 +923,9 @@ dependencies = [
 
 [[package]]
 name = "rustcrypto-group"
-version = "0.14.0-rc.0"
+version = "0.14.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c4b1463f274a3ff6fb2f44da43e576cb9424367bd96f185ead87b52fe00523"
+checksum = "369f9b61aa45933c062c9f6b5c3c50ab710687eca83dd3802653b140b43f85ed"
 dependencies = [
  "rand_core 0.10.0",
  "rustcrypto-ff",
@@ -1043,9 +1043,9 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.11.0-rc.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b233a7d59d7bfc027208506a33ffc9532b2acb24ddc61fe7e758dc2250db431"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
 dependencies = [
  "digest",
  "keccak",
@@ -1053,18 +1053,18 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "3.0.0-rc.10"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f1880df446116126965eeec169136b2e0251dba37c6223bcc819569550edea3"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 dependencies = [
  "digest",
 ]
 
 [[package]]
 name = "spki"
-version = "0.8.0-rc.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8baeff88f34ed0691978ec34440140e1572b68c7dd4a495fd14a3dc1944daa80"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
 dependencies = [
  "base64ct",
  "der",

--- a/curve25519-dalek/Cargo.toml
+++ b/curve25519-dalek/Cargo.toml
@@ -47,8 +47,8 @@ required-features = ["alloc", "rand_core"]
 
 [dependencies]
 cfg-if = "1"
-ff = { version = "0.14.0-rc.0", package = "rustcrypto-ff", default-features = false, optional = true }
-group = { version = "0.14.0-rc.0", package = "rustcrypto-group", default-features = false, optional = true }
+ff = { version = "0.14.0-rc.1", package = "rustcrypto-ff", default-features = false, optional = true }
+group = { version = "0.14.0-rc.1", package = "rustcrypto-group", default-features = false, optional = true }
 rand_core = { version = "0.10", default-features = false, optional = true }
 digest = { version = "0.11", default-features = false, optional = true, features = ["block-api"] }
 subtle = { version = "2.6.0", default-features = false, features = [

--- a/ed25519-dalek/Cargo.toml
+++ b/ed25519-dalek/Cargo.toml
@@ -32,7 +32,7 @@ curve25519-dalek = { version = "=5.0.0-pre.6", default-features = false, feature
     "digest",
 ] }
 ed25519 = { version = "3.0.0-rc.5", default-features = false }
-signature = { version = "3.0", optional = true, default-features = false }
+signature = { version = "3", optional = true, default-features = false }
 sha2 = { version = "0.11", default-features = false }
 subtle = { version = "2.3.0", default-features = false }
 

--- a/ed25519-dalek/Cargo.toml
+++ b/ed25519-dalek/Cargo.toml
@@ -31,8 +31,8 @@ all-features = true
 curve25519-dalek = { version = "=5.0.0-pre.6", default-features = false, features = [
     "digest",
 ] }
-ed25519 = { version = "3.0.0-rc.4", default-features = false }
-signature = { version = "3.0.0-rc.10", optional = true, default-features = false }
+ed25519 = { version = "3.0.0-rc.5", default-features = false }
+signature = { version = "3.0", optional = true, default-features = false }
 sha2 = { version = "0.11", default-features = false }
 subtle = { version = "2.3.0", default-features = false }
 
@@ -51,10 +51,10 @@ curve25519-dalek = { version = "=5.0.0-pre.6", default-features = false, feature
 x25519-dalek = { version = "=3.0.0-pre.6", default-features = false, features = [
     "static_secrets",
 ] }
-blake2 = "0.11.0-rc.5"
-chacha20 = { version = "0.10.0-rc.10", default-features = false, features = ["rng"] }
-sha3 = "0.11.0-rc.9"
-getrandom = { version = "0.4.0-rc.1", features = ["sys_rng"] }
+blake2 = "0.11.0-rc.6"
+chacha20 = { version = "0.10", default-features = false, features = ["rng"] }
+sha3 = "0.11"
+getrandom = { version = "0.4", features = ["sys_rng"] }
 hex = "0.4"
 bincode = "1.0"
 serde_json = "1.0"

--- a/ed25519-dalek/src/signing.rs
+++ b/ed25519-dalek/src/signing.rs
@@ -719,10 +719,10 @@ impl TryFrom<&pkcs8::KeypairBytes> for SigningKey {
         // Validate the public key in the PKCS#8 document if present
         if let Some(public_bytes) = &pkcs8_key.public_key {
             let expected_verifying_key = VerifyingKey::from_bytes(public_bytes.as_ref())
-                .map_err(|_| pkcs8::Error::KeyMalformed)?;
+                .map_err(|_| pkcs8::Error::KeyMalformed(pkcs8::KeyError::Invalid))?;
 
             if signing_key.verifying_key() != expected_verifying_key {
-                return Err(pkcs8::Error::KeyMalformed);
+                return Err(pkcs8::Error::KeyMalformed(pkcs8::KeyError::Invalid));
             }
         }
 


### PR DESCRIPTION
This bumps `pkcs8`, `signature`, `spki`, `sha3`, and `der` to newly released versions.

This also bumps the version of `blake2`, `rustcrypto-ff`, `rustcrypto-group`, and `ed25519` to their latest pre-released versions.