### PR TITLE
curve: Double the 64-bit inputs when squaring, not the 128-bit products

### DIFF
--- a/curve25519-dalek/CHANGELOG.md
+++ b/curve25519-dalek/CHANGELOG.md
@@ -10,6 +10,7 @@ major series.
 * Add `EdwardsPoint::vartime_triple_scalar_mul_basepoint`, computing `a1*A1 + a2*A2 + b*B` in roughly half the doublings of the naive approach when `a1` and `a2` are less than 2^128 ([#858](https://github.com/dalek-cryptography/curve25519-dalek/pull/858))
 * Add `HalfWidthScalar`, a `Scalar` that is known to be less than 2^128 ([#858](https://github.com/dalek-cryptography/curve25519-dalek/pull/858))
 * Perf: Square `FieldElement51` directly rather than through `pow2k(1)` ([#922](https://github.com/dalek-cryptography/curve25519-dalek/pull/922))
+* Perf: Double the 64-bit inputs when squaring `FieldElement51`, rather than the 128-bit products ([#923](https://github.com/dalek-cryptography/curve25519-dalek/pull/923))
 
 ## 5.0.0 - 2026-07-06
 

--- a/curve25519-dalek/src/backend/serial/u64/field.rs
+++ b/curve25519-dalek/src/backend/serial/u64/field.rs
@@ -600,16 +600,29 @@ fn square_limbs(mut a: [u64; 5]) -> [u64; 5] {
     let a3_19 = 19 * a[3];
     let a4_19 = 19 * a[4];
 
-    // Multiply to get 128-bit coefficients of output.
+    // Precomputation: the doublings.
     //
-    // The 128-bit multiplications by 2 turn into 1 slr + 1 slrd each,
-    // which doesn't seem any better or worse than doing them as precomputations
-    // on the 64-bit inputs.
-    let     c0: u128 = m(a[0],  a[0]) + 2*( m(a[1], a4_19) + m(a[2], a3_19) );
-    let mut c1: u128 = m(a[3], a3_19) + 2*( m(a[0],  a[1]) + m(a[2], a4_19) );
-    let mut c2: u128 = m(a[1],  a[1]) + 2*( m(a[0],  a[2]) + m(a[4], a3_19) );
-    let mut c3: u128 = m(a[4], a4_19) + 2*( m(a[0],  a[3]) + m(a[1],  a[2]) );
-    let mut c4: u128 = m(a[2],  a[2]) + 2*( m(a[0],  a[4]) + m(a[1],  a[3]) );
+    // Every product below other than the five squares a[i]^2 appears exactly
+    // twice in the full 5x5 product, so it is computed once and doubled. The
+    // doubling is done here, on one 64-bit operand, rather than on the 128-bit
+    // product: `2*(x*y) == (2*x)*y`, so the coefficients are unchanged, but a
+    // 64-bit shift is one instruction where a 128-bit one is two, and four
+    // shifts here cover ten doubled products.
+    //
+    // `2*a[i]` fits into a u64 whenever 51 + b + 1 < 64, i.e. b < 12, and
+    // `2*19*a[3]` whenever 51 + b + lg(19) + 1 < 64, i.e. b < 7.75. Both are
+    // slacker than the b < 3 this function already requires.
+    let a0_2 = 2 * a[0];
+    let a1_2 = 2 * a[1];
+    let a2_2 = 2 * a[2];
+    let a3_19_2 = 2 * a3_19;
+
+    // Multiply to get 128-bit coefficients of output.
+    let     c0: u128 = m(a[0], a[0]) + m(a1_2, a4_19) + m(a2_2, a3_19);
+    let mut c1: u128 = m(a[3], a3_19) + m(a0_2,  a[1]) + m(a2_2, a4_19);
+    let mut c2: u128 = m(a[1], a[1])  + m(a0_2,  a[2]) + m(a[4], a3_19_2);
+    let mut c3: u128 = m(a[4], a4_19) + m(a0_2,  a[3]) + m(a1_2, a[2]);
+    let mut c4: u128 = m(a[2], a[2])  + m(a0_2,  a[4]) + m(a1_2, a[3]);
 
     // Same bound as in multiply:
     //    c[i] < 2^(102 + 2*b) * (1+i + (4-i)*19)


### PR DESCRIPTION
Continuação do #922, mesma função.

Os dez produtos parciais que aparecem duas vezes estavam sendo dobrados no coeficiente de 128 bits. Como `2*(x*y) == (2*x)*y`, dá pra dobrar um operando de 64 bits em vez disso, e aí quatro valores pré-computados cobrem os dez. O `serial::u32` já faz exatamente assim, então dá pra ler o diff lado a lado com o `u32/field.rs`. Tirei junto o comentário que dizia que as duas formas "don't seem any better or worse".

Continua idêntico bit a bit. Conferi limbo a limbo contra a implementação anterior, 20 mil casos mais os extremos, e o `proptest_square_agrees_with_mul` já cobre isso sem precisar mexer no teste. Os limites seguem folgados: `2*a[i]` precisa de b < 12 e `2*19*a[3]` de b < 7.75, sendo que o que já era exigido é b < 3.

Constant time não muda, e dá pra ver comparando os dois binários: branches (8889), `cmov` (579) e `set*` (483) ficam idênticos. A única coluna que se mexe são 85 `shld` a menos, que é exatamente 5 por cópia inlinada do `square_limbs`, ou seja as duplicações de 128 bits que saíram.

Instruções por operação, callgrind, descontando o setup:

```
compress      -4.18%
decompress    -3.97%
ladder        -2.66%
mul_base      -0.80%
```

Rende mais fora do X25519 do que dentro, porque `invert` e `sqrt_ratio_i` são cadeias de `pow2k`.

Medi assim, caso queira refazer. Um bin que roda o kernel N vezes:

```rust
fn main() {
    let n: u32 = std::env::args().nth(1).unwrap().parse().unwrap();
    let p = EdwardsPoint::mul_base(&Scalar::from(12345u64)).compress();
    let mut acc = 0u8;
    for _ in 0..n {
        acc ^= black_box(black_box(p).decompress()).unwrap().compress().to_bytes()[0];
    }
    black_box(acc);
}
```

```sh
for n in 20 40; do
  valgrind --tool=callgrind --callgrind-out-file=/dev/null ./kernel $n
done
# (Ir(40) - Ir(20)) / 20 = uma operação, sem o setup do processo
```

Como conta instrução e não tempo, os runs podem ir todos em paralelo sem afetar o resultado, o que deixa a comparação inteira em poucos segundos.

Dessa vez não vou falar de tempo. Nas mesmas rodadas o `Scalar inversion`, que é mod l e não tem nada a ver com essa mudança, deu -18%. Se o controle se mexe mais que o alvo, o número não me diz nada.

O wasm32 não é afetado, o `serial::u64` não é compilado lá. A rlib sai byte a byte igual nos dois lados.

<details>
<summary>English version</summary>

Continuation of #922, same function.

The ten partial products that show up twice were being doubled on the 128-bit coefficient. Since `2*(x*y) == (2*x)*y` you can double a 64-bit operand instead, and then four precomputed values cover all ten. `serial::u32` already does it exactly like this, so the diff can be read side by side with `u32/field.rs`. I dropped the comment saying the two forms "don't seem any better or worse" along with it.

Still bit-for-bit identical. I checked it limb by limb against the previous implementation, 20k cases plus the edges, and `proptest_square_agrees_with_mul` already covers it without touching the test. The bounds are still slack: `2*a[i]` needs b < 12 and `2*19*a[3]` needs b < 7.75, and what's already required is b < 3.

Constant time doesn't change, and you can see it by comparing the two binaries: branches (8889), `cmov` (579) and `set*` (483) all come out identical. The only column that moves is 85 fewer `shld`, which is exactly 5 per inlined copy of `square_limbs`, i.e. the 128-bit doublings that went away.

Instructions per op, callgrind, setup subtracted:

```
compress      -4.18%
decompress    -3.97%
ladder        -2.66%
mul_base      -0.80%
```

It helps more outside X25519 than inside it, since `invert` and `sqrt_ratio_i` are `pow2k` chains.

This is how I measured, if you want to redo it. A bin that runs the kernel N times:

```rust
fn main() {
    let n: u32 = std::env::args().nth(1).unwrap().parse().unwrap();
    let p = EdwardsPoint::mul_base(&Scalar::from(12345u64)).compress();
    let mut acc = 0u8;
    for _ in 0..n {
        acc ^= black_box(black_box(p).decompress()).unwrap().compress().to_bytes()[0];
    }
    black_box(acc);
}
```

```sh
for n in 20 40; do
  valgrind --tool=callgrind --callgrind-out-file=/dev/null ./kernel $n
done
# (Ir(40) - Ir(20)) / 20 = one operation, with the process setup out of it
```

Since it counts instructions and not time, the runs can all go in parallel without affecting the result, which puts the whole comparison in a few seconds.

I'm not going to say anything about wall clock this time. In the same runs `Scalar inversion`, which is mod l and has nothing to do with this change, came out at -18%. If the control moves more than the target, the number doesn't tell me anything.

wasm32 is unaffected, `serial::u64` isn't compiled there. The rlib comes out byte-identical either way.

</details>
