### PR TITLE
curve: Document the wasm32 word size and what the simd backend does not cover

### DIFF
--- a/curve25519-dalek/README.md
+++ b/curve25519-dalek/README.md
@@ -128,6 +128,10 @@ in `~/.cargo/config`.
 
 Note: The [SIMD backend] requires a word size of 64 bits. Attempting to set bits=32 and backend=`simd` will yield a compile error.
 
+On `wasm32` the automatic 32-bit choice is the right one: forcing
+`bits="64"` measures 1.6-1.9x slower for X25519, because wasm has no
+64x64->128 multiply, so the 64-bit backend's `u128` products are emulated.
+
 ### Cross-compilation
 
 Because backend selection is done by target, cross-compiling will select the correct word size automatically. For example, if a x86-64 Linux machine runs the following commands, `curve25519-dalek` will be compiled with the 32-bit `serial` backend.
@@ -147,6 +151,11 @@ For a given CPU feature, you can also specify an appropriate `-C target_feature`
 | :---    | :---                                      | :---              |
 | AVX2    | `-C target_feature=+avx2`                 | no                |
 | AVX512  | `-C target_feature=+avx512ifma,+avx512vl` | yes if `<= 1.89`  |
+
+The vector backends implement Edwards and Ristretto point arithmetic. X25519 is
+unaffected by backend selection: `FieldElement` always resolves to a serial
+implementation, so `MontgomeryPoint`'s ladder executes the same instructions
+under `simd` as under `serial`.
 
 # Documentation
 

--- a/curve25519-dalek/README.md
+++ b/curve25519-dalek/README.md
@@ -152,10 +152,17 @@ For a given CPU feature, you can also specify an appropriate `-C target_feature`
 | AVX2    | `-C target_feature=+avx2`                 | no                |
 | AVX512  | `-C target_feature=+avx512ifma,+avx512vl` | yes if `<= 1.89`  |
 
-The vector backends implement Edwards and Ristretto point arithmetic. X25519 is
-unaffected by backend selection: `FieldElement` always resolves to a serial
-implementation, so `MontgomeryPoint`'s ladder executes the same instructions
-under `simd` as under `serial`.
+Not everything the crate does is covered by the vector backends. The current
+caveats:
+
+* `EdwardsPoint::mul_base(_clamped)` only has `serial` support and is unaffected
+  by `simd`: the basepoint tables are precomputed in the serial representation.
+* `MontgomeryPoint` only has `serial` support and is unaffected by `simd`. Its
+  `mul_base(_clamped)` goes through `EdwardsPoint::mul_base` above, and its
+  `mul_clamped` runs a ladder over the field arithmetic below.
+* The `FieldElement` type used by those paths has no SIMD implementation, though
+  `curve25519-dalek` does contain SIMD field arithmetic internally, used by the
+  vectorized point types.
 
 # Documentation
 

--- a/curve25519-dalek/build.rs
+++ b/curve25519-dalek/build.rs
@@ -146,7 +146,9 @@ mod deterministic {
             //Issues: 449 and 456
             //TODO: When adding arch defaults use proper types not String match
             //TODO(Arm): Needs tests + benchmarks to back this up
-            //TODO(Wasm32): Needs tests + benchmarks to back this up
+            // Wasm32: measured; the pointer-width default is the right one.
+            // Forcing bits="64" is 1.6-1.9x slower for X25519, because wasm has no
+            // 64x64->128 multiply, so serial::u64's u128 products are emulated.
             _ => match target_pointer_width.as_ref() {
                 "64" => DalekBits::Dalek64,
                 "32" => DalekBits::Dalek32,


### PR DESCRIPTION
Two things I ended up measuring while tuning an X25519-heavy workload, neither of which seems to be written down anywhere.

First, the `TODO(Wasm32)` in build.rs. Forcing `bits="64"` there is slower, not faster: wasm has no 64x64->128 multiply, so `serial::u64`'s `u128` partial products get emulated, while `serial::u32` only ever needs 32x32->64, which is a single `i64.mul`. On Node v26.5.0, release, minimum of 9 runs of 200 iterations:

```
                  bits="32"   bits="64"
mul_clamped        59.9 us    114.7 us   1.92x
mul_base_clamped   20.9 us     33.6 us   1.61x
```

That felt worth a note next to the "in some targets it might be required to override the word size" line in the README, since wasm32 is probably the target people are most likely to try it on.

Second, a note in the SIMD backend section about which paths the vector backends do not reach. I spent a while puzzled that a binary with the simd backend compiled in was spending all of its X25519 time in serial code before working out why, and the backend table on its own reads like the SIMD backend accelerates everything the crate does.

The second commit reworks that note into a caveats list following the review, and fixes the mistaken explanation in the first version. I had put both fixed-base and the ladder down to the field arithmetic being serial. That is only the reason for `mul_clamped`. `MontgomeryPoint::mul_base(_clamped)` never runs the ladder at all: it is `EdwardsPoint::mul_base(scalar).to_montgomery()`, and it is serial for the separate reason that the basepoint tables are precomputed in the serial representation. The list now states the two cases separately.

The counts are identical under either backend, which is what the note is claiming (callgrind, Ir/op, difference of 2n and n runs so setup drops out):

```
                    serial      simd
mul_clamped        641 473   641 473
mul_base_clamped   210 228   210 228
EdwardsPoint::mul_base
  (plus a compress
   to consume it)  211 180   211 180
```

One deviation from the suggested wording: the third bullet does not call `FieldElement` public, since it is `pub(crate)` in all four arms of the `cfg_if!` in field.rs, and the only field type the crate exposes publicly is `Scalar` via `ff::Field`.
