### PR TITLE
ed25519-dalek: bump `ed25519` crate dependency to v3.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1116,9 +1116,9 @@ dependencies = [
 
 [[package]]
 name = "serdect"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9af4a3e75ebd5599b30d4de5768e00b5095d518a79fefc3ecbaf77e665d1ec06"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
 dependencies = [
  "base16ct",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -363,12 +369,12 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "3.0.0-rc.5"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf8e9f747a3618916ed918759c99ddc9de22888782edba712c0a856a09ed42d"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
 dependencies = [
  "pkcs8",
- "serde",
+ "serdect",
  "signature",
 ]
 
@@ -1028,6 +1034,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serdect"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9af4a3e75ebd5599b30d4de5768e00b5095d518a79fefc3ecbaf77e665d1ec06"
+dependencies = [
+ "base16ct",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -57,15 +66,6 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
-
-[[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "bit-set"
@@ -212,6 +212,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de0758edba32d61d1fd9f4d69491b47604b91ee2f7e6b33de7e54ca4ebe55dc3"
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,6 +270,12 @@ dependencies = [
  "cast",
  "itertools",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-deque"
@@ -315,7 +330,6 @@ dependencies = [
 name = "curve25519-dalek"
 version = "5.0.0-pre.6"
 dependencies = [
- "bincode",
  "cfg-if",
  "cpufeatures",
  "criterion",
@@ -324,6 +338,7 @@ dependencies = [
  "fiat-crypto",
  "getrandom 0.4.0",
  "hex",
+ "postcard",
  "proptest",
  "rand_core 0.10.0",
  "rustc_version",
@@ -382,7 +397,6 @@ dependencies = [
 name = "ed25519-dalek"
 version = "3.0.0-pre.6"
 dependencies = [
- "bincode",
  "blake2",
  "chacha20",
  "criterion",
@@ -392,6 +406,7 @@ dependencies = [
  "hex",
  "hex-literal",
  "keccak",
+ "postcard",
  "rand_core 0.10.0",
  "serde",
  "serde_json",
@@ -410,6 +425,18 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "equivalent"
@@ -495,6 +522,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -508,6 +544,20 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "serde",
+ "spin",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "heck"
@@ -625,6 +675,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -722,6 +781,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "heapless",
+ "serde",
 ]
 
 [[package]]
@@ -979,6 +1051,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1077,6 +1155,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "spki"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1085,6 +1172,12 @@ dependencies = [
  "base64ct",
  "der",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strobe-rs"
@@ -1144,6 +1237,26 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1476,10 +1589,10 @@ dependencies = [
 name = "x25519-dalek"
 version = "3.0.0-pre.6"
 dependencies = [
- "bincode",
  "criterion",
  "curve25519-dalek",
  "getrandom 0.4.0",
+ "postcard",
  "rand_core 0.10.0",
  "serde",
  "zeroize",

--- a/curve25519-dalek/Cargo.toml
+++ b/curve25519-dalek/Cargo.toml
@@ -30,7 +30,7 @@ rustdoc-args = [
 all-features = true
 
 [dev-dependencies]
-bincode = "1"
+postcard = { version = "1", features = ["alloc"] }
 criterion = { version = "0.5", features = ["html_reports"] }
 getrandom = { version = "0.4", features = ["sys_rng"] }
 hex = "0.4.2"

--- a/curve25519-dalek/src/edwards.rs
+++ b/curve25519-dalek/src/edwards.rs
@@ -2453,25 +2453,26 @@ mod test {
 
     #[test]
     #[cfg(feature = "serde")]
-    fn serde_bincode_basepoint_roundtrip() {
-        use bincode;
-
-        let encoded = bincode::serialize(&constants::ED25519_BASEPOINT_POINT).unwrap();
-        let enc_compressed = bincode::serialize(&constants::ED25519_BASEPOINT_COMPRESSED).unwrap();
+    fn serde_postcard_basepoint_roundtrip() {
+        let encoded = postcard::to_allocvec(&constants::ED25519_BASEPOINT_POINT).unwrap();
+        let enc_compressed =
+            postcard::to_allocvec(&constants::ED25519_BASEPOINT_COMPRESSED).unwrap();
         assert_eq!(encoded, enc_compressed);
 
         // Check that the encoding is 32 bytes exactly
         assert_eq!(encoded.len(), 32);
 
-        let dec_uncompressed: EdwardsPoint = bincode::deserialize(&encoded).unwrap();
-        let dec_compressed: CompressedEdwardsY = bincode::deserialize(&encoded).unwrap();
+        let dec_uncompressed: EdwardsPoint = postcard::from_bytes(&encoded).unwrap();
+        let dec_compressed: CompressedEdwardsY = postcard::from_bytes(&encoded).unwrap();
 
         assert_eq!(dec_uncompressed, constants::ED25519_BASEPOINT_POINT);
         assert_eq!(dec_compressed, constants::ED25519_BASEPOINT_COMPRESSED);
 
-        // Check that the encoding itself matches the usual one
+        // Check that the encoding itself matches the usual one.
+        // serde::Deserialize on fixed-size arrays calls tuple deserialization. postcard
+        // (de)serializes tuples by just doing each element and that's it.
         let raw_bytes = constants::ED25519_BASEPOINT_COMPRESSED.as_bytes();
-        let bp: EdwardsPoint = bincode::deserialize(raw_bytes).unwrap();
+        let bp: EdwardsPoint = postcard::from_bytes(raw_bytes).unwrap();
         assert_eq!(bp, constants::ED25519_BASEPOINT_POINT);
     }
 

--- a/curve25519-dalek/src/montgomery.rs
+++ b/curve25519-dalek/src/montgomery.rs
@@ -537,17 +537,18 @@ mod test {
 
     #[test]
     #[cfg(feature = "serde")]
-    fn serde_bincode_basepoint_roundtrip() {
-        use bincode;
-
-        let encoded = bincode::serialize(&constants::X25519_BASEPOINT).unwrap();
-        let decoded: MontgomeryPoint = bincode::deserialize(&encoded).unwrap();
+    fn serde_postcard_basepoint_roundtrip() {
+        let encoded = postcard::to_allocvec(&constants::X25519_BASEPOINT).unwrap();
+        let decoded: MontgomeryPoint = postcard::from_bytes(&encoded).unwrap();
 
         assert_eq!(encoded.len(), 32);
         assert_eq!(decoded, constants::X25519_BASEPOINT);
 
+        // Check that the encoding itself matches the usual one.
+        // serde::Deserialize on fixed-size arrays calls tuple deserialization. postcard
+        // (de)serializes tuples by just doing each element and that's it.
         let raw_bytes = constants::X25519_BASEPOINT.as_bytes();
-        let bp: MontgomeryPoint = bincode::deserialize(raw_bytes).unwrap();
+        let bp: MontgomeryPoint = postcard::from_bytes(raw_bytes).unwrap();
         assert_eq!(bp, constants::X25519_BASEPOINT);
     }
 

--- a/curve25519-dalek/src/ristretto.rs
+++ b/curve25519-dalek/src/ristretto.rs
@@ -1282,26 +1282,26 @@ mod test {
 
     #[test]
     #[cfg(feature = "serde")]
-    fn serde_bincode_basepoint_roundtrip() {
-        use bincode;
-
-        let encoded = bincode::serialize(&constants::RISTRETTO_BASEPOINT_POINT).unwrap();
+    fn serde_postcard_basepoint_roundtrip() {
+        let encoded = postcard::to_allocvec(&constants::RISTRETTO_BASEPOINT_POINT).unwrap();
         let enc_compressed =
-            bincode::serialize(&constants::RISTRETTO_BASEPOINT_COMPRESSED).unwrap();
+            postcard::to_allocvec(&constants::RISTRETTO_BASEPOINT_COMPRESSED).unwrap();
         assert_eq!(encoded, enc_compressed);
 
         // Check that the encoding is 32 bytes exactly
         assert_eq!(encoded.len(), 32);
 
-        let dec_uncompressed: RistrettoPoint = bincode::deserialize(&encoded).unwrap();
-        let dec_compressed: CompressedRistretto = bincode::deserialize(&encoded).unwrap();
+        let dec_uncompressed: RistrettoPoint = postcard::from_bytes(&encoded).unwrap();
+        let dec_compressed: CompressedRistretto = postcard::from_bytes(&encoded).unwrap();
 
         assert_eq!(dec_uncompressed, constants::RISTRETTO_BASEPOINT_POINT);
         assert_eq!(dec_compressed, constants::RISTRETTO_BASEPOINT_COMPRESSED);
 
-        // Check that the encoding itself matches the usual one
+        // Check that the encoding itself matches the usual one.
+        // serde::Deserialize on fixed-size arrays calls tuple deserialization. postcard
+        // (de)serializes tuples by just doing each element and that's it.
         let raw_bytes = constants::RISTRETTO_BASEPOINT_COMPRESSED.as_bytes();
-        let bp: RistrettoPoint = bincode::deserialize(raw_bytes).unwrap();
+        let bp: RistrettoPoint = postcard::from_bytes(raw_bytes).unwrap();
         assert_eq!(bp, constants::RISTRETTO_BASEPOINT_POINT);
     }
 

--- a/curve25519-dalek/src/scalar.rs
+++ b/curve25519-dalek/src/scalar.rs
@@ -1862,17 +1862,18 @@ pub(crate) mod test {
 
     #[test]
     #[cfg(feature = "serde")]
-    fn serde_bincode_scalar_roundtrip() {
-        use bincode;
-        let encoded = bincode::serialize(&X).unwrap();
-        let parsed: Scalar = bincode::deserialize(&encoded).unwrap();
+    fn serde_postcard_scalar_roundtrip() {
+        let encoded = postcard::to_allocvec(&X).unwrap();
+        let parsed: Scalar = postcard::from_bytes(&encoded).unwrap();
         assert_eq!(parsed, X);
 
         // Check that the encoding is 32 bytes exactly
         assert_eq!(encoded.len(), 32);
 
-        // Check that the encoding itself matches the usual one
-        assert_eq!(X, bincode::deserialize(X.as_bytes()).unwrap(),);
+        // Check that the encoding itself matches the usual one.
+        // serde::Deserialize on fixed-size arrays calls tuple deserialization. postcard
+        // (de)serializes tuples by just doing each element and that's it.
+        assert_eq!(X, postcard::from_bytes(X.as_bytes()).unwrap(),);
     }
 
     #[cfg(debug_assertions)]

--- a/ed25519-dalek/Cargo.toml
+++ b/ed25519-dalek/Cargo.toml
@@ -56,7 +56,7 @@ chacha20 = { version = "0.10", default-features = false, features = ["rng"] }
 sha3 = "0.11"
 getrandom = { version = "0.4", features = ["sys_rng"] }
 hex = "0.4"
-bincode = "1.0"
+postcard = { version = "1", features = ["alloc"] }
 serde_json = "1.0"
 criterion = { version = "0.5", features = ["html_reports"] }
 hex-literal = "1"

--- a/ed25519-dalek/Cargo.toml
+++ b/ed25519-dalek/Cargo.toml
@@ -31,7 +31,7 @@ all-features = true
 curve25519-dalek = { version = "=5.0.0-pre.6", default-features = false, features = [
     "digest",
 ] }
-ed25519 = { version = "3.0.0-rc.5", default-features = false }
+ed25519 = { version = "3", default-features = false }
 signature = { version = "3", optional = true, default-features = false }
 sha2 = { version = "0.11", default-features = false }
 subtle = { version = "2.3.0", default-features = false }

--- a/ed25519-dalek/src/lib.rs
+++ b/ed25519-dalek/src/lib.rs
@@ -188,14 +188,14 @@
 //! ```
 //!
 //! They can be then serialised into any of the wire formats which serde supports.
-//! For example, using [bincode](https://github.com/TyOverby/bincode):
+//! For example, using [postcard](https://docs.rs/postcard):
 //!
 #![cfg_attr(all(feature = "rand_core", feature = "serde"), doc = "```")]
 #![cfg_attr(not(all(feature = "rand_core", feature = "serde")), doc = "```ignore")]
 //! # fn main() {
 //! # use getrandom::{SysRng, rand_core::{TryRng, UnwrapErr}};
 //! # use ed25519_dalek::{SigningKey, Signature, Signer, Verifier, VerifyingKey};
-//! use bincode::serialize;
+//! use postcard::to_allocvec;
 //! # let mut csprng = UnwrapErr(SysRng);
 //! # let signing_key: SigningKey = SigningKey::generate(&mut csprng);
 //! # let message: &[u8] = b"This is a test of the tsunami alert system.";
@@ -203,8 +203,8 @@
 //! # let verifying_key: VerifyingKey = signing_key.verifying_key();
 //! # let verified: bool = verifying_key.verify(message, &signature).is_ok();
 //!
-//! let encoded_verifying_key: Vec<u8> = serialize(&verifying_key).unwrap();
-//! let encoded_signature: Vec<u8> = serialize(&signature).unwrap();
+//! let encoded_verifying_key: Vec<u8> = to_allocvec(&verifying_key).unwrap();
+//! let encoded_signature: Vec<u8> = to_allocvec(&signature).unwrap();
 //! # }
 //! ```
 //!
@@ -216,8 +216,8 @@
 //! # fn main() {
 //! # use getrandom::{SysRng, rand_core::{TryRng, UnwrapErr}};
 //! # use ed25519_dalek::{SigningKey, Signature, Signer, Verifier, VerifyingKey};
-//! # use bincode::serialize;
-//! use bincode::deserialize;
+//! # use postcard::to_allocvec;
+//! use postcard::from_bytes;
 //!
 //! # let mut csprng = UnwrapErr(SysRng);
 //! # let signing_key: SigningKey = SigningKey::generate(&mut csprng);
@@ -225,10 +225,10 @@
 //! # let signature: Signature = signing_key.sign(message);
 //! # let verifying_key: VerifyingKey = signing_key.verifying_key();
 //! # let verified: bool = verifying_key.verify(message, &signature).is_ok();
-//! # let encoded_verifying_key: Vec<u8> = serialize(&verifying_key).unwrap();
-//! # let encoded_signature: Vec<u8> = serialize(&signature).unwrap();
-//! let decoded_verifying_key: VerifyingKey = deserialize(&encoded_verifying_key).unwrap();
-//! let decoded_signature: Signature = deserialize(&encoded_signature).unwrap();
+//! # let encoded_verifying_key: Vec<u8> = to_allocvec(&verifying_key).unwrap();
+//! # let encoded_signature: Vec<u8> = to_allocvec(&signature).unwrap();
+//! let decoded_verifying_key: VerifyingKey = from_bytes(&encoded_verifying_key).unwrap();
+//! let decoded_signature: Signature = from_bytes(&encoded_signature).unwrap();
 //!
 //! # assert_eq!(verifying_key, decoded_verifying_key);
 //! # assert_eq!(signature, decoded_signature);

--- a/ed25519-dalek/tests/ed25519.rs
+++ b/ed25519-dalek/tests/ed25519.rs
@@ -547,8 +547,10 @@ mod serialisation {
 
     use super::*;
 
-    // The size for bincode to serialize the length of a byte array.
-    static BINCODE_INT_LENGTH: usize = 8;
+    // The minimum number of bytes needed for postcard to encode a length prefix for a sequence. We
+    // only want to serialize secret keys, signatures, and (compressed) public keys, all of which
+    // are less than 128 bytes in length. So the initial `varint(usize)` will only take 1 byte.
+    static POSTCARD_MIN_LEN_SIZE: usize = 1;
 
     static PUBLIC_KEY_BYTES: [u8; PUBLIC_KEY_LENGTH] = [
         130, 039, 155, 015, 062, 076, 188, 063, 124, 122, 026, 251, 233, 253, 225, 220, 014, 041,
@@ -569,10 +571,10 @@ mod serialisation {
     ];
 
     #[test]
-    fn serialize_deserialize_signature_bincode() {
+    fn serialize_deserialize_signature_postcard() {
         let signature: Signature = Signature::from_bytes(&SIGNATURE_BYTES);
-        let encoded_signature: Vec<u8> = bincode::serialize(&signature).unwrap();
-        let decoded_signature: Signature = bincode::deserialize(&encoded_signature).unwrap();
+        let encoded_signature: Vec<u8> = postcard::to_allocvec(&signature).unwrap();
+        let decoded_signature: Signature = postcard::from_bytes(&encoded_signature).unwrap();
 
         assert_eq!(signature, decoded_signature);
     }
@@ -587,11 +589,11 @@ mod serialisation {
     }
 
     #[test]
-    fn serialize_deserialize_verifying_key_bincode() {
+    fn serialize_deserialize_verifying_key_postcard() {
         let verifying_key: VerifyingKey = VerifyingKey::from_bytes(&PUBLIC_KEY_BYTES).unwrap();
-        let encoded_verifying_key: Vec<u8> = bincode::serialize(&verifying_key).unwrap();
+        let encoded_verifying_key: Vec<u8> = postcard::to_allocvec(&verifying_key).unwrap();
         let decoded_verifying_key: VerifyingKey =
-            bincode::deserialize(&encoded_verifying_key).unwrap();
+            postcard::from_bytes(&encoded_verifying_key).unwrap();
 
         assert_eq!(
             &PUBLIC_KEY_BYTES[..],
@@ -638,10 +640,10 @@ mod serialisation {
     }
 
     #[test]
-    fn serialize_deserialize_signing_key_bincode() {
+    fn serialize_deserialize_signing_key_postcard() {
         let signing_key = SigningKey::from_bytes(&SECRET_KEY_BYTES);
-        let encoded_signing_key: Vec<u8> = bincode::serialize(&signing_key).unwrap();
-        let decoded_signing_key: SigningKey = bincode::deserialize(&encoded_signing_key).unwrap();
+        let encoded_signing_key: Vec<u8> = postcard::to_allocvec(&signing_key).unwrap();
+        let decoded_signing_key: SigningKey = postcard::from_bytes(&encoded_signing_key).unwrap();
 
         #[allow(clippy::needless_range_loop)]
         for i in 0..SECRET_KEY_LENGTH {
@@ -705,8 +707,8 @@ mod serialisation {
     fn serialize_verifying_key_size() {
         let verifying_key: VerifyingKey = VerifyingKey::from_bytes(&PUBLIC_KEY_BYTES).unwrap();
         assert_eq!(
-            bincode::serialized_size(&verifying_key).unwrap() as usize,
-            BINCODE_INT_LENGTH + PUBLIC_KEY_LENGTH
+            postcard::to_allocvec(&verifying_key).unwrap().len(),
+            POSTCARD_MIN_LEN_SIZE + PUBLIC_KEY_LENGTH
         );
     }
 
@@ -714,8 +716,8 @@ mod serialisation {
     fn serialize_signature_size() {
         let signature: Signature = Signature::from_bytes(&SIGNATURE_BYTES);
         assert_eq!(
-            bincode::serialized_size(&signature).unwrap() as usize,
-            SIGNATURE_LENGTH
+            postcard::to_allocvec(&signature).unwrap().len(),
+            POSTCARD_MIN_LEN_SIZE + SIGNATURE_LENGTH
         );
     }
 
@@ -723,8 +725,8 @@ mod serialisation {
     fn serialize_signing_key_size() {
         let signing_key = SigningKey::from_bytes(&SECRET_KEY_BYTES);
         assert_eq!(
-            bincode::serialized_size(&signing_key).unwrap() as usize,
-            BINCODE_INT_LENGTH + SECRET_KEY_LENGTH
+            postcard::to_allocvec(&signing_key).unwrap().len(),
+            POSTCARD_MIN_LEN_SIZE + SECRET_KEY_LENGTH
         );
     }
 }

--- a/ed25519-dalek/tests/ed25519.rs
+++ b/ed25519-dalek/tests/ed25519.rs
@@ -549,7 +549,9 @@ mod serialisation {
 
     // The minimum number of bytes needed for postcard to encode a length prefix for a sequence. We
     // only want to serialize secret keys, signatures, and (compressed) public keys, all of which
-    // are less than 128 bytes in length. So the initial `varint(usize)` will only take 1 byte.
+    // have a `Serialize` impl that calls `serialize_bytes` (which serializes a seq, in postcard
+    // parlance) on the byte representation.  Since all of these have a byte representation of
+    // length <128, the initial `varint(usize)` will be precisely 1 byte for all of them.
     static POSTCARD_MIN_LEN_SIZE: usize = 1;
 
     static PUBLIC_KEY_BYTES: [u8; PUBLIC_KEY_LENGTH] = [

--- a/x25519-dalek/Cargo.toml
+++ b/x25519-dalek/Cargo.toml
@@ -51,7 +51,7 @@ serde = { version = "1", default-features = false, optional = true, features = [
 zeroize = { version = "1", default-features = false, optional = true }
 
 [dev-dependencies]
-bincode = "1"
+postcard = { version = "1", features = ["alloc"] }
 criterion = "0.5"
 getrandom = { version = "0.4", features = ["sys_rng"] }
 

--- a/x25519-dalek/tests/x25519_tests.rs
+++ b/x25519-dalek/tests/x25519_tests.rs
@@ -20,13 +20,11 @@ fn byte_basepoint_matches_edwards_scalar_mul() {
 
 #[test]
 #[cfg(feature = "serde")]
-fn serde_bincode_public_key_roundtrip() {
-    use bincode;
-
+fn serde_postcard_public_key_roundtrip() {
     let public_key = PublicKey::from(X25519_BASEPOINT_BYTES);
 
-    let encoded = bincode::serialize(&public_key).unwrap();
-    let decoded: PublicKey = bincode::deserialize(&encoded).unwrap();
+    let encoded = postcard::to_allocvec(&public_key).unwrap();
+    let decoded: PublicKey = postcard::from_bytes(&encoded).unwrap();
 
     assert_eq!(encoded.len(), 32);
     assert_eq!(decoded.as_bytes(), public_key.as_bytes());
@@ -34,23 +32,19 @@ fn serde_bincode_public_key_roundtrip() {
 
 #[test]
 #[cfg(feature = "serde")]
-fn serde_bincode_public_key_matches_from_bytes() {
-    use bincode;
-
+fn serde_postcard_public_key_matches_from_bytes() {
     let expected = PublicKey::from(X25519_BASEPOINT_BYTES);
-    let decoded: PublicKey = bincode::deserialize(&X25519_BASEPOINT_BYTES).unwrap();
+    let decoded: PublicKey = postcard::from_bytes(&X25519_BASEPOINT_BYTES).unwrap();
 
     assert_eq!(decoded.as_bytes(), expected.as_bytes());
 }
 
 #[test]
 #[cfg(feature = "serde")]
-fn serde_bincode_static_secret_roundtrip() {
-    use bincode;
-
+fn serde_postcard_static_secret_roundtrip() {
     let static_secret = StaticSecret::from([0x24; 32]);
-    let encoded = bincode::serialize(&static_secret).unwrap();
-    let decoded: StaticSecret = bincode::deserialize(&encoded).unwrap();
+    let encoded = postcard::to_allocvec(&static_secret).unwrap();
+    let decoded: StaticSecret = postcard::from_bytes(&encoded).unwrap();
 
     assert_eq!(encoded.len(), 32);
     assert_eq!(decoded.to_bytes(), static_secret.to_bytes());
@@ -58,11 +52,9 @@ fn serde_bincode_static_secret_roundtrip() {
 
 #[test]
 #[cfg(feature = "serde")]
-fn serde_bincode_static_secret_matches_from_bytes() {
-    use bincode;
-
+fn serde_postcard_static_secret_matches_from_bytes() {
     let expected = StaticSecret::from([0x24; 32]);
-    let decoded: StaticSecret = bincode::deserialize(&[0x24; 32]).unwrap();
+    let decoded: StaticSecret = postcard::from_bytes(&[0x24; 32]).unwrap();
 
     assert_eq!(decoded.to_bytes(), expected.to_bytes());
 }


### PR DESCRIPTION
This has two test failures:

    serialisation::serialize_deserialize_signature_json
    serialisation::serialize_signature_size

These are due to a last minute change to use `serdect` for implementing `serde` support: RustCrypto/signatures#1324.

The signature size regression from `64` to `72` is a deliberate tradeoff we've accepted in `serdect`. First note that this test is for now the unmaintained `bincode` crate.

The core problem is that `serde` does not actually provide fixed-size arrays as a type within its data model (serde-rs/serde#1937) and you're instead left faking it using `SerializeTuple` and serializing it a byte-at-a-time as a tuple. While this gives optimal-sized results on `bincode`, it gives less-than-optimal results on e.g. `rmp-serde` where the bytes each end up tagged with a type prefix.

`serde` does provide portable APIs for using optimal format-specific byte encodings, but they carry an additional length prefix, which is unnecessary and suboptimal for something fixed-width like an Ed25519 signature, but alas as noted earlier `serde` does not actually have fixed-width arrays in its data model.

The second test failure occurs specifically because `serdect` introspects the format and uses `base16ct` to perform hex serialization for human readable formats. While this is a readability improvement for these formats (and also makes them easier to implement in constant-time, though it's not relevant here), the drawback is it currently requires the `alloc` feature for such formats, which is a regression:

    Error("serializer is human readable, which requires the `alloc` crate feature", line: 0, column: 0)

Note that regardless these are both breaking changes to how `serde` serialization is handled.

Edit: added reference below to `serde_bytes` which was also removed, but could potentially be added back to address some of the issues outlined here. I would be curious to know the use cases where it helps though.

See also:
- RustCrypto/formats#1111
- RustCrypto/formats#1112
- dalek-cryptography/ed25519-dalek#140
- dalek-cryptography/ed25519-dalek#146