### PR TITLE
Prep v5.0-rc.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,7 +305,7 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "5.0.0"
+version = "5.0.0-rc.0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "3.0.0"
+version = "3.0.0-rc.0"
 dependencies = [
  "blake2",
  "chacha20",
@@ -1466,7 +1466,7 @@ dependencies = [
 
 [[package]]
 name = "x25519-dalek"
-version = "3.0.0"
+version = "3.0.0-rc.0"
 dependencies = [
  "criterion",
  "curve25519-dalek",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,7 +305,7 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "5.0.0-pre.6"
+version = "5.0.0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "3.0.0-pre.6"
+version = "3.0.0"
 dependencies = [
  "blake2",
  "chacha20",
@@ -1466,7 +1466,7 @@ dependencies = [
 
 [[package]]
 name = "x25519-dalek"
-version = "3.0.0-pre.6"
+version = "3.0.0"
 dependencies = [
  "criterion",
  "curve25519-dalek",

--- a/curve25519-dalek/CHANGELOG.md
+++ b/curve25519-dalek/CHANGELOG.md
@@ -5,7 +5,7 @@ major series.
 
 ## 5.x series
 
-### 5.0.0-rc.0 - 2026-05-25
+### 5.0.0-rc.0 - 2026-05-28
 
 * Remove `ff` and `group` features until they have a release ([#907](https://github.com/dalek-cryptography/curve25519-dalek/pull/907))
 * Perf: Use maximum available NAF window size in `VartimePrecomputedStraus` ([#848](https://github.com/dalek-cryptography/curve25519-dalek/pull/848))

--- a/curve25519-dalek/CHANGELOG.md
+++ b/curve25519-dalek/CHANGELOG.md
@@ -5,7 +5,7 @@ major series.
 
 ## 5.x series
 
-### 5.0.0 - 2026-05-24
+### 5.0.0-rc.0 - 2026-05-24
 
 * Remove `ff` and `group` features until they have a release
 * Upgrade `rand_core` dependency to v0.10.0

--- a/curve25519-dalek/CHANGELOG.md
+++ b/curve25519-dalek/CHANGELOG.md
@@ -5,34 +5,17 @@ major series.
 
 ## 5.x series
 
-## 5.0.0-pre.6
+### 5.0.0 - 2026-05-24
 
+* Remove `ff` and `group` features until they have a release
 * Upgrade `rand_core` dependency to v0.10.0
 * Upgrade `digest` and `sha2` deps
-
-## 5.0.0-pre.5
-
-* Upgrade `rand_core` dependency to v0.10.0-rc-6
-
-## 5.0.0-pre.4
-
 * Add allocation-free `EdwardsPoint::compress_batch()`
 * Perf: Use maximum available NAF window size in `VartimePrecomputedStraus`
-* Upgrade `rand_core` dependency to v0.10.0-rc-3
-
-## 5.0.0-pre.3
-
 * Add Lizard bytes-to-point injection for Ristretto. Gated under `lizard` feature.
-* Upgrade `rand_core` dependency to v0.10.0-rc-2
-
-## 5.0.0-pre.1
-
 * Rename `Scalar::batch_invert` -> `Scalar::invert_batch` for consistency. Also make it no-alloc.
 * Add an allocating batch inversion called `Scalar::invert_batch_alloc`.
 * Add `Scalar::div_by_2`
-
-## 5.0.0-pre.0
-
 * Update edition to 2024
 * Update the MSRV from 1.60 to 1.85
 * Remove deprecated functions `FieldElement::as_bytes()` and `EdwardsPoint::nonspec_map_to_curve()`
@@ -41,7 +24,7 @@ major series.
 
 ## 4.x series
 
-### 4.2.0 [YANKED]
+### 4.2.0 [YANKED] - 2025-07-08
 
 NOTE: yanked because `hash_to_curve` was improperly implemented (#785)
 
@@ -52,7 +35,7 @@ NOTE: yanked because `hash_to_curve` was improperly implemented (#785)
 * Add batch conversion function `EdwardsPoint::to_montgomery_batch()`
 * Make `VartimePrecomputedStraus::optional_mixed_multiscalar_mul()` and `VartimeRistrettoPrecomputation::vartime_mixed_multiscalar_mul()` accept more points than static scalars
 
-### 4.1.3
+### 4.1.3 - 2024-06-18
 
 * Security: Fix timing leak in Scalar subtraction on u32, u64, fiat_u32, and fiat_u64 backends
 * Fix assorted new warnings and lints from rustc and clippy

--- a/curve25519-dalek/CHANGELOG.md
+++ b/curve25519-dalek/CHANGELOG.md
@@ -5,22 +5,22 @@ major series.
 
 ## 5.x series
 
-### 5.0.0-rc.0 - 2026-05-24
+### 5.0.0-rc.0 - 2026-05-25
 
-* Remove `ff` and `group` features until they have a release
+* Remove `ff` and `group` features until they have a release ([#907](https://github.com/dalek-cryptography/curve25519-dalek/pull/907))
+* Perf: Use maximum available NAF window size in `VartimePrecomputedStraus` ([#848](https://github.com/dalek-cryptography/curve25519-dalek/pull/848))
+* Add Lizard bytes-to-point injection for Ristretto. Gated under `lizard` feature. ([#826](https://github.com/dalek-cryptography/curve25519-dalek/pull/826))
+* Rename `Scalar::batch_invert` -> `Scalar::invert_batch` for consistency. Also make it no-alloc. ([#789](https://github.com/dalek-cryptography/curve25519-dalek/pull/789))
+* Add an allocating batch inversion called `Scalar::invert_batch_alloc` ([#789](https://github.com/dalek-cryptography/curve25519-dalek/pull/789))
+* Add `Scalar::div_by_2` ([#805](https://github.com/dalek-cryptography/curve25519-dalek/pull/805))
+* Add `EdwardsPoint::hash_to_curve` ([#786](https://github.com/dalek-cryptography/curve25519-dalek/pull/786))
+* Undeprecate `Scalar::from_bits()`
+* Remove deprecated functions `FieldElement::as_bytes()` and `EdwardsPoint::nonspec_map_to_curve()`
 * Upgrade `rand_core` dependency to v0.10.0
 * Upgrade `digest` and `sha2` deps
-* Add allocation-free `EdwardsPoint::compress_batch()`
-* Perf: Use maximum available NAF window size in `VartimePrecomputedStraus`
-* Add Lizard bytes-to-point injection for Ristretto. Gated under `lizard` feature.
-* Rename `Scalar::batch_invert` -> `Scalar::invert_batch` for consistency. Also make it no-alloc.
-* Add an allocating batch inversion called `Scalar::invert_batch_alloc`.
-* Add `Scalar::div_by_2`
 * Update edition to 2024
 * Update the MSRV from 1.60 to 1.85
-* Remove deprecated functions `FieldElement::as_bytes()` and `EdwardsPoint::nonspec_map_to_curve()`
 * Use constant-time equality testing for compressed Ristretto and Edwards points, rather than autoderived equality
-* Undeprecate `Scalar::from_bits()`
 
 ## 4.x series
 

--- a/curve25519-dalek/Cargo.toml
+++ b/curve25519-dalek/Cargo.toml
@@ -3,7 +3,7 @@ name = "curve25519-dalek"
 # Before incrementing:
 # - update CHANGELOG
 # - update README if required by semver
-version = "5.0.0"
+version = "5.0.0-rc.0"
 edition = "2024"
 rust-version = "1.85.0"
 authors = [

--- a/curve25519-dalek/Cargo.toml
+++ b/curve25519-dalek/Cargo.toml
@@ -3,7 +3,7 @@ name = "curve25519-dalek"
 # Before incrementing:
 # - update CHANGELOG
 # - update README if required by semver
-version = "5.0.0-pre.6"
+version = "5.0.0"
 edition = "2024"
 rust-version = "1.85.0"
 authors = [

--- a/curve25519-dalek/README.md
+++ b/curve25519-dalek/README.md
@@ -30,12 +30,10 @@ cofactor-related abstraction mismatches.
 
 # Use
 
-## Stable
-
 To import `curve25519-dalek`, add the following to the dependencies section of
 your project's `Cargo.toml`:
 ```toml
-curve25519-dalek = "5"
+curve25519-dalek = "5.0.0-rc.0"
 ```
 
 If opting into [SemVer-exempted features](#public-api-semver-exemptions) a range
@@ -74,6 +72,7 @@ latest breaking changes in high level are below:
 * Remove deprecated functions `FieldElement::as_bytes()` and `EdwardsPoint::nonspec_map_to_curve()`
 * Use constant-time equality testing for compressed Ristretto and Edwards points, rather than autoderived equality
 * Undeprecate `Scalar::from_bits()`
+* Remove `group` and `group-bits` features temporarily. Will reinstate once the underlying deps have a release.
 
 # Backends
 

--- a/curve25519-dalek/README.md
+++ b/curve25519-dalek/README.md
@@ -35,7 +35,7 @@ cofactor-related abstraction mismatches.
 To import `curve25519-dalek`, add the following to the dependencies section of
 your project's `Cargo.toml`:
 ```toml
-curve25519-dalek = "5.0.0-pre.6"
+curve25519-dalek = "5"
 ```
 
 If opting into [SemVer-exempted features](#public-api-semver-exemptions) a range

--- a/curve25519-dalek/src/lizard/lizard_ristretto.rs
+++ b/curve25519-dalek/src/lizard/lizard_ristretto.rs
@@ -70,8 +70,11 @@ impl RistrettoPoint {
         if n_found == 1 { Some(result) } else { None }
     }
 
-    /// Computes the at most 8 positive FieldElements f such that `self ==
+    /// Computes the at most 16 FieldElements f such that `self ==
     /// RistrettoPoint::elligator_ristretto_flavor(f)`.
+    /// The first 8 return values are positive field elements (i.e., have the LSB (`bytes[0] & 1`)
+    /// unset), if defined. The last 8 return values are negative field elements (i.e., have the LSB
+    /// set), if defined.
     fn elligator_ristretto_flavor_inverse(&self) -> [CtOption<FieldElement>; 16] {
         // Elligator2 computes a Point from a FieldElement in two steps: first
         // it computes a (s,t) on the Jacobi quartic and then computes the

--- a/ed25519-dalek/CHANGELOG.md
+++ b/ed25519-dalek/CHANGELOG.md
@@ -8,7 +8,7 @@ Entries are listed in reverse chronological order per undeprecated major series.
 
 # 3.x series
 
-## 3.0.0 - 2026-05-24
+## 3.0.0-rc.0 - 2026-05-24
 
 * Upgrade `ed25519` dependency to v3.0.0
 * Upgrade `signature` dependency to v3.0.0

--- a/ed25519-dalek/CHANGELOG.md
+++ b/ed25519-dalek/CHANGELOG.md
@@ -8,7 +8,7 @@ Entries are listed in reverse chronological order per undeprecated major series.
 
 # 3.x series
 
-## 3.0.0-pre.7
+## 3.0.0 - 2026-05-24
 
 * Upgrade `ed25519` dependency to v3.0.0
 * Upgrade `signature` dependency to v3.0.0
@@ -16,40 +16,21 @@ Entries are listed in reverse chronological order per undeprecated major series.
 * Upgrade `getrandom` dependency to v0.4
 * Upgrade `chacha20` dependency to v0.10
 * Add `strobe-rs` dependency and delete vendored STROBE impl
-
-## 3.0.0-pre.6
-
 * Upgrade `rand_core` dependency to v0.10.0
 * Upgrade `digest` and `sha2` deps
-
-## 3.0.0-pre.5
-
-* Upgrade `rand_core` dependency to v0.10.0-rc-6
-
-## 3.0.0-pre.4
-
-* Upgrade `rand_core` dependency to v0.10.0-rc-3
-
-## 3.0.0-pre.3
-
-* Upgrade `rand_core` dependency to v0.10.0-rc-2
-
-## 3.0.0-pre.0
-
 * Update edition to 2024
 * Update the MSRV from 1.60 to 1.85
-* Update `ed25519` and `signature` deps
 * Remove `std` feature
 * Make signing and verifying keys use `pkcs8::spki::SignatureAlgorithmIdentifier` instead of `DynSignatureAlgorithmIdentifier`
 
 # 2.x series
 
-## 2.2.0
+## 2.2.0 - 2025-07-08
 
 * Add `hazmat`-gated methods `SigningKey::verify_stream()` and `VerifyingKey::verify_stream()`
 * Add `Debug` and `Eq` traits for `hazmat::ExpandedSecretKey`
 
-## 2.1.1
+## 2.1.1 - 2024-02-06
 
 * Fix nightly SIMD build
 

--- a/ed25519-dalek/CHANGELOG.md
+++ b/ed25519-dalek/CHANGELOG.md
@@ -8,7 +8,7 @@ Entries are listed in reverse chronological order per undeprecated major series.
 
 # 3.x series
 
-## 3.0.0-rc.0 - 2026-05-25
+## 3.0.0-rc.0 - 2026-05-28
 
 * Add allocation-free `EdwardsPoint::compress_batch` ([#832](https://github.com/dalek-cryptography/curve25519-dalek/pull/832))
 * Add `strobe-rs` dependency and delete vendored STROBE impl ([#895](https://github.com/dalek-cryptography/curve25519-dalek/pull/895))

--- a/ed25519-dalek/CHANGELOG.md
+++ b/ed25519-dalek/CHANGELOG.md
@@ -8,20 +8,21 @@ Entries are listed in reverse chronological order per undeprecated major series.
 
 # 3.x series
 
-## 3.0.0-rc.0 - 2026-05-24
+## 3.0.0-rc.0 - 2026-05-25
 
+* Add allocation-free `EdwardsPoint::compress_batch` ([#832](https://github.com/dalek-cryptography/curve25519-dalek/pull/832))
+* Add `strobe-rs` dependency and delete vendored STROBE impl ([#895](https://github.com/dalek-cryptography/curve25519-dalek/pull/895))
+* Make signing and verifying keys use `pkcs8::spki::SignatureAlgorithmIdentifier` instead of `DynSignatureAlgorithmIdentifier` ([#779](https://github.com/dalek-cryptography/curve25519-dalek/pull/779))
+* Impl `MultipartSigner` and `MultipartVerifier` for `SigningKey` and `VerifyingKey` ([#764](https://github.com/dalek-cryptography/curve25519-dalek/pull/764))
 * Upgrade `ed25519` dependency to v3.0.0
 * Upgrade `signature` dependency to v3.0.0
-* Upgrade `sha3` dependency to v0.11
+* Upgrade `sha2` and `sha3` dependencies to v0.11
 * Upgrade `getrandom` dependency to v0.4
 * Upgrade `chacha20` dependency to v0.10
-* Add `strobe-rs` dependency and delete vendored STROBE impl
 * Upgrade `rand_core` dependency to v0.10.0
-* Upgrade `digest` and `sha2` deps
 * Update edition to 2024
 * Update the MSRV from 1.60 to 1.85
-* Remove `std` feature
-* Make signing and verifying keys use `pkcs8::spki::SignatureAlgorithmIdentifier` instead of `DynSignatureAlgorithmIdentifier`
+* Remove `std` feature now that `error::Error` is in `core`
 
 # 2.x series
 

--- a/ed25519-dalek/Cargo.toml
+++ b/ed25519-dalek/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ed25519-dalek"
-version = "3.0.0"
+version = "3.0.0-rc.0"
 edition = "2024"
 authors = [
     "isis lovecruft <isis@patternsinthevoid.net>",
@@ -28,7 +28,7 @@ rustdoc-args = [
 all-features = true
 
 [dependencies]
-curve25519-dalek = { version = "5", default-features = false, features = [
+curve25519-dalek = { version = "5.0.0-rc.0", default-features = false, features = [
     "digest",
 ] }
 ed25519 = { version = "3", default-features = false }
@@ -44,11 +44,11 @@ zeroize = { version = "1.5", default-features = false, optional = true }
 strobe-rs = { version = "0.13", optional = true }
 
 [dev-dependencies]
-curve25519-dalek = { version = "5", default-features = false, features = [
+curve25519-dalek = { version = "5.0.0-rc.0", default-features = false, features = [
     "digest",
     "rand_core",
 ] }
-x25519-dalek = { version = "3", default-features = false, features = [
+x25519-dalek = { version = "3.0.0-rc.0", default-features = false, features = [
     "static_secrets",
 ] }
 blake2 = "0.11.0-rc.6"

--- a/ed25519-dalek/Cargo.toml
+++ b/ed25519-dalek/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ed25519-dalek"
-version = "3.0.0-pre.7"
+version = "3.0.0"
 edition = "2024"
 authors = [
     "isis lovecruft <isis@patternsinthevoid.net>",
@@ -28,7 +28,7 @@ rustdoc-args = [
 all-features = true
 
 [dependencies]
-curve25519-dalek = { version = "=5.0.0-pre.6", default-features = false, features = [
+curve25519-dalek = { version = "5", default-features = false, features = [
     "digest",
 ] }
 ed25519 = { version = "3", default-features = false }
@@ -44,11 +44,11 @@ zeroize = { version = "1.5", default-features = false, optional = true }
 strobe-rs = { version = "0.13", optional = true }
 
 [dev-dependencies]
-curve25519-dalek = { version = "=5.0.0-pre.6", default-features = false, features = [
+curve25519-dalek = { version = "5", default-features = false, features = [
     "digest",
     "rand_core",
 ] }
-x25519-dalek = { version = "=3.0.0-pre.6", default-features = false, features = [
+x25519-dalek = { version = "3", default-features = false, features = [
     "static_secrets",
 ] }
 blake2 = "0.11.0-rc.6"

--- a/ed25519-dalek/README.md
+++ b/ed25519-dalek/README.md
@@ -8,7 +8,7 @@ verification.
 To import `ed25519-dalek`, add the following to the dependencies section of
 your project's `Cargo.toml`:
 ```toml
-ed25519-dalek = "3.0.0-pre.7"
+ed25519-dalek = "3"
 ```
 
 # Feature Flags

--- a/ed25519-dalek/README.md
+++ b/ed25519-dalek/README.md
@@ -8,7 +8,7 @@ verification.
 To import `ed25519-dalek`, add the following to the dependencies section of
 your project's `Cargo.toml`:
 ```toml
-ed25519-dalek = "3"
+ed25519-dalek = "3.0.0-rc.0"
 ```
 
 # Feature Flags

--- a/x25519-dalek/CHANGELOG.md
+++ b/x25519-dalek/CHANGELOG.md
@@ -4,7 +4,7 @@ Entries are listed in reverse chronological order.
 
 # 3.x Series
 
-## 3.0.0-rc.0 - 2026-05-25
+## 3.0.0-rc.0 - 2026-05-28
 
 * Remove `alloc` feature flag, which was doing nothing
 * Update edition to 2024

--- a/x25519-dalek/CHANGELOG.md
+++ b/x25519-dalek/CHANGELOG.md
@@ -4,28 +4,12 @@ Entries are listed in reverse chronological order.
 
 # 3.x Series
 
-## 3.0.0-pre.6
+## 3.0.0 - 2026-05-24
 
 * Upgrade `rand_core` dependency to v0.10.0
-
-## 3.0.0-pre.5
-
-* Upgrade `rand_core` dependency to v0.10.0-rc-6
-
-## 3.0.0-pre.4
-
 * Removed `alloc` feature flag, which was doing nothing
-* Upgrade `rand_core` dependency to v0.10.0-rc-3
-
-## 3.0.0-pre.3
-
-* Upgrade `rand_core` dependency to v0.10.0-rc-2
-
-## 3.0.0-pre.0
-
 * Update edition to 2024
 * Update the MSRV from 1.60 to 1.85
-* Update `rand_core` dep
 * Remove `Zeroize` impl for `x25519::{EphemeralSecret, ReusableSecret, SharedSecret, StaticSecret}` to prevent misuse. These are now only zeroized on drop.
 * Remove deprecated functions `{Ephemeral,Reusable,Static}Secret::new()`
 
@@ -33,7 +17,7 @@ Entries are listed in reverse chronological order.
 
 * Note: All `x255919-dalek` 2.x releases are in sync with the underlying `curve25519-dalek` 4.x releases.
 
-## 2.0.1
+## 2.0.1 - 2024-02-06
 
 * Fix nightly SIMD build
 

--- a/x25519-dalek/CHANGELOG.md
+++ b/x25519-dalek/CHANGELOG.md
@@ -4,7 +4,7 @@ Entries are listed in reverse chronological order.
 
 # 3.x Series
 
-## 3.0.0 - 2026-05-24
+## 3.0.0-rc.0 - 2026-05-24
 
 * Upgrade `rand_core` dependency to v0.10.0
 * Removed `alloc` feature flag, which was doing nothing

--- a/x25519-dalek/CHANGELOG.md
+++ b/x25519-dalek/CHANGELOG.md
@@ -4,14 +4,14 @@ Entries are listed in reverse chronological order.
 
 # 3.x Series
 
-## 3.0.0-rc.0 - 2026-05-24
+## 3.0.0-rc.0 - 2026-05-25
 
-* Upgrade `rand_core` dependency to v0.10.0
-* Removed `alloc` feature flag, which was doing nothing
+* Remove `alloc` feature flag, which was doing nothing
 * Update edition to 2024
 * Update the MSRV from 1.60 to 1.85
 * Remove `Zeroize` impl for `x25519::{EphemeralSecret, ReusableSecret, SharedSecret, StaticSecret}` to prevent misuse. These are now only zeroized on drop.
 * Remove deprecated functions `{Ephemeral,Reusable,Static}Secret::new()`
+* Upgrade `rand_core` dependency to v0.10.0
 
 # 2.x Series
 

--- a/x25519-dalek/Cargo.toml
+++ b/x25519-dalek/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 # - update html_root_url
 # - update CHANGELOG
 # - if any changes were made to README.md, mirror them in src/lib.rs docs
-version = "3.0.0"
+version = "3.0.0-rc.0"
 authors = [
     "Isis Lovecruft <isis@patternsinthevoid.net>",
     "DebugSteven <debugsteven@gmail.com>",
@@ -42,7 +42,7 @@ rustdoc-args = [
 all-features = true
 
 [dependencies]
-curve25519-dalek = { version = "5", default-features = false }
+curve25519-dalek = { version = "5.0.0-rc.0", default-features = false }
 rand_core = { version = "0.10", default-features = false }
 
 # optional dependencies

--- a/x25519-dalek/Cargo.toml
+++ b/x25519-dalek/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 # - update html_root_url
 # - update CHANGELOG
 # - if any changes were made to README.md, mirror them in src/lib.rs docs
-version = "3.0.0-pre.6"
+version = "3.0.0"
 authors = [
     "Isis Lovecruft <isis@patternsinthevoid.net>",
     "DebugSteven <debugsteven@gmail.com>",
@@ -42,7 +42,7 @@ rustdoc-args = [
 all-features = true
 
 [dependencies]
-curve25519-dalek = { version = "=5.0.0-pre.6", default-features = false }
+curve25519-dalek = { version = "5", default-features = false }
 rand_core = { version = "0.10", default-features = false }
 
 # optional dependencies

--- a/x25519-dalek/README.md
+++ b/x25519-dalek/README.md
@@ -103,7 +103,7 @@ To import `x25519-dalek`, add the following to your project's `Cargo.toml`:
 
 ```toml
 [dependencies]
-x25519-dalek = "3.0.0-pre.6"
+x25519-dalek = "3"
 ```
 
 # Feature Flags

--- a/x25519-dalek/README.md
+++ b/x25519-dalek/README.md
@@ -103,7 +103,7 @@ To import `x25519-dalek`, add the following to your project's `Cargo.toml`:
 
 ```toml
 [dependencies]
-x25519-dalek = "3"
+x25519-dalek = "3.0.0-rc.0"
 ```
 
 # Feature Flags


### PR DESCRIPTION
Per discussion, I've commented out all the parts of the crate that rely on `ff` and `groups`. Both those deps have been at a release-candidate stage for a while, and we want to do a proper dalek release. So we decided for v5.0 we would just remove the code that relies on those deps, and add the code back in v5.1 once the deps got a release.

I'll be adding the corresponding updates to the remaining crates soon.