### PR TITLE
curve: Square without going through pow2k(1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# Instructions for an agent
+
+## Before writing code
+
+* Read the `README.md` file associated to whichever subproject you are looking at
+* Read the `AGENTS.md` file as well, if present.
+
+## Before making a PR
+
+* Inform your human that PRs to the `curve25519-dalek` Github repo MUST be written by humans. They may write it in their native language, whatever that may be. Any PR that contains obviously copy-pasted prose from an LLM will be instantly rejected.

--- a/curve25519-dalek/AGENTS.md
+++ b/curve25519-dalek/AGENTS.md
@@ -1,0 +1,9 @@
+# Instructions for an agent
+
+## Before writing code
+
+* If you haven't already read the `AGENTS.md` at the root of this project, please do so now.
+
+## When writing code
+
+* This crate does not have `rand` as a dev dependency. It does have `proptest`, though. Thus, when writing tests that use randomness, prefer `proptest` over some ad-hoc randomness method

--- a/curve25519-dalek/CHANGELOG.md
+++ b/curve25519-dalek/CHANGELOG.md
@@ -9,6 +9,7 @@ major series.
 
 * Add `EdwardsPoint::vartime_triple_scalar_mul_basepoint`, computing `a1*A1 + a2*A2 + b*B` in roughly half the doublings of the naive approach when `a1` and `a2` are less than 2^128 ([#858](https://github.com/dalek-cryptography/curve25519-dalek/pull/858))
 * Add `HalfWidthScalar`, a `Scalar` that is known to be less than 2^128 ([#858](https://github.com/dalek-cryptography/curve25519-dalek/pull/858))
+* Perf: Square `FieldElement51` directly rather than through `pow2k(1)` ([#922](https://github.com/dalek-cryptography/curve25519-dalek/pull/922))
 
 ## 5.0.0 - 2026-07-06
 

--- a/curve25519-dalek/src/backend/serial/u64/field.rs
+++ b/curve25519-dalek/src/backend/serial/u64/field.rs
@@ -676,40 +676,32 @@ fn square_limbs(mut a: [u64; 5]) -> [u64; 5] {
 mod test {
     use super::*;
 
-    /// `square` and `square2` must agree with `mul` on all valid inputs
-    #[test]
-    fn square_agrees_with_mul() {
-        // xorshift64, so this needs no dependency and is reproducible.
-        let mut s = 0x1234_5678_9abc_def1u64;
-        let mut next = move || {
-            s ^= s << 13;
-            s ^= s >> 7;
-            s ^= s << 17;
-            s
-        };
-
-        // We test field elements with limbs up to the 2^54-1 limit
-        for bits in [51, 52, 53, 54] {
+    proptest::proptest! {
+        /// `square` and `square2` must agree with `mul` on all valid inputs.
+        #[test]
+        fn proptest_square_agrees_with_mul(
+            bits in 50u32..=54, // Go up to the max allowable input to square* functions, 2^54-1
+            limbs in proptest::array::uniform5(proptest::num::u64::ANY),
+        ) {
+            // Sample uniform limbs and then mask to `bits`, so that we explore various bitlengths
             let mask = (1u64 << bits) - 1;
-            for _ in 0..256 {
-                let x = FieldElement51([
-                    next() & mask,
-                    next() & mask,
-                    next() & mask,
-                    next() & mask,
-                    next() & mask,
-                ]);
-                assert_eq!(x.square().to_bytes(), (&x * &x).to_bytes());
-                let sq = x.square();
-                assert_eq!(x.square2().to_bytes(), (&sq + &sq).to_bytes());
-            }
-        }
+            let x = FieldElement51(limbs.map(|limb| limb & mask));
+            let sq = x.square();
 
-        // Test 0, 1, and the max allowed input to square
+            proptest::prop_assert_eq!(sq.to_bytes(), (&x * &x).to_bytes());
+            proptest::prop_assert_eq!(x.square2().to_bytes(), (&sq + &sq).to_bytes());
+        }
+    }
+
+    /// `square` and `square2` must agree with `mul` at the edges of the valid input range:
+    /// zero, one, and the largest limbs `square` accepts
+    #[test]
+    fn square_agrees_with_mul_at_bounds() {
         for limbs in [[0; 5], [1, 0, 0, 0, 0], [(1 << 54) - 1; 5]] {
             let x = FieldElement51(limbs);
-            assert_eq!(x.square().to_bytes(), (&x * &x).to_bytes());
             let sq = x.square();
+
+            assert_eq!(sq.to_bytes(), (&x * &x).to_bytes());
             assert_eq!(x.square2().to_bytes(), (&sq + &sq).to_bytes());
         }
     }

--- a/curve25519-dalek/src/backend/serial/u64/field.rs
+++ b/curve25519-dalek/src/backend/serial/u64/field.rs
@@ -24,6 +24,15 @@ use subtle::ConditionallySelectable;
 #[cfg(feature = "zeroize")]
 use zeroize::Zeroize;
 
+/// Limbs representing the integer 16p, where p is 2^255 - 19. Used in subtraction routines.
+const SIXTEEN_P: [u64; 5] = [
+    36028797018963664u64,
+    36028797018963952u64,
+    36028797018963952u64,
+    36028797018963952u64,
+    36028797018963952u64,
+];
+
 /// A `FieldElement51` represents an element of the field
 /// \\( \mathbb Z / (2\^{255} - 19)\\).
 ///
@@ -123,13 +132,9 @@ impl<'a> Sub<&'a FieldElement51> for &FieldElement51 {
         //
         // Note the constant added in limb 0 is 2^55 - 304, hence our
         // precondition
-        FieldElement51::reduce([
-            (self.0[0] + 36028797018963664u64) - _rhs.0[0],
-            (self.0[1] + 36028797018963952u64) - _rhs.0[1],
-            (self.0[2] + 36028797018963952u64) - _rhs.0[2],
-            (self.0[3] + 36028797018963952u64) - _rhs.0[3],
-            (self.0[4] + 36028797018963952u64) - _rhs.0[4],
-        ])
+        FieldElement51::reduce(core::array::from_fn(|i| {
+            self.0[i] + SIXTEEN_P[i] - _rhs.0[i]
+        }))
     }
 }
 
@@ -335,13 +340,7 @@ impl FieldElement51 {
     /// Each limb of the output is < 2^(51 + epsilon) where epsilon = 1e-10
     pub fn negate(&mut self) {
         // See commentary in the Sub impl
-        let neg = FieldElement51::reduce([
-            36028797018963664u64 - self.0[0],
-            36028797018963952u64 - self.0[1],
-            36028797018963952u64 - self.0[2],
-            36028797018963952u64 - self.0[3],
-            36028797018963952u64 - self.0[4],
-        ]);
+        let neg = FieldElement51::reduce(core::array::from_fn(|i| SIXTEEN_P[i] - self.0[i]));
         self.0 = neg.0;
     }
 

--- a/curve25519-dalek/src/backend/serial/u64/field.rs
+++ b/curve25519-dalek/src/backend/serial/u64/field.rs
@@ -450,104 +450,13 @@ impl FieldElement51 {
     }
 
     /// Given `k > 0`, return `self^(2^k)`.
-    #[rustfmt::skip] // keep alignment of c* calculations
     pub fn pow2k(&self, mut k: u32) -> FieldElement51 {
-
-        debug_assert!( k > 0 );
-
-        /// Multiply two 64-bit integers with 128 bits of output.
-        #[inline(always)]
-        fn m(x: u64, y: u64) -> u128 {
-            (x as u128) * (y as u128)
-        }
+        debug_assert!(k > 0);
 
         let mut a: [u64; 5] = self.0;
 
         loop {
-            // Precondition: assume input limbs a[i] are bounded as
-            //
-            // a[i] < 2^(51 + b)
-            //
-            // where b is a real parameter measuring the "bit excess" of the limbs.
-
-            // Precomputation: 64-bit multiply by 19.
-            //
-            // This fits into a u64 whenever 51 + b + lg(19) < 64.
-            //
-            // Since 51 + b + lg(19) < 51 + 4.25 + b
-            //                       = 55.25 + b,
-            // this fits if b < 8.75.
-            let a3_19 = 19 * a[3];
-            let a4_19 = 19 * a[4];
-
-            // Multiply to get 128-bit coefficients of output.
-            //
-            // The 128-bit multiplications by 2 turn into 1 slr + 1 slrd each,
-            // which doesn't seem any better or worse than doing them as precomputations
-            // on the 64-bit inputs.
-            let     c0: u128 = m(a[0],  a[0]) + 2*( m(a[1], a4_19) + m(a[2], a3_19) );
-            let mut c1: u128 = m(a[3], a3_19) + 2*( m(a[0],  a[1]) + m(a[2], a4_19) );
-            let mut c2: u128 = m(a[1],  a[1]) + 2*( m(a[0],  a[2]) + m(a[4], a3_19) );
-            let mut c3: u128 = m(a[4], a4_19) + 2*( m(a[0],  a[3]) + m(a[1],  a[2]) );
-            let mut c4: u128 = m(a[2],  a[2]) + 2*( m(a[0],  a[4]) + m(a[1],  a[3]) );
-
-            // Same bound as in multiply:
-            //    c[i] < 2^(102 + 2*b) * (1+i + (4-i)*19)
-            //         < 2^(102 + lg(1 + 4*19) + 2*b)
-            //         < 2^(108.27 + 2*b)
-            //
-            // The carry (c[i] >> 51) fits into a u64 when
-            //    108.27 + 2*b - 51 < 64
-            //    2*b < 6.73
-            //    b < 3.365.
-            //
-            // So we require b < 3 to ensure this fits.
-            debug_assert!(a[0] < (1 << 54));
-            debug_assert!(a[1] < (1 << 54));
-            debug_assert!(a[2] < (1 << 54));
-            debug_assert!(a[3] < (1 << 54));
-            debug_assert!(a[4] < (1 << 54));
-
-            const LOW_51_BIT_MASK: u64 = (1u64 << 51) - 1;
-
-            // Casting to u64 and back tells the compiler that the carry is bounded by 2^64, so
-            // that the addition is a u128 + u64 rather than u128 + u128.
-            c1 += ((c0 >> 51) as u64) as u128;
-            a[0] = (c0 as u64) & LOW_51_BIT_MASK;
-
-            c2 += ((c1 >> 51) as u64) as u128;
-            a[1] = (c1 as u64) & LOW_51_BIT_MASK;
-
-            c3 += ((c2 >> 51) as u64) as u128;
-            a[2] = (c2 as u64) & LOW_51_BIT_MASK;
-
-            c4 += ((c3 >> 51) as u64) as u128;
-            a[3] = (c3 as u64) & LOW_51_BIT_MASK;
-
-            let carry: u64 = (c4 >> 51) as u64;
-            a[4] = (c4 as u64) & LOW_51_BIT_MASK;
-
-            // To see that this does not overflow, we need a[0] + carry * 19 < 2^64.
-            //
-            // c4 < a2^2 + 2*a0*a4 + 2*a1*a3 + (carry from c3)
-            //    < 2^(102 + 2*b + lg(5)) + 2^64.
-            //
-            // When b < 3 we get
-            //
-            // c4 < 2^110.33  so that carry < 2^59.33
-            //
-            // so that
-            //
-            // a[0] + carry * 19 < 2^51 + 19 * 2^59.33 < 2^63.58
-            //
-            // and there is no overflow.
-            a[0] += carry * 19;
-
-            // Now a[1] < 2^51 + 2^(64 -51) = 2^51 + 2^13 < 2^(51 + epsilon).
-            a[1] += a[0] >> 51;
-            a[0] &= LOW_51_BIT_MASK;
-
-            // Now all a[i] < 2^(51 + epsilon) and a = self^(2^k).
+            a = square_limbs(a);
 
             k -= 1;
             if k == 0 {
@@ -560,16 +469,159 @@ impl FieldElement51 {
 
     /// Returns the square of this field element.
     pub fn square(&self) -> FieldElement51 {
-        self.pow2k(1)
+        FieldElement51(square_limbs(self.0))
     }
 
     /// Returns 2 times the square of this field element.
     pub fn square2(&self) -> FieldElement51 {
-        let mut square = self.pow2k(1);
-        for i in 0..5 {
-            square.0[i] *= 2;
+        let mut square = square_limbs(self.0);
+        for limb in &mut square {
+            *limb *= 2;
         }
 
-        square
+        FieldElement51(square)
+    }
+}
+
+/// One squaring step in radix \\(2^{51}\\): given the limbs of \\(x\\), return
+/// the limbs of \\(x^2\\).
+///
+/// This is `pow2k`'s loop body, unchanged, so that `square` need not enter the
+/// loop to square once.
+#[rustfmt::skip] // keep alignment of c* calculations
+#[inline(always)]
+fn square_limbs(mut a: [u64; 5]) -> [u64; 5] {
+    /// Multiply two 64-bit integers with 128 bits of output.
+    #[inline(always)]
+    fn m(x: u64, y: u64) -> u128 {
+        (x as u128) * (y as u128)
+    }
+
+    // Precondition: assume input limbs a[i] are bounded as
+    //
+    // a[i] < 2^(51 + b)
+    //
+    // where b is a real parameter measuring the "bit excess" of the limbs.
+
+    // Precomputation: 64-bit multiply by 19.
+    //
+    // This fits into a u64 whenever 51 + b + lg(19) < 64.
+    //
+    // Since 51 + b + lg(19) < 51 + 4.25 + b
+    //                       = 55.25 + b,
+    // this fits if b < 8.75.
+    let a3_19 = 19 * a[3];
+    let a4_19 = 19 * a[4];
+
+    // Multiply to get 128-bit coefficients of output.
+    //
+    // The 128-bit multiplications by 2 turn into 1 slr + 1 slrd each,
+    // which doesn't seem any better or worse than doing them as precomputations
+    // on the 64-bit inputs.
+    let     c0: u128 = m(a[0],  a[0]) + 2*( m(a[1], a4_19) + m(a[2], a3_19) );
+    let mut c1: u128 = m(a[3], a3_19) + 2*( m(a[0],  a[1]) + m(a[2], a4_19) );
+    let mut c2: u128 = m(a[1],  a[1]) + 2*( m(a[0],  a[2]) + m(a[4], a3_19) );
+    let mut c3: u128 = m(a[4], a4_19) + 2*( m(a[0],  a[3]) + m(a[1],  a[2]) );
+    let mut c4: u128 = m(a[2],  a[2]) + 2*( m(a[0],  a[4]) + m(a[1],  a[3]) );
+
+    // Same bound as in multiply:
+    //    c[i] < 2^(102 + 2*b) * (1+i + (4-i)*19)
+    //         < 2^(102 + lg(1 + 4*19) + 2*b)
+    //         < 2^(108.27 + 2*b)
+    //
+    // The carry (c[i] >> 51) fits into a u64 when
+    //    108.27 + 2*b - 51 < 64
+    //    2*b < 6.73
+    //    b < 3.365.
+    //
+    // So we require b < 3 to ensure this fits.
+    debug_assert!(a[0] < (1 << 54));
+    debug_assert!(a[1] < (1 << 54));
+    debug_assert!(a[2] < (1 << 54));
+    debug_assert!(a[3] < (1 << 54));
+    debug_assert!(a[4] < (1 << 54));
+
+    const LOW_51_BIT_MASK: u64 = (1u64 << 51) - 1;
+
+    // Casting to u64 and back tells the compiler that the carry is bounded by 2^64, so
+    // that the addition is a u128 + u64 rather than u128 + u128.
+    c1 += ((c0 >> 51) as u64) as u128;
+    a[0] = (c0 as u64) & LOW_51_BIT_MASK;
+
+    c2 += ((c1 >> 51) as u64) as u128;
+    a[1] = (c1 as u64) & LOW_51_BIT_MASK;
+
+    c3 += ((c2 >> 51) as u64) as u128;
+    a[2] = (c2 as u64) & LOW_51_BIT_MASK;
+
+    c4 += ((c3 >> 51) as u64) as u128;
+    a[3] = (c3 as u64) & LOW_51_BIT_MASK;
+
+    let carry: u64 = (c4 >> 51) as u64;
+    a[4] = (c4 as u64) & LOW_51_BIT_MASK;
+
+    // To see that this does not overflow, we need a[0] + carry * 19 < 2^64.
+    //
+    // c4 < a2^2 + 2*a0*a4 + 2*a1*a3 + (carry from c3)
+    //    < 2^(102 + 2*b + lg(5)) + 2^64.
+    //
+    // When b < 3 we get
+    //
+    // c4 < 2^110.33  so that carry < 2^59.33
+    //
+    // so that
+    //
+    // a[0] + carry * 19 < 2^51 + 19 * 2^59.33 < 2^63.58
+    //
+    // and there is no overflow.
+    a[0] += carry * 19;
+
+    // Now a[1] < 2^51 + 2^(64 -51) = 2^51 + 2^13 < 2^(51 + epsilon).
+    a[1] += a[0] >> 51;
+    a[0] &= LOW_51_BIT_MASK;
+
+    // Now all a[i] < 2^(51 + epsilon) and a = (input)^2.
+
+    a
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// `square` and `square2` must agree with `mul` across the documented bit
+    /// excess (`b < 3`, i.e. limbs below 2^54), which the curve-level tests do
+    /// not reach: they only ever square reduced elements.
+    #[test]
+    fn square_agrees_with_mul() {
+        // xorshift64, so this needs no dependency and is reproducible.
+        let mut s = 0x1234_5678_9abc_def1u64;
+        let mut next = move || {
+            s ^= s << 13;
+            s ^= s >> 7;
+            s ^= s << 17;
+            s
+        };
+
+        for bits in [51, 52, 53, 54] {
+            let mask = (1u64 << bits) - 1;
+            for _ in 0..256 {
+                let x = FieldElement51([
+                    next() & mask,
+                    next() & mask,
+                    next() & mask,
+                    next() & mask,
+                    next() & mask,
+                ]);
+                assert_eq!(x.square().to_bytes(), (&x * &x).to_bytes());
+                let sq = x.square();
+                assert_eq!(x.square2().to_bytes(), (&sq + &sq).to_bytes());
+            }
+        }
+
+        for limbs in [[0; 5], [1, 0, 0, 0, 0], [(1 << 54) - 1; 5]] {
+            let x = FieldElement51(limbs);
+            assert_eq!(x.square().to_bytes(), (&x * &x).to_bytes());
+        }
     }
 }

--- a/curve25519-dalek/src/backend/serial/u64/field.rs
+++ b/curve25519-dalek/src/backend/serial/u64/field.rs
@@ -56,6 +56,13 @@ impl Zeroize for FieldElement51 {
 }
 
 impl<'a> AddAssign<&'a FieldElement51> for FieldElement51 {
+    /// Given `self` and `_rhs`, set `self` to `self + _rhs`
+    ///
+    /// # Requires
+    /// `self.0[i] + _rhs.0[i]` MUST be < 2^64 for all `i`
+    ///
+    /// # Postcondition
+    /// `out.0[i] == self.0 + _rhs.0[i]` for all `i`
     fn add_assign(&mut self, _rhs: &'a FieldElement51) {
         for i in 0..5 {
             self.0[i] += _rhs.0[i];
@@ -65,6 +72,11 @@ impl<'a> AddAssign<&'a FieldElement51> for FieldElement51 {
 
 impl<'a> Add<&'a FieldElement51> for &FieldElement51 {
     type Output = FieldElement51;
+
+    /// Given `self` and `_rhs`, return `self + _rhs`
+    ///
+    /// # Requires
+    /// `self.0[i] + _rhs.[i]` MUST be < 2^64 for all `i`
     fn add(self, _rhs: &'a FieldElement51) -> FieldElement51 {
         let mut output = *self;
         output += _rhs;
@@ -73,6 +85,14 @@ impl<'a> Add<&'a FieldElement51> for &FieldElement51 {
 }
 
 impl<'a> SubAssign<&'a FieldElement51> for FieldElement51 {
+    /// Given \\(x,y\\), return \\(x - y\\).
+    ///
+    /// # Requires
+    /// Each limb of `self` must be < 2^64 - 2^55. And each limb of `rhs`
+    /// MUST be ≤ 2^55 - 304.
+    ///
+    /// # Postcondition
+    /// Each limb of the output is < 2^(51 + epsilon) where epsilon = 1e-10
     fn sub_assign(&mut self, _rhs: &'a FieldElement51) {
         let result = (self as &FieldElement51) - _rhs;
         self.0 = result.0;
@@ -81,6 +101,15 @@ impl<'a> SubAssign<&'a FieldElement51> for FieldElement51 {
 
 impl<'a> Sub<&'a FieldElement51> for &FieldElement51 {
     type Output = FieldElement51;
+
+    /// Given \\(x,y\\), return \\(x - y\\).
+    ///
+    /// # Requires
+    /// Each limb of `self` must be < 2^64 - 2^55. And each limb of `rhs`
+    /// MUST be ≤ 2^55 - 304.
+    ///
+    /// # Postcondition
+    /// Each limb of the output is < 2^(51 + epsilon) where epsilon = 1e-10
     fn sub(self, _rhs: &'a FieldElement51) -> FieldElement51 {
         // To avoid underflow, first add a multiple of p.
         // Choose 16*p = p << 4 to be larger than 54-bit _rhs.
@@ -91,6 +120,9 @@ impl<'a> Sub<&'a FieldElement51> for &FieldElement51 {
         //
         // Since we don't yet have type-level integers to do this, we
         // have to add an explicit reduction call here.
+        //
+        // Note the constant added in limb 0 is 2^55 - 304, hence our
+        // precondition
         FieldElement51::reduce([
             (self.0[0] + 36028797018963664u64) - _rhs.0[0],
             (self.0[1] + 36028797018963952u64) - _rhs.0[1],
@@ -102,6 +134,13 @@ impl<'a> Sub<&'a FieldElement51> for &FieldElement51 {
 }
 
 impl<'a> MulAssign<&'a FieldElement51> for FieldElement51 {
+    /// Given `self` and `_rhs`, set `self` to `self * _rhs`
+    ///
+    /// # Requires
+    /// Each limb in `self` and `_rhs` MUST be < 2^54
+    ///
+    /// # Postcondition
+    /// The limbs of the output are all < 2^(51 + epsilon) where epsilon is 1e-11
     fn mul_assign(&mut self, _rhs: &'a FieldElement51) {
         let result = (self as &FieldElement51) * _rhs;
         self.0 = result.0;
@@ -111,6 +150,13 @@ impl<'a> MulAssign<&'a FieldElement51> for FieldElement51 {
 impl<'a> Mul<&'a FieldElement51> for &FieldElement51 {
     type Output = FieldElement51;
 
+    /// Given `self` and `_rhs`, return `self * _rhs`
+    ///
+    /// # Requires
+    /// Each limb in `self` and `_rhs` MUST be < 2^54
+    ///
+    /// # Postcondition
+    /// The limbs of the output are all < 2^(51 + epsilon) where epsilon is 1e-11
     #[rustfmt::skip] // keep alignment of c* calculations
     fn mul(self, _rhs: &'a FieldElement51) -> FieldElement51 {
         /// Helper function to multiply two 64-bit integers with 128
@@ -215,6 +261,14 @@ impl<'a> Mul<&'a FieldElement51> for &FieldElement51 {
 
 impl Neg for &FieldElement51 {
     type Output = FieldElement51;
+
+    /// Given \\(x\\), return \\(-x\\).
+    ///
+    /// # Requires
+    /// Each limb of `self` MUST be ≤ 2^55 - 304
+    ///
+    /// # Postcondition
+    /// Each limb of the output is < 2^(51 + epsilon) where epsilon = 1e-10
     fn neg(self) -> FieldElement51 {
         let mut output = *self;
         output.negate();
@@ -273,6 +327,12 @@ impl FieldElement51 {
     ]);
 
     /// Invert the sign of this field element
+    ///
+    /// # Requires
+    /// Each limb of `self` MUST be ≤ 2^55 - 304
+    ///
+    /// # Postcondition
+    /// Each limb of the output is < 2^(51 + epsilon) where epsilon = 1e-10
     pub fn negate(&mut self) {
         // See commentary in the Sub impl
         let neg = FieldElement51::reduce([
@@ -285,7 +345,8 @@ impl FieldElement51 {
         self.0 = neg.0;
     }
 
-    /// Given 64-bit input limbs, reduce to enforce the bound 2^(51 + epsilon).
+    /// Given 64-bit input limbs, reduce to enforce the bound 2^(51 + epsilon) for all
+    /// limbs, where epsilon = 1e-10.
     #[inline(always)]
     fn reduce(mut limbs: [u64; 5]) -> FieldElement51 {
         const LOW_51_BIT_MASK: u64 = (1u64 << 51) - 1;
@@ -334,6 +395,8 @@ impl FieldElement51 {
     /// the canonical encoding, and check that the input was
     /// canonical.
     ///
+    /// # Postcondition
+    /// The limbs of the output are all < 2^51
     #[rustfmt::skip] // keep alignment of bit shifts
     pub const fn from_bytes(bytes: &[u8; 32]) -> FieldElement51 {
         const fn load8_at(input: &[u8], i: usize) -> u64 {
@@ -450,12 +513,21 @@ impl FieldElement51 {
     }
 
     /// Given `k > 0`, return `self^(2^k)`.
+    ///
+    /// # Requires
+    /// Each limb in `self` MUST be < 2^54
+    ///
+    /// # Postcondition
+    /// The entries of the output are all < 2^(51 + epsilon), where epsilon = 1e-9
     pub fn pow2k(&self, mut k: u32) -> FieldElement51 {
         debug_assert!(k > 0);
 
         let mut a: [u64; 5] = self.0;
 
         loop {
+            // square_limbs has the same precondition and postcondition as this function.
+            // Also its precondition is satisfied by its postcondition, so we can feed the
+            // output into itself.
             a = square_limbs(a);
 
             k -= 1;
@@ -468,26 +540,42 @@ impl FieldElement51 {
     }
 
     /// Returns the square of this field element.
+    ///
+    /// # Requires
+    /// Each limb in `self` MUST be < 2^54
+    ///
+    /// # Postcondition
+    /// Each limb of the output is < 2^(51 + epsilon) where epsilon = 1e-11
     pub fn square(&self) -> FieldElement51 {
         FieldElement51(square_limbs(self.0))
     }
 
     /// Returns 2 times the square of this field element.
+    ///
+    /// # Requires
+    /// Each limb in `self` MUST be < 2^54
+    ///
+    /// # Postcondition
+    /// Each limb of the output is < 2^(51 + epsilon) where epsilon = 1e-11
     pub fn square2(&self) -> FieldElement51 {
         let mut square = square_limbs(self.0);
         for limb in &mut square {
             *limb *= 2;
         }
 
+        // square_limbs returns limbs less than 2^(51 + epsilon). Multiplying by 2 gives
+        // us our postcondition
         FieldElement51(square)
     }
 }
 
-/// One squaring step in radix \\(2^{51}\\): given the limbs of \\(x\\), return
-/// the limbs of \\(x^2\\).
+/// Given the limbs of \\(x\\), return the limbs of \\(x^2\\).
 ///
-/// This is `pow2k`'s loop body, unchanged, so that `square` need not enter the
-/// loop to square once.
+/// # Requires
+/// Each entry in `a` MUST be < 2^54
+///
+/// # Postcondition
+/// Each entry of the output is < 2^(51 + epsilon) where epsilon = 1e-11
 #[rustfmt::skip] // keep alignment of c* calculations
 #[inline(always)]
 fn square_limbs(mut a: [u64; 5]) -> [u64; 5] {
@@ -589,9 +677,7 @@ fn square_limbs(mut a: [u64; 5]) -> [u64; 5] {
 mod test {
     use super::*;
 
-    /// `square` and `square2` must agree with `mul` across the documented bit
-    /// excess (`b < 3`, i.e. limbs below 2^54), which the curve-level tests do
-    /// not reach: they only ever square reduced elements.
+    /// `square` and `square2` must agree with `mul` on all valid inputs
     #[test]
     fn square_agrees_with_mul() {
         // xorshift64, so this needs no dependency and is reproducible.
@@ -603,6 +689,7 @@ mod test {
             s
         };
 
+        // We test field elements with limbs up to the 2^54-1 limit
         for bits in [51, 52, 53, 54] {
             let mask = (1u64 << bits) - 1;
             for _ in 0..256 {
@@ -619,9 +706,12 @@ mod test {
             }
         }
 
+        // Test 0, 1, and the max allowed input to square
         for limbs in [[0; 5], [1, 0, 0, 0, 0], [(1 << 54) - 1; 5]] {
             let x = FieldElement51(limbs);
             assert_eq!(x.square().to_bytes(), (&x * &x).to_bytes());
+            let sq = x.square();
+            assert_eq!(x.square2().to_bytes(), (&sq + &sq).to_bytes());
         }
     }
 }


### PR DESCRIPTION
`FieldElement51::square` was written as `self.pow2k(1)`, so every squaring on the Montgomery ladder entered pow2k's loop to go round it exactly once. This factors the loop body out into a `square_limbs` free function and has `square`/`square2` call it directly. The arithmetic is moved across verbatim, same limbs, same bit-excess preconditions, same `debug_assert!`s, so `pow2k(k)` and k chained `square()`s still produce identical limbs.

The benchmark it moves is `Montgomery pseudomultiplication`, and only under LTO, which is what inlines the squaring into the ladder step:

```sh
RUST_PERF_FLAGS="-C llvm-args=-align-all-functions=6 -C llvm-args=-align-all-nofallthru-blocks=6"

git checkout main
RUSTFLAGS="$RUST_PERF_FLAGS" CARGO_PROFILE_BENCH_LTO=fat \
  cargo bench --all-features --bench dalek_benchmarks -- \
  "Montgomery pseudomultiplication" --save-baseline base

git checkout <this branch>
RUSTFLAGS="$RUST_PERF_FLAGS" CARGO_PROFILE_BENCH_LTO=fat \
  cargo bench --all-features --bench dalek_benchmarks -- \
  "Montgomery pseudomultiplication" --baseline base
```

Four rounds of that, rebuilding the baseline from `main` each time: -15.5%, -13.9%, -17.8%, -5.8%. Under `thin` it is smaller. @rozbb measured -19.92% and -8.82% independently.

A caveat on the rest of the suite: it does not resolve a change of this size. The `scalar benches` group is arithmetic mod l and cannot be affected by this PR, yet it swings between -8.6% and +7.7% at p = 0.00 across runs, and a full-suite comparison repeated over the same two commits is uncorrelated with itself (r = +0.04). Varying only `-align-all-functions` moves individual multiscalar benchmarks from +25% to -10%. Details in the thread below.

On a stock `cargo build --release` this change is worth nothing, and key generation does not move in any profile, since it spends its time in the fixed-base table rather than in squarings.

The added test squares random elements up to the top of the documented bit excess (limbs < 2^54) and checks against `mul`. The curve-level tests never get there, since they only square reduced elements, and I confirmed it fails if I perturb the reduction step.

Ran the suite under the default, `serial`, `fiat`, `bits="32"`, `+avx2` and `--all-features`, plus clippy, fmt and a wasm32 build.
