### PR TITLE
curve: Bring back `ff` and `group`

### DIFF
--- a/.github/workflows/curve25519-dalek.yml
+++ b/.github/workflows/curve25519-dalek.yml
@@ -127,7 +127,7 @@ jobs:
         # This should automatically pick up the simd backend in a x86_64 runner
         # It should pick AVX2 due to stable toolchain used since AVX512 requires nigthly
         RUSTFLAGS: '-C target_feature=+avx2'
-      run: cargo test --no-default-features --features alloc,precomputed-tables,zeroize --target x86_64-unknown-linux-gnu
+      run: cargo test --no-default-features --features alloc,precomputed-tables,zeroize,group-bits --target x86_64-unknown-linux-gnu
 
   msrv:
     name: Current MSRV is 1.85.0

--- a/.github/workflows/curve25519-dalek.yml
+++ b/.github/workflows/curve25519-dalek.yml
@@ -127,7 +127,7 @@ jobs:
         # This should automatically pick up the simd backend in a x86_64 runner
         # It should pick AVX2 due to stable toolchain used since AVX512 requires nigthly
         RUSTFLAGS: '-C target_feature=+avx2'
-      run: cargo test --no-default-features --features alloc,precomputed-tables,zeroize,group-bits --target x86_64-unknown-linux-gnu
+      run: cargo test --no-default-features --features alloc,precomputed-tables,zeroize,group --target x86_64-unknown-linux-gnu
 
   msrv:
     name: Current MSRV is 1.85.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 4
 
 [[package]]
+name = "addchain"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2e69442aa5628ea6951fa33e24efe8313f4321a91bd729fc2f75bdfc858570"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -76,6 +87,18 @@ name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
 
 [[package]]
 name = "blake2"
@@ -319,6 +342,8 @@ dependencies = [
  "proptest",
  "rand_core 0.10.0",
  "rustc_version",
+ "rustcrypto-ff",
+ "rustcrypto-group",
  "serde",
  "sha2",
  "subtle",
@@ -331,7 +356,7 @@ version = "0.1.1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -452,6 +477,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "getrandom"
@@ -665,6 +696,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
+name = "num-bigint"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6f7833f2cbf2360a6cfd58cd41a53aa7a90bd4c202f5b1c7dd2ed73c57b2c3"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -761,7 +812,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -812,6 +863,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -916,6 +973,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustcrypto-ff"
+version = "0.14.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd2a8adb347447693cd2ba0d218c4b66c62da9b0a5672b17b981e4291ec65ff6"
+dependencies = [
+ "bitvec",
+ "rand_core 0.10.0",
+ "rustcrypto-ff_derive",
+ "subtle",
+]
+
+[[package]]
+name = "rustcrypto-ff_derive"
+version = "0.14.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cda22ea03582974ab5687fc131eba2dc78e258e7eef4d7e01bcd0522ed79f66"
+dependencies = [
+ "addchain",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "rustcrypto-group"
+version = "0.14.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "369f9b61aa45933c062c9f6b5c3c50ab710687eca83dd3802653b140b43f85ed"
+dependencies = [
+ "rand_core 0.10.0",
+ "rustcrypto-ff",
+ "subtle",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -994,7 +1089,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1105,6 +1200,17 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
@@ -1113,6 +1219,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -1144,7 +1256,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1289,7 +1401,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
  "wasm-bindgen-shared",
 ]
 
@@ -1406,7 +1518,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.114",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -1422,7 +1534,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -1465,6 +1577,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
 name = "x25519-dalek"
 version = "3.0.0-rc.0"
 dependencies = [
@@ -1494,7 +1615,7 @@ checksum = "1328722bbf2115db7e19d69ebcc15e795719e2d66b60827c6a69a117365e37a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1514,7 +1635,7 @@ checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "addchain"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2e69442aa5628ea6951fa33e24efe8313f4321a91bd729fc2f75bdfc858570"
+checksum = "5665045de74fda906c0abfaec40cf2551f88c34dccea869f3fe950dde7209764"
 dependencies = [
  "num-bigint",
  "num-integer",
@@ -335,15 +335,15 @@ dependencies = [
  "criterion",
  "curve25519-dalek-derive",
  "digest",
+ "ff",
  "fiat-crypto",
  "getrandom 0.4.0",
+ "group",
  "hex",
  "postcard",
  "proptest",
  "rand_core 0.10.0",
  "rustc_version",
- "rustcrypto-ff",
- "rustcrypto-group",
  "serde",
  "sha2",
  "subtle",
@@ -356,7 +356,7 @@ version = "0.1.1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]
@@ -461,6 +461,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "ff"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f686ab92a9fb0eaf188f6c6c87b89490baa6fdb0db4544ba4dc47f7942489f"
+dependencies = [
+ "bitvec",
+ "ff_derive",
+ "rand_core 0.10.0",
+ "subtle",
+]
+
+[[package]]
+name = "ff_derive"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "241afe8c15ffa21933eaefe8a563af36fd9fc98a3e8a044e8f7db52eb1fae3d8"
+dependencies = [
+ "addchain",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "fiat-crypto"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -508,6 +535,17 @@ dependencies = [
  "rand_core 0.10.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "group"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd1a1c7a5206c5b7a3f5a0d7ccd3ff85d0c8f5133d62a02680255b0004af5f4"
+dependencies = [
+ "ff",
+ "rand_core 0.10.0",
+ "subtle",
 ]
 
 [[package]]
@@ -697,11 +735,10 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "num-bigint"
-version = "0.3.3"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6f7833f2cbf2360a6cfd58cd41a53aa7a90bd4c202f5b1c7dd2ed73c57b2c3"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -812,7 +849,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]
@@ -973,44 +1010,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustcrypto-ff"
-version = "0.14.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd2a8adb347447693cd2ba0d218c4b66c62da9b0a5672b17b981e4291ec65ff6"
-dependencies = [
- "bitvec",
- "rand_core 0.10.0",
- "rustcrypto-ff_derive",
- "subtle",
-]
-
-[[package]]
-name = "rustcrypto-ff_derive"
-version = "0.14.0-rc.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cda22ea03582974ab5687fc131eba2dc78e258e7eef4d7e01bcd0522ed79f66"
-dependencies = [
- "addchain",
- "num-bigint",
- "num-integer",
- "num-traits",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "rustcrypto-group"
-version = "0.14.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "369f9b61aa45933c062c9f6b5c3c50ab710687eca83dd3802653b140b43f85ed"
-dependencies = [
- "rand_core 0.10.0",
- "rustcrypto-ff",
- "subtle",
-]
-
-[[package]]
 name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1089,7 +1088,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]
@@ -1200,17 +1199,6 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
@@ -1256,7 +1244,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]
@@ -1401,7 +1389,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -1518,7 +1506,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn 2.0.114",
+ "syn",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -1534,7 +1522,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -1615,7 +1603,7 @@ checksum = "1328722bbf2115db7e19d69ebcc15e795719e2d66b60827c6a69a117365e37a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]
@@ -1635,7 +1623,7 @@ checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,17 +3,6 @@
 version = 4
 
 [[package]]
-name = "addchain"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5665045de74fda906c0abfaec40cf2551f88c34dccea869f3fe950dde7209764"
-dependencies = [
- "num-bigint",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -87,18 +76,6 @@ name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
-
-[[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
 
 [[package]]
 name = "blake2"
@@ -466,25 +443,8 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1f686ab92a9fb0eaf188f6c6c87b89490baa6fdb0db4544ba4dc47f7942489f"
 dependencies = [
- "bitvec",
- "ff_derive",
  "rand_core 0.10.0",
  "subtle",
-]
-
-[[package]]
-name = "ff_derive"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241afe8c15ffa21933eaefe8a563af36fd9fc98a3e8a044e8f7db52eb1fae3d8"
-dependencies = [
- "addchain",
- "num-bigint",
- "num-integer",
- "num-traits",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -504,12 +464,6 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "getrandom"
@@ -734,25 +688,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -900,12 +835,6 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -1207,12 +1136,6 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -1562,15 +1485,6 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
-]
-
-[[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
 ]
 
 [[package]]

--- a/curve25519-dalek/CHANGELOG.md
+++ b/curve25519-dalek/CHANGELOG.md
@@ -5,6 +5,11 @@ major series.
 
 ## 5.x series
 
+
+# Unreleased
+
+* Remove `group-bits` feature due to soundness issues with underlying trait [#909](https://github.com/dalek-cryptography/curve25519-dalek/pull/909)
+
 ### 5.0.0-rc.0 - 2026-05-28
 
 * Remove `ff` and `group` features until they have a release ([#907](https://github.com/dalek-cryptography/curve25519-dalek/pull/907))

--- a/curve25519-dalek/CHANGELOG.md
+++ b/curve25519-dalek/CHANGELOG.md
@@ -8,7 +8,8 @@ major series.
 
 # Unreleased
 
-* Remove `group-bits` feature due to soundness issues with underlying trait [#909](https://github.com/dalek-cryptography/curve25519-dalek/pull/909)
+* Remove `group-bits` feature due to soundness issues with underlying trait ([#909](https://github.com/dalek-cryptography/curve25519-dalek/pull/909))
+* Re-export `rand_core` ([#908](https://github.com/dalek-cryptography/curve25519-dalek/pull/908))
 
 ### 5.0.0-rc.0 - 2026-05-28
 

--- a/curve25519-dalek/Cargo.toml
+++ b/curve25519-dalek/Cargo.toml
@@ -47,8 +47,8 @@ required-features = ["alloc", "rand_core"]
 
 [dependencies]
 cfg-if = "1"
-ff = { version = "0.14.0-rc.1", package = "rustcrypto-ff", default-features = false, optional = true }
-group = { version = "0.14.0-rc.1", package = "rustcrypto-group", default-features = false, optional = true }
+ff = { version = "0.14", default-features = false, optional = true }
+group = { version = "0.14", default-features = false, optional = true }
 rand_core = { version = "0.10", default-features = false, optional = true }
 digest = { version = "0.11", default-features = false, optional = true, features = ["block-api"] }
 subtle = { version = "2.6.0", default-features = false, features = [

--- a/curve25519-dalek/Cargo.toml
+++ b/curve25519-dalek/Cargo.toml
@@ -71,7 +71,6 @@ alloc = ["zeroize?/alloc"]
 precomputed-tables = []
 legacy_compatibility = []
 group = ["dep:group", "rand_core"]
-group-bits = ["group", "ff/bits"]
 digest = ["dep:digest"]
 lizard = ["digest"]
 

--- a/curve25519-dalek/Cargo.toml
+++ b/curve25519-dalek/Cargo.toml
@@ -47,6 +47,8 @@ required-features = ["alloc", "rand_core"]
 
 [dependencies]
 cfg-if = "1"
+ff = { version = "0.14.0-rc.1", package = "rustcrypto-ff", default-features = false, optional = true }
+group = { version = "0.14.0-rc.1", package = "rustcrypto-group", default-features = false, optional = true }
 rand_core = { version = "0.10", default-features = false, optional = true }
 digest = { version = "0.11", default-features = false, optional = true, features = ["block-api"] }
 subtle = { version = "2.6.0", default-features = false, features = [
@@ -68,6 +70,8 @@ default = ["alloc", "precomputed-tables", "zeroize"]
 alloc = ["zeroize?/alloc"]
 precomputed-tables = []
 legacy_compatibility = []
+group = ["dep:group", "rand_core"]
+group-bits = ["group", "ff/bits"]
 digest = ["dep:digest"]
 lizard = ["digest"]
 

--- a/curve25519-dalek/README.md
+++ b/curve25519-dalek/README.md
@@ -54,7 +54,6 @@ curve25519-dalek = ">= 5.0, < 5.2"
 | `serde`            |          | Enables `serde` serialization/deserialization for all the point and scalar types. |
 | `legacy_compatibility`|       | Enables `Scalar::from_bits`, which allows the user to build unreduced scalars whose arithmetic is broken. Do not use this unless you know what you're doing. |
 | `group`            |          | Enables external `group` and `ff` crate traits. |
-| `group-bits`       |          | Enables `group` and impls `ff::PrimeFieldBits` for `Scalar`.  |
 | `lizard`           |          | Enables the [Lizard](src/lizard/README.md) bytestring-to-point injection for `RistrettoPoint`. Specifically enables the methods `lizard_encode` and `lizard_decode`. |
 
 To disable the default features when using `curve25519-dalek` as a dependency,

--- a/curve25519-dalek/README.md
+++ b/curve25519-dalek/README.md
@@ -53,6 +53,8 @@ curve25519-dalek = ">= 5.0, < 5.2"
 | `digest`           |          | Enables `RistrettoPoint::{from_hash, hash_from_bytes}` and `Scalar::{from_hash, hash_from_bytes}`. Also enables hash-to-curve methods `EdwardsPoint::{encode_to_curve, hash_to_curve}`. This is an optional dependency whose version is not subject to SemVer. See [below](#public-api-semver-exemptions) for more details. |
 | `serde`            |          | Enables `serde` serialization/deserialization for all the point and scalar types. |
 | `legacy_compatibility`|       | Enables `Scalar::from_bits`, which allows the user to build unreduced scalars whose arithmetic is broken. Do not use this unless you know what you're doing. |
+| `group`            |          | Enables external `group` and `ff` crate traits. |
+| `group-bits`       |          | Enables `group` and impls `ff::PrimeFieldBits` for `Scalar`.  |
 | `lizard`           |          | Enables the [Lizard](src/lizard/README.md) bytestring-to-point injection for `RistrettoPoint`. Specifically enables the methods `lizard_encode` and `lizard_decode`. |
 
 To disable the default features when using `curve25519-dalek` as a dependency,

--- a/curve25519-dalek/benches/dalek_benchmarks.rs
+++ b/curve25519-dalek/benches/dalek_benchmarks.rs
@@ -304,7 +304,7 @@ mod ristretto_benches {
                 |b, &&size| {
                     let mut rng = SysRng;
                     let points: Vec<RistrettoPoint> = (0..size)
-                        .map(|_| RistrettoPoint::try_from_rng(&mut rng).unwrap())
+                        .map(|_| RistrettoPoint::try_random(&mut rng).unwrap())
                         .collect();
                     b.iter(|| RistrettoPoint::double_and_compress_batch(&points));
                 },

--- a/curve25519-dalek/src/edwards.rs
+++ b/curve25519-dalek/src/edwards.rs
@@ -110,6 +110,13 @@ use digest::{
     typenum::IsGreater,
 };
 
+#[cfg(feature = "group")]
+use {
+    group::{GroupEncoding, cofactor::CofactorGroup, prime::PrimeGroup},
+    rand_core::TryRng,
+    subtle::CtOption,
+};
+
 #[cfg(feature = "rand_core")]
 use rand_core::Rng;
 
@@ -1441,6 +1448,338 @@ impl Debug for EdwardsPoint {
             "EdwardsPoint{{\n\tX: {:?},\n\tY: {:?},\n\tZ: {:?},\n\tT: {:?}\n}}",
             &self.X, &self.Y, &self.Z, &self.T
         )
+    }
+}
+
+// ------------------------------------------------------------------------
+// group traits
+// ------------------------------------------------------------------------
+
+// Use the full trait path to avoid Group::identity overlapping Identity::identity in the
+// rest of the module (e.g. tests).
+#[cfg(feature = "group")]
+impl group::Group for EdwardsPoint {
+    type Scalar = Scalar;
+
+    fn try_from_rng<R: TryRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+        let mut repr = CompressedEdwardsY([0u8; 32]);
+        loop {
+            rng.try_fill_bytes(&mut repr.0)?;
+            if let Some(p) = repr.decompress() {
+                if !IsIdentity::is_identity(&p) {
+                    break Ok(p);
+                }
+            }
+        }
+    }
+
+    fn identity() -> Self {
+        Identity::identity()
+    }
+
+    fn generator() -> Self {
+        constants::ED25519_BASEPOINT_POINT
+    }
+
+    fn is_identity(&self) -> Choice {
+        self.ct_eq(&Identity::identity())
+    }
+
+    fn double(&self) -> Self {
+        self.double()
+    }
+}
+
+#[cfg(feature = "group")]
+impl GroupEncoding for EdwardsPoint {
+    type Repr = [u8; 32];
+
+    fn from_bytes(bytes: &Self::Repr) -> CtOption<Self> {
+        let repr = CompressedEdwardsY(*bytes);
+        let (is_valid_y_coord, X, Y, Z) = decompress::step_1(&repr);
+        CtOption::new(decompress::step_2(&repr, X, Y, Z), is_valid_y_coord)
+    }
+
+    fn from_bytes_unchecked(bytes: &Self::Repr) -> CtOption<Self> {
+        // Just use the checked API; there are no checks we can skip.
+        Self::from_bytes(bytes)
+    }
+
+    fn to_bytes(&self) -> Self::Repr {
+        self.compress().to_bytes()
+    }
+}
+
+/// A `SubgroupPoint` represents a point on the Edwards form of Curve25519, that is
+/// guaranteed to be in the prime-order subgroup.
+#[cfg(feature = "group")]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct SubgroupPoint(EdwardsPoint);
+
+#[cfg(feature = "group")]
+impl From<SubgroupPoint> for EdwardsPoint {
+    fn from(p: SubgroupPoint) -> Self {
+        p.0
+    }
+}
+
+#[cfg(feature = "group")]
+impl Neg for SubgroupPoint {
+    type Output = Self;
+
+    fn neg(self) -> Self::Output {
+        SubgroupPoint(-self.0)
+    }
+}
+
+#[cfg(feature = "group")]
+impl Add<&SubgroupPoint> for &SubgroupPoint {
+    type Output = SubgroupPoint;
+    fn add(self, other: &SubgroupPoint) -> SubgroupPoint {
+        SubgroupPoint(self.0 + other.0)
+    }
+}
+
+#[cfg(feature = "group")]
+define_add_variants!(
+    LHS = SubgroupPoint,
+    RHS = SubgroupPoint,
+    Output = SubgroupPoint
+);
+
+#[cfg(feature = "group")]
+impl Add<&SubgroupPoint> for &EdwardsPoint {
+    type Output = EdwardsPoint;
+    fn add(self, other: &SubgroupPoint) -> EdwardsPoint {
+        self + other.0
+    }
+}
+
+#[cfg(feature = "group")]
+define_add_variants!(
+    LHS = EdwardsPoint,
+    RHS = SubgroupPoint,
+    Output = EdwardsPoint
+);
+
+#[cfg(feature = "group")]
+impl AddAssign<&SubgroupPoint> for SubgroupPoint {
+    fn add_assign(&mut self, rhs: &SubgroupPoint) {
+        self.0 += rhs.0
+    }
+}
+
+#[cfg(feature = "group")]
+define_add_assign_variants!(LHS = SubgroupPoint, RHS = SubgroupPoint);
+
+#[cfg(feature = "group")]
+impl AddAssign<&SubgroupPoint> for EdwardsPoint {
+    fn add_assign(&mut self, rhs: &SubgroupPoint) {
+        *self += rhs.0
+    }
+}
+
+#[cfg(feature = "group")]
+define_add_assign_variants!(LHS = EdwardsPoint, RHS = SubgroupPoint);
+
+#[cfg(feature = "group")]
+impl Sub<&SubgroupPoint> for &SubgroupPoint {
+    type Output = SubgroupPoint;
+    fn sub(self, other: &SubgroupPoint) -> SubgroupPoint {
+        SubgroupPoint(self.0 - other.0)
+    }
+}
+
+#[cfg(feature = "group")]
+define_sub_variants!(
+    LHS = SubgroupPoint,
+    RHS = SubgroupPoint,
+    Output = SubgroupPoint
+);
+
+#[cfg(feature = "group")]
+impl Sub<&SubgroupPoint> for &EdwardsPoint {
+    type Output = EdwardsPoint;
+    fn sub(self, other: &SubgroupPoint) -> EdwardsPoint {
+        self - other.0
+    }
+}
+
+#[cfg(feature = "group")]
+define_sub_variants!(
+    LHS = EdwardsPoint,
+    RHS = SubgroupPoint,
+    Output = EdwardsPoint
+);
+
+#[cfg(feature = "group")]
+impl SubAssign<&SubgroupPoint> for SubgroupPoint {
+    fn sub_assign(&mut self, rhs: &SubgroupPoint) {
+        self.0 -= rhs.0;
+    }
+}
+
+#[cfg(feature = "group")]
+define_sub_assign_variants!(LHS = SubgroupPoint, RHS = SubgroupPoint);
+
+#[cfg(feature = "group")]
+impl SubAssign<&SubgroupPoint> for EdwardsPoint {
+    fn sub_assign(&mut self, rhs: &SubgroupPoint) {
+        *self -= rhs.0;
+    }
+}
+
+#[cfg(feature = "group")]
+define_sub_assign_variants!(LHS = EdwardsPoint, RHS = SubgroupPoint);
+
+#[cfg(feature = "group")]
+impl<T> Sum<T> for SubgroupPoint
+where
+    T: Borrow<SubgroupPoint>,
+{
+    fn sum<I>(iter: I) -> Self
+    where
+        I: Iterator<Item = T>,
+    {
+        use group::Group;
+        iter.fold(SubgroupPoint::identity(), |acc, item| acc + item.borrow())
+    }
+}
+
+#[cfg(feature = "group")]
+impl Mul<&Scalar> for &SubgroupPoint {
+    type Output = SubgroupPoint;
+
+    /// Scalar multiplication: compute `scalar * self`.
+    ///
+    /// For scalar multiplication of a basepoint,
+    /// `EdwardsBasepointTable` is approximately 4x faster.
+    fn mul(self, scalar: &Scalar) -> SubgroupPoint {
+        SubgroupPoint(self.0 * scalar)
+    }
+}
+
+#[cfg(feature = "group")]
+define_mul_variants!(LHS = Scalar, RHS = SubgroupPoint, Output = SubgroupPoint);
+
+#[cfg(feature = "group")]
+impl Mul<&SubgroupPoint> for &Scalar {
+    type Output = SubgroupPoint;
+
+    /// Scalar multiplication: compute `scalar * self`.
+    ///
+    /// For scalar multiplication of a basepoint,
+    /// `EdwardsBasepointTable` is approximately 4x faster.
+    fn mul(self, point: &SubgroupPoint) -> SubgroupPoint {
+        point * self
+    }
+}
+
+#[cfg(feature = "group")]
+define_mul_variants!(LHS = SubgroupPoint, RHS = Scalar, Output = SubgroupPoint);
+
+#[cfg(feature = "group")]
+impl MulAssign<&Scalar> for SubgroupPoint {
+    fn mul_assign(&mut self, scalar: &Scalar) {
+        self.0 *= scalar;
+    }
+}
+
+#[cfg(feature = "group")]
+define_mul_assign_variants!(LHS = SubgroupPoint, RHS = Scalar);
+
+#[cfg(feature = "group")]
+impl ConstantTimeEq for SubgroupPoint {
+    fn ct_eq(&self, other: &SubgroupPoint) -> Choice {
+        self.0.ct_eq(&other.0)
+    }
+}
+
+#[cfg(feature = "group")]
+impl ConditionallySelectable for SubgroupPoint {
+    fn conditional_select(a: &SubgroupPoint, b: &SubgroupPoint, choice: Choice) -> SubgroupPoint {
+        SubgroupPoint(EdwardsPoint::conditional_select(&a.0, &b.0, choice))
+    }
+}
+
+#[cfg(all(feature = "group", feature = "zeroize"))]
+impl Zeroize for SubgroupPoint {
+    fn zeroize(&mut self) {
+        self.0.zeroize();
+    }
+}
+
+#[cfg(feature = "group")]
+impl group::Group for SubgroupPoint {
+    type Scalar = Scalar;
+
+    fn try_from_rng<R: TryRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+        use group::ff::Field;
+
+        // This will almost never loop, but `Group::random` is documented as returning a
+        // non-identity element.
+        let s = loop {
+            let s: Scalar = Field::try_from_rng(rng)?;
+            if !s.is_zero_vartime() {
+                break s;
+            }
+        };
+
+        // This gives an element of the prime-order subgroup.
+        Ok(Self::generator() * s)
+    }
+
+    fn identity() -> Self {
+        SubgroupPoint(Identity::identity())
+    }
+
+    fn generator() -> Self {
+        SubgroupPoint(EdwardsPoint::generator())
+    }
+
+    fn is_identity(&self) -> Choice {
+        self.0.ct_eq(&Identity::identity())
+    }
+
+    fn double(&self) -> Self {
+        SubgroupPoint(self.0.double())
+    }
+}
+
+#[cfg(feature = "group")]
+impl GroupEncoding for SubgroupPoint {
+    type Repr = <EdwardsPoint as GroupEncoding>::Repr;
+
+    fn from_bytes(bytes: &Self::Repr) -> CtOption<Self> {
+        EdwardsPoint::from_bytes(bytes).and_then(|p| p.into_subgroup())
+    }
+
+    fn from_bytes_unchecked(bytes: &Self::Repr) -> CtOption<Self> {
+        EdwardsPoint::from_bytes_unchecked(bytes).and_then(|p| p.into_subgroup())
+    }
+
+    fn to_bytes(&self) -> Self::Repr {
+        self.0.compress().to_bytes()
+    }
+}
+
+#[cfg(feature = "group")]
+impl PrimeGroup for SubgroupPoint {}
+
+#[cfg(feature = "group")]
+impl CofactorGroup for EdwardsPoint {
+    type Subgroup = SubgroupPoint;
+
+    fn clear_cofactor(&self) -> Self::Subgroup {
+        SubgroupPoint(self.mul_by_cofactor())
+    }
+
+    fn into_subgroup(self) -> CtOption<Self::Subgroup> {
+        CtOption::new(SubgroupPoint(self), CofactorGroup::is_torsion_free(&self))
+    }
+
+    fn is_torsion_free(&self) -> Choice {
+        (self * constants::BASEPOINT_ORDER).ct_eq(&Self::identity())
     }
 }
 

--- a/curve25519-dalek/src/edwards.rs
+++ b/curve25519-dalek/src/edwards.rs
@@ -1461,7 +1461,7 @@ impl Debug for EdwardsPoint {
 impl group::Group for EdwardsPoint {
     type Scalar = Scalar;
 
-    fn try_from_rng<R: TryRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+    fn try_random<R: TryRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
         let mut repr = CompressedEdwardsY([0u8; 32]);
         loop {
             rng.try_fill_bytes(&mut repr.0)?;
@@ -1713,13 +1713,13 @@ impl Zeroize for SubgroupPoint {
 impl group::Group for SubgroupPoint {
     type Scalar = Scalar;
 
-    fn try_from_rng<R: TryRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+    fn try_random<R: TryRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
         use group::ff::Field;
 
         // This will almost never loop, but `Group::random` is documented as returning a
         // non-identity element.
         let s = loop {
-            let s: Scalar = Field::try_from_rng(rng)?;
+            let s: Scalar = Field::try_random(rng)?;
             if !s.is_zero_vartime() {
                 break s;
             }

--- a/curve25519-dalek/src/ristretto.rs
+++ b/curve25519-dalek/src/ristretto.rs
@@ -674,7 +674,7 @@ impl RistrettoPoint {
     /// results are added, to ensure a uniform distribution.
     #[cfg(feature = "rand_core")]
     pub fn random<R: CryptoRng + ?Sized>(rng: &mut R) -> Self {
-        Self::try_from_rng(rng)
+        Self::try_random(rng)
             .map_err(|_: Infallible| {})
             .expect("[bug] unfallible rng failed")
     }
@@ -696,7 +696,7 @@ impl RistrettoPoint {
     /// point should be unknown.  The map is applied twice and the
     /// results are added, to ensure a uniform distribution.
     #[cfg(feature = "rand_core")]
-    pub fn try_from_rng<R: TryCryptoRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+    pub fn try_random<R: TryCryptoRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
         let mut uniform_bytes = [0u8; 64];
         rng.try_fill_bytes(&mut uniform_bytes)?;
 
@@ -1179,7 +1179,7 @@ impl Debug for RistrettoPoint {
 impl group::Group for RistrettoPoint {
     type Scalar = Scalar;
 
-    fn try_from_rng<R: TryRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+    fn try_random<R: TryRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
         // NOTE: this is duplicated due to different `rng` bounds
         let mut uniform_bytes = [0u8; 64];
         rng.try_fill_bytes(&mut uniform_bytes)?;
@@ -1499,7 +1499,7 @@ mod test {
         let mut rng = SysRng;
 
         let mut points: Vec<RistrettoPoint> = (0..1024)
-            .map(|_| RistrettoPoint::try_from_rng(&mut rng).unwrap())
+            .map(|_| RistrettoPoint::try_random(&mut rng).unwrap())
             .collect();
         points[500] = <RistrettoPoint as Group>::identity();
 

--- a/curve25519-dalek/src/ristretto.rs
+++ b/curve25519-dalek/src/ristretto.rs
@@ -177,6 +177,13 @@ use digest::array::typenum::U64;
 use crate::constants;
 use crate::field::FieldElement;
 
+#[cfg(feature = "group")]
+use {
+    group::{GroupEncoding, cofactor::CofactorGroup, prime::PrimeGroup},
+    rand_core::TryRng,
+    subtle::CtOption,
+};
+
 #[cfg(feature = "rand_core")]
 use {
     core::convert::Infallible,
@@ -1163,6 +1170,86 @@ impl Debug for RistrettoPoint {
 }
 
 // ------------------------------------------------------------------------
+// group traits
+// ------------------------------------------------------------------------
+
+// Use the full trait path to avoid Group::identity overlapping Identity::identity in the
+// rest of the module (e.g. tests).
+#[cfg(feature = "group")]
+impl group::Group for RistrettoPoint {
+    type Scalar = Scalar;
+
+    fn try_from_rng<R: TryRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+        // NOTE: this is duplicated due to different `rng` bounds
+        let mut uniform_bytes = [0u8; 64];
+        rng.try_fill_bytes(&mut uniform_bytes)?;
+        Ok(RistrettoPoint::from_uniform_bytes(&uniform_bytes))
+    }
+
+    fn identity() -> Self {
+        Identity::identity()
+    }
+
+    fn generator() -> Self {
+        constants::RISTRETTO_BASEPOINT_POINT
+    }
+
+    fn is_identity(&self) -> Choice {
+        self.ct_eq(&Identity::identity())
+    }
+
+    fn double(&self) -> Self {
+        self + self
+    }
+}
+
+#[cfg(feature = "group")]
+impl GroupEncoding for RistrettoPoint {
+    type Repr = [u8; 32];
+
+    fn from_bytes(bytes: &Self::Repr) -> CtOption<Self> {
+        let (s_encoding_is_canonical, s_is_negative, s) =
+            decompress::step_1(&CompressedRistretto(*bytes));
+
+        let s_is_valid = s_encoding_is_canonical & !s_is_negative;
+
+        let (ok, t_is_negative, y_is_zero, res) = decompress::step_2(s);
+
+        CtOption::new(res, s_is_valid & ok & !t_is_negative & !y_is_zero)
+    }
+
+    fn from_bytes_unchecked(bytes: &Self::Repr) -> CtOption<Self> {
+        // Just use the checked API; the checks we could skip aren't expensive.
+        Self::from_bytes(bytes)
+    }
+
+    fn to_bytes(&self) -> Self::Repr {
+        self.compress().to_bytes()
+    }
+}
+
+#[cfg(feature = "group")]
+impl PrimeGroup for RistrettoPoint {}
+
+/// Ristretto has a cofactor of 1.
+#[cfg(feature = "group")]
+impl CofactorGroup for RistrettoPoint {
+    type Subgroup = Self;
+
+    fn clear_cofactor(&self) -> Self::Subgroup {
+        *self
+    }
+
+    fn into_subgroup(self) -> CtOption<Self::Subgroup> {
+        CtOption::new(self, Choice::from(1))
+    }
+
+    fn is_torsion_free(&self) -> Choice {
+        Choice::from(1)
+    }
+}
+
+// ------------------------------------------------------------------------
 // Zeroize traits
 // ------------------------------------------------------------------------
 
@@ -1190,6 +1277,8 @@ mod test {
     use crate::edwards::CompressedEdwardsY;
     #[cfg(feature = "rand_core")]
     use getrandom::{SysRng, rand_core::UnwrapErr};
+    #[cfg(feature = "group")]
+    use proptest::prelude::*;
 
     #[test]
     #[cfg(feature = "serde")]
@@ -1400,6 +1489,57 @@ mod test {
             let compressed_P = P.compress();
             let Q = compressed_P.decompress().unwrap();
             assert_eq!(P, Q);
+        }
+    }
+
+    #[test]
+    #[cfg(all(feature = "alloc", feature = "rand_core", feature = "group"))]
+    fn double_and_compress_1024_random_points() {
+        use group::Group;
+        let mut rng = SysRng;
+
+        let mut points: Vec<RistrettoPoint> = (0..1024)
+            .map(|_| RistrettoPoint::try_from_rng(&mut rng).unwrap())
+            .collect();
+        points[500] = <RistrettoPoint as Group>::identity();
+
+        let compressed = RistrettoPoint::double_and_compress_batch(&points);
+
+        for (P, P2_compressed) in points.iter().zip(compressed.iter()) {
+            assert_eq!(*P2_compressed, (P + P).compress());
+        }
+    }
+
+    #[cfg(feature = "group")]
+    proptest! {
+        #[test]
+        fn multiply_double_and_compress_random_points(
+            p1 in any::<[u8; 64]>(),
+            p2 in any::<[u8; 64]>(),
+            s1 in any::<[u8; 32]>(),
+            s2 in any::<[u8; 32]>(),
+        ) {
+            use group::Group;
+
+            let scalars = [
+                Scalar::from_bytes_mod_order(s1),
+                Scalar::ZERO,
+                Scalar::from_bytes_mod_order(s2),
+            ];
+
+            let points = [
+                RistrettoPoint::from_uniform_bytes(&p1),
+                <RistrettoPoint as Group>::identity(),
+                RistrettoPoint::from_uniform_bytes(&p2),
+            ];
+
+            let multiplied_points: [_; 3] =
+                core::array::from_fn(|i| scalars[i].div_by_2() * points[i]);
+            let compressed = RistrettoPoint::double_and_compress_batch(&multiplied_points);
+
+            for ((s, P), P2_compressed) in scalars.iter().zip(points).zip(compressed) {
+                prop_assert_eq!(P2_compressed, (s * P).compress());
+            }
         }
     }
 

--- a/curve25519-dalek/src/scalar.rs
+++ b/curve25519-dalek/src/scalar.rs
@@ -124,8 +124,6 @@ use cfg_if::cfg_if;
 
 #[cfg(feature = "group")]
 use group::ff::{Field, FromUniformBytes, PrimeField};
-#[cfg(feature = "group-bits")]
-use group::ff::{FieldBits, PrimeFieldBits};
 
 #[cfg(feature = "group")]
 use rand_core::TryRng;
@@ -1357,19 +1355,6 @@ impl PrimeField for Scalar {
             0, 0, 0,
         ],
     };
-}
-
-#[cfg(feature = "group-bits")]
-impl PrimeFieldBits for Scalar {
-    type ReprBits = [u8; 32];
-
-    fn to_le_bits(&self) -> FieldBits<Self::ReprBits> {
-        self.to_repr().into()
-    }
-
-    fn char_le_bits() -> FieldBits<Self::ReprBits> {
-        constants::BASEPOINT_ORDER.to_bytes().into()
-    }
 }
 
 #[cfg(feature = "group")]

--- a/curve25519-dalek/src/scalar.rs
+++ b/curve25519-dalek/src/scalar.rs
@@ -122,6 +122,14 @@ use core::ops::{Sub, SubAssign};
 
 use cfg_if::cfg_if;
 
+#[cfg(feature = "group")]
+use group::ff::{Field, FromUniformBytes, PrimeField};
+#[cfg(feature = "group-bits")]
+use group::ff::{FieldBits, PrimeFieldBits};
+
+#[cfg(feature = "group")]
+use rand_core::TryRng;
+
 #[cfg(feature = "rand_core")]
 use rand_core::CryptoRng;
 
@@ -1236,6 +1244,141 @@ impl UnpackedScalar {
     }
 }
 
+#[cfg(feature = "group")]
+impl Field for Scalar {
+    const ZERO: Self = Self::ZERO;
+    const ONE: Self = Self::ONE;
+
+    fn try_from_rng<R: TryRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+        // NOTE: this is duplicated due to different `rng` bounds
+        let mut scalar_bytes = [0u8; 64];
+        rng.try_fill_bytes(&mut scalar_bytes)?;
+        Ok(Self::from_bytes_mod_order_wide(&scalar_bytes))
+    }
+
+    fn square(&self) -> Self {
+        self * self
+    }
+
+    fn double(&self) -> Self {
+        self + self
+    }
+
+    fn invert(&self) -> CtOption<Self> {
+        CtOption::new(self.invert(), !self.is_zero())
+    }
+
+    fn sqrt_ratio(num: &Self, div: &Self) -> (Choice, Self) {
+        #[allow(unused_qualifications)]
+        group::ff::helpers::sqrt_ratio_generic(num, div)
+    }
+
+    fn sqrt(&self) -> CtOption<Self> {
+        #[allow(unused_qualifications)]
+        group::ff::helpers::sqrt_tonelli_shanks(
+            self,
+            [
+                0xcb02_4c63_4b9e_ba7d,
+                0x029b_df3b_d45e_f39a,
+                0x0000_0000_0000_0000,
+                0x0200_0000_0000_0000,
+            ],
+        )
+    }
+}
+
+#[cfg(feature = "group")]
+impl PrimeField for Scalar {
+    type Repr = [u8; 32];
+
+    fn from_repr(repr: Self::Repr) -> CtOption<Self> {
+        Self::from_canonical_bytes(repr)
+    }
+
+    fn from_repr_vartime(repr: Self::Repr) -> Option<Self> {
+        // Check that the high bit is not set
+        if (repr[31] >> 7) != 0u8 {
+            return None;
+        }
+
+        let candidate = Scalar { bytes: repr };
+
+        if candidate == candidate.reduce() {
+            Some(candidate)
+        } else {
+            None
+        }
+    }
+
+    fn to_repr(&self) -> Self::Repr {
+        self.to_bytes()
+    }
+
+    fn is_odd(&self) -> Choice {
+        Choice::from(self.as_bytes()[0] & 1)
+    }
+
+    const MODULUS: &'static str =
+        "0x1000000000000000000000000000000014def9dea2f79cd65812631a5cf5d3ed";
+    const NUM_BITS: u32 = 253;
+    const CAPACITY: u32 = 252;
+
+    const TWO_INV: Self = Self {
+        bytes: [
+            0xf7, 0xe9, 0x7a, 0x2e, 0x8d, 0x31, 0x09, 0x2c, 0x6b, 0xce, 0x7b, 0x51, 0xef, 0x7c,
+            0x6f, 0x0a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x08,
+        ],
+    };
+    const MULTIPLICATIVE_GENERATOR: Self = Self {
+        bytes: [
+            2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0,
+        ],
+    };
+    const S: u32 = 2;
+    const ROOT_OF_UNITY: Self = Self {
+        bytes: [
+            0xd4, 0x07, 0xbe, 0xeb, 0xdf, 0x75, 0x87, 0xbe, 0xfe, 0x83, 0xce, 0x42, 0x53, 0x56,
+            0xf0, 0x0e, 0x7a, 0xc2, 0xc1, 0xab, 0x60, 0x6d, 0x3d, 0x7d, 0xe7, 0x81, 0x79, 0xe0,
+            0x10, 0x73, 0x4a, 0x09,
+        ],
+    };
+    const ROOT_OF_UNITY_INV: Self = Self {
+        bytes: [
+            0x19, 0xcc, 0x37, 0x71, 0x3a, 0xed, 0x8a, 0x99, 0xd7, 0x18, 0x29, 0x60, 0x8b, 0xa3,
+            0xee, 0x05, 0x86, 0x3d, 0x3e, 0x54, 0x9f, 0x92, 0xc2, 0x82, 0x18, 0x7e, 0x86, 0x1f,
+            0xef, 0x8c, 0xb5, 0x06,
+        ],
+    };
+    const DELTA: Self = Self {
+        bytes: [
+            16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0,
+        ],
+    };
+}
+
+#[cfg(feature = "group-bits")]
+impl PrimeFieldBits for Scalar {
+    type ReprBits = [u8; 32];
+
+    fn to_le_bits(&self) -> FieldBits<Self::ReprBits> {
+        self.to_repr().into()
+    }
+
+    fn char_le_bits() -> FieldBits<Self::ReprBits> {
+        constants::BASEPOINT_ORDER.to_bytes().into()
+    }
+}
+
+#[cfg(feature = "group")]
+impl FromUniformBytes<64> for Scalar {
+    fn from_uniform_bytes(bytes: &[u8; 64]) -> Self {
+        Scalar::from_bytes_mod_order_wide(bytes)
+    }
+}
+
 /// Read one or more u64s stored as little endian bytes.
 ///
 /// ## Panics
@@ -1886,6 +2029,56 @@ pub(crate) mod test {
         let x = 0x2323_2323_2323_2323_2323_2323_2323_2323u128;
         let sx = Scalar::from(x);
         assert_eq!(sx + s1, Scalar::from(x + 1));
+    }
+
+    #[cfg(feature = "group")]
+    #[test]
+    fn ff_constants() {
+        assert_eq!(Scalar::from(2u64) * Scalar::TWO_INV, Scalar::ONE);
+
+        assert_eq!(
+            Scalar::ROOT_OF_UNITY * Scalar::ROOT_OF_UNITY_INV,
+            Scalar::ONE,
+        );
+
+        // ROOT_OF_UNITY^{2^s} mod m == 1
+        assert_eq!(
+            Scalar::ROOT_OF_UNITY.pow(&[1u64 << Scalar::S, 0, 0, 0]),
+            Scalar::ONE,
+        );
+
+        // DELTA^{t} mod m == 1
+        assert_eq!(
+            Scalar::DELTA.pow(&[
+                0x9604_98c6_973d_74fb,
+                0x0537_be77_a8bd_e735,
+                0x0000_0000_0000_0000,
+                0x0400_0000_0000_0000,
+            ]),
+            Scalar::ONE,
+        );
+    }
+
+    #[cfg(feature = "group")]
+    #[test]
+    fn ff_impls() {
+        assert!(bool::from(Scalar::ZERO.is_even()));
+        assert!(bool::from(Scalar::ONE.is_odd()));
+        assert!(bool::from(Scalar::from(2u64).is_even()));
+        assert!(bool::from(Scalar::DELTA.is_even()));
+
+        assert!(bool::from(Field::invert(&Scalar::ZERO).is_none()));
+        assert_eq!(Field::invert(&X).unwrap(), XINV);
+
+        let x_sq = X.square();
+        // We should get back either the positive or negative root.
+        assert!([X, -X].contains(&x_sq.sqrt().unwrap()));
+
+        assert_eq!(Scalar::from_repr_vartime(X.to_repr()), Some(X));
+        assert_eq!(Scalar::from_repr_vartime([0xff; 32]), None);
+
+        assert_eq!(Scalar::from_repr(X.to_repr()).unwrap(), X);
+        assert!(bool::from(Scalar::from_repr([0xff; 32]).is_none()));
     }
 
     #[test]

--- a/curve25519-dalek/src/scalar.rs
+++ b/curve25519-dalek/src/scalar.rs
@@ -1249,7 +1249,7 @@ impl Field for Scalar {
     const ZERO: Self = Self::ZERO;
     const ONE: Self = Self::ONE;
 
-    fn try_from_rng<R: TryRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+    fn try_random<R: TryRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
         // NOTE: this is duplicated due to different `rng` bounds
         let mut scalar_bytes = [0u8; 64];
         rng.try_fill_bytes(&mut scalar_bytes)?;

--- a/ed25519-dalek/CHANGELOG.md
+++ b/ed25519-dalek/CHANGELOG.md
@@ -8,6 +8,10 @@ Entries are listed in reverse chronological order per undeprecated major series.
 
 # 3.x series
 
+## Unreleased
+
+* Re-export `rand_core` ([#908](https://github.com/dalek-cryptography/curve25519-dalek/pull/908))
+
 ## 3.0.0-rc.0 - 2026-05-28
 
 * Add allocation-free `EdwardsPoint::compress_batch` ([#832](https://github.com/dalek-cryptography/curve25519-dalek/pull/832))

--- a/x25519-dalek/CHANGELOG.md
+++ b/x25519-dalek/CHANGELOG.md
@@ -4,6 +4,10 @@ Entries are listed in reverse chronological order.
 
 # 3.x Series
 
+## Unreleased
+
+* Re-export `rand_core` ([#908](https://github.com/dalek-cryptography/curve25519-dalek/pull/908))
+
 ## 3.0.0-rc.0 - 2026-05-28
 
 * Remove `alloc` feature flag, which was doing nothing


### PR DESCRIPTION
Now that they've had v0.14 releases we can bring them back for 5.0.0