### PR TITLE
curve: Fix nightly build under -D warnings

### DIFF
--- a/curve25519-dalek/src/backend.rs
+++ b/curve25519-dalek/src/backend.rs
@@ -54,6 +54,9 @@ enum BackendKind {
     Serial,
 }
 
+// `cpufeatures::new!` expands to `u8::max_value()`, which rustc 1.99 deprecates.
+// Remove once a `cpufeatures` release stops using it.
+#[allow(deprecated)]
 #[inline]
 fn get_selected_backend() -> BackendKind {
     #[cfg(curve25519_dalek_backend = "avx512")]


### PR DESCRIPTION
The Test Nightly job in workspace.yml doesn't build at the moment. `cpufeatures::new!` expands to `u8::max_value()`, which rustc deprecates as of 1.99-nightly, and the lint gets attributed to the call site rather than to cpufeatures, so the workflow's `-D warnings` turns it into an error:

```
error: use of deprecated associated function `core::num::<impl u8>::max_value`
  --> curve25519-dalek/src/backend.rs:70:9
   |
70 |         cpufeatures::new!(cpuid_avx2, "avx2");
```

Silencing it on this side is admittedly a workaround. It really wants fixing in cpufeatures, but 0.3.0 is the current release so there's nothing to bump to yet. Happy to close this if you'd rather cut a cpufeatures release instead; either way the `allow` should come back out once that lands.

Reproduced on nightly ba28ff76f (2026-08-13); stable is unaffected so far.
